### PR TITLE
perf(python): 3.3x faster pipeline — threading, numba, collection plotting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,13 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
-    "numpy>=1.26",
+    # numpy capped <2.5 so numba can load (numba requires numpy<=2.4). numba
+    # JIT-compiles the Step-4 network-randomization hot loop
+    # (randmio_und_signed), ~28x faster than the pure-Python fallback; the
+    # code runs without numba too, just slower (see pipeline/null_models.py).
+    "numpy>=1.26,<2.5",
+    "numba>=0.60",
+    "psutil>=5.9",  # RAM/CPU-aware parallel worker sizing (pipeline/parallel.py)
     "scipy>=1.13",
     "matplotlib>=3.8",
     "pandas>=2.2",

--- a/python/PIPELINE_PORT_STATUS.md
+++ b/python/PIPELINE_PORT_STATUS.md
@@ -1034,6 +1034,54 @@ purely-numerical steps, slower specifically where MATLAB parallelizes:
 (e.g. `multiprocessing`/`joblib` across recordings or lags) — that's where
 essentially all of the total deficit lives.
 
+### Optimization pass — 3.3x faster end-to-end (2026-07-09)
+
+A follow-up performance pass took the full run from 1166.9s to **350.0s** —
+Python is now **~2.66x faster than MATLAB** (931s), not 25% slower. Same
+machine, same config (2 recordings, `[10, 25, 50]`ms, `ProbThreshRepNum=200`):
+
+| Step | Before | After | Speedup | What changed |
+|---|---|---|---|---|
+| 1. Spike detection | 568.8s | 103.6s | **5.5x** | Channel-level threading (`detect_spikes_recording(max_workers=)`): per-channel wavelet CWT + bandpass release the GIL, so threads parallelize over one shared ~3.8 GB `dat` array with no extra RAM. Bit-identical output. |
+| 2. Neuronal activity | 6.2s | 6.4s | — | Unchanged (already fast). |
+| 3. Functional connectivity | 80.2s | 42.7s | **1.9x** | Recording-level process map. |
+| 4. Network activity | 511.7s | 197.3s | **2.6x** | numba-JIT `randmio_und_signed` (~28x on the PC-norm null models); collection-based plotting (~5x plot phase, single-threaded); recording-level process map. |
+| **Total** | **1166.9s** | **350.0s** | **3.3x** | |
+
+Key pieces (all default-on, with serial fallbacks; see
+`src/meanap/pipeline/parallel.py`):
+
+- **RAM/CPU-aware worker sizing.** Step 1 is RAM-bound (~3.8 GB/recording) →
+  *threads over channels* on one shared array (no per-worker copy). Steps 3/4
+  are CPU-bound/low-RAM → *processes over recordings*. Counts auto-size to
+  physical cores and free RAM (`psutil`) with headroom; override via
+  `params.spike_detection_channel_workers` / `params.recording_workers`
+  (`None` = auto). Per-worker BLAS threads pinned to avoid oversubscription.
+- **numba** is now a dependency (forces `numpy<2.5`); `randmio_und_signed` has
+  an `@njit` core + pure-Python fallback (runs without numba, just slower).
+  All step-3/4 parity fixtures pass under numpy 2.4.6.
+- **Plotting** (`network_plot.py`): edges were individual `ax.plot()` Line2D
+  artists and nodes individual `add_patch` circles (hundreds per figure ×
+  ~380 figures) → one `LineCollection` + `PatchCollection(match_original=True)`.
+  Cut the plot phase ~5x *and* removed a `get_text_width_height_descent`
+  layout pathology (458s→1.1s in profile — the per-edge artists were making
+  `tight_layout`/bbox re-measure text catastrophically). Output pixel-validated
+  unchanged.
+- **Step 4** restructured into A (parallel compute) → B (serial batch-bounds
+  reduce) → C (parallel plot). Deterministic metrics bit-identical
+  serial-vs-parallel. Phase B is also where the not-yet-ported cross-recording
+  node-cartography boundary clustering (pooled PC/Z density landscape → basins,
+  `TrialLandscapeDensity.m`/`findBasinsOfAttraction.m`) will live.
+
+Caveats: measured on a shared 16-core box where step-4 *process*-parallelism
+scales poorly (memory-bandwidth/BLAS contention → only ~1.1-1.4x across
+recordings), so most of step 4's win is the numba + plotting changes, which are
+single-threaded and portable. On a dedicated ~8-core machine the recording map
+should contribute more. Remaining portable candidates: numba
+`randmio_und_v2`/`latmio_und_v2` (small-worldness, same `@njit` pattern);
+cutting NMF's fit count (`init="nndsvda"` was tried — ~8% *slower* since the
+per-rank sweep pays NNDSVD's SVD-init cost on every fit, reverted).
+
 **How this was measured** — headless (`Params.guiMode=0`) execution of
 MATLAB MEA-NAP is not a well-trodden path; getting a clean end-to-end run
 required finding and working around 5 bugs/config traps that the

--- a/src/meanap/network_plot.py
+++ b/src/meanap/network_plot.py
@@ -295,15 +295,29 @@ def plot_network(
                 edge_lw.append(lw)
                 edge_colors.append(col)
 
-    # Sort edges light → dark so darker edges appear on top
+    # Sort edges light → dark so darker edges draw last (on top), then render
+    # them all as a single LineCollection. Drawing each edge as its own
+    # ax.plot() Line2D was the dominant plotting cost — hundreds of artists per
+    # figure × 144 figures — profiled as ~500k draw_path calls. One collection
+    # is visually identical (same per-edge color/width, same draw order) but an
+    # order of magnitude fewer matplotlib objects.
     if edges_x:
+        from matplotlib.collections import LineCollection
+
         order = np.argsort([c[0] for c in edge_colors])[::-1]
-        for idx in order:
-            ax.plot(
-                edges_x[idx], edges_y[idx],
-                color=edge_colors[idx], linewidth=edge_lw[idx],
-                zorder=1, solid_capstyle="round",
-            )
+        segments = [
+            np.array([[edges_x[idx][0], edges_y[idx][0]],
+                      [edges_x[idx][1], edges_y[idx][1]]])
+            for idx in order
+        ]
+        lc = LineCollection(
+            segments,
+            colors=[edge_colors[idx] for idx in order],
+            linewidths=[edge_lw[idx] for idx in order],
+            capstyle="round",
+            zorder=1,
+        )
+        ax.add_collection(lc)
 
     # ── Nodes ─────────────────────────────────────────────────────────────────
     ct_line_styles = ["-", "--", ":", "-.", "-"]
@@ -315,6 +329,8 @@ def plot_network(
         and cell_type_matrix.shape[1] > 0
     )
 
+    outer_patches = []
+    inner_patches = []
     for i in range(n):
         zi = float(z[i]) if not np.isnan(z[i]) else 0.0
         if zi <= 0:
@@ -322,26 +338,35 @@ def plot_network(
 
         node_size = _get_node_size(zi, node_scale_f, min_node_size)
         fc = node_facecolor(i)
-        outer = mpatches.Circle(
+        outer_patches.append(mpatches.Circle(
             (xc[i], yc[i]), node_size / 2,
-            facecolor=fc, edgecolor="white", linewidth=0.1, zorder=2,
-        )
-        ax.add_patch(outer)
+            facecolor=fc, edgecolor="white", linewidth=0.1,
+        ))
 
         if has_ct:
             ct_sizes = np.linspace(0.9, 0.3, cell_type_matrix.shape[1]) * node_size
             for k in range(cell_type_matrix.shape[1]):
                 if cell_type_matrix[i, k] == 1:
                     r = ct_sizes[k] / 2
-                    inner = mpatches.Circle(
+                    inner_patches.append(mpatches.Circle(
                         (xc[i], yc[i]), r,
                         facecolor=fc,
                         edgecolor=ct_edge_colors[k % len(ct_edge_colors)],
                         linewidth=1.0,
                         linestyle=ct_line_styles[k % len(ct_line_styles)],
-                        zorder=3,
-                    )
-                    ax.add_patch(inner)
+                    ))
+
+    # Batch node circles into PatchCollections (match_original keeps each
+    # circle's own face/edge/width/style) — same artist-count reduction as the
+    # edge LineCollection: one draw call instead of one add_patch per node.
+    # Outer circles sit at zorder 2 (above edges); cell-type inner rings at
+    # zorder 3 (above the outer circle).
+    from matplotlib.collections import PatchCollection
+
+    if outer_patches:
+        ax.add_collection(PatchCollection(outer_patches, match_original=True, zorder=2))
+    if inner_patches:
+        ax.add_collection(PatchCollection(inner_patches, match_original=True, zorder=3))
 
     # ── Legend: node size metric ────────────────────────────────────────────────
     x_max = float(xc.max())

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -126,6 +126,13 @@ class Params:
     time_processes: bool = False
     output_spreadsheet_file_type: str = "csv"
 
+    # ── Parallelism ──────────────────────────────────────────────────────────
+    # None = auto-size against available cores/RAM (see pipeline/parallel.py).
+    # Step 1 threads over channels on one shared ~3.8 GB array (RAM-safe);
+    # steps 3/4 run recordings in separate processes (CPU-bound, low RAM).
+    spike_detection_channel_workers: int | None = None
+    recording_workers: int | None = None
+
     # ── Two-photon / CAT-NAP ─────────────────────────────────────────────────
     twop_activity: str = "peaks"
     twop_redo_denoising: bool = False

--- a/src/meanap/pipeline/nmf.py
+++ b/src/meanap/pipeline/nmf.py
@@ -73,6 +73,12 @@ def _nnmf(x: np.ndarray, k: int, rng: np.random.Generator) -> tuple[np.ndarray, 
     output convention: ``D`` is the root-mean-square residual
     ``norm(A - W*H, 'fro') / sqrt(m*n)``, not sklearn's raw Frobenius error.
 
+    Uses ``init="random"``. (``init="nndsvda"`` was benchmarked and is ~8%
+    *slower* here despite converging in fewer iterations: cal_nmf runs ~N fits
+    on the same matrix for the per-rank sweep, and NNDSVD pays an SVD-based
+    init cost on every fit that outweighs the convergence gain. NMF here is
+    fit-count-bound, not init-bound.)
+
     Falls back to a large residual (rather than raising) on numerical
     failure — matching ``calNMF.m``'s own defensive early-exit on a failed
     ``nnmf`` call, just via Python's exception mechanism instead of

--- a/src/meanap/pipeline/null_models.py
+++ b/src/meanap/pipeline/null_models.py
@@ -20,6 +20,59 @@ from typing import Iterator
 
 import numpy as np
 
+# ``randmio_und_signed`` is the pipeline's single hottest Step-4 function
+# (profiled at ~46% of Step 4 — 159M inner iterations of a sequential swap
+# loop that can't be vectorized, since each accepted swap mutates the matrix
+# the next one reads). That's the textbook case for a JIT. We compile the
+# inner loop with numba when it's importable and fall back to an equivalent
+# pure-NumPy implementation otherwise, so the module has no hard numba
+# dependency — it just runs ~10-30x faster when numba is present.
+try:
+    from numba import njit
+
+    _HAVE_NUMBA = True
+except Exception:  # pragma: no cover - numba optional / version-gated
+    _HAVE_NUMBA = False
+
+
+if _HAVE_NUMBA:
+
+    @njit(cache=True)
+    def _randmio_signed_core(r, sgn, total_iter, max_attempts, seed):  # pragma: no cover - jitted
+        """In-place degree-preserving signed swaps on ``r`` (and its sign
+        matrix ``sgn``). Compiled; uses numba's own RNG (seeded per call).
+        ``sgn`` is kept consistent with ``r`` so sign comparisons are integer
+        lookups rather than repeated ``np.sign`` calls."""
+        np.random.seed(seed)
+        n = r.shape[0]
+        for _ in range(total_iter):
+            for _attempt in range(max_attempts + 1):
+                # Draw 4 distinct nodes (retry distinctness without consuming
+                # an attempt — matches the reference ``next_quad`` semantics).
+                while True:
+                    a = np.random.randint(0, n)
+                    b = np.random.randint(0, n)
+                    c = np.random.randint(0, n)
+                    d = np.random.randint(0, n)
+                    if a != b and a != c and a != d and b != c and b != d and c != d:
+                        break
+
+                s_ab = sgn[a, b]
+                s_cd = sgn[c, d]
+                s_ad = sgn[a, d]
+                s_cb = sgn[c, b]
+
+                if s_ab == s_cd and s_ad == s_cb and s_ab != s_ad:
+                    r_ab = r[a, b]
+                    r_cd = r[c, d]
+                    r_ad = r[a, d]
+                    r_cb = r[c, b]
+                    r[a, d] = r_ab; r[a, b] = r_ad; r[d, a] = r_ab; r[b, a] = r_ad
+                    r[c, b] = r_cd; r[c, d] = r_cb; r[b, c] = r_cd; r[d, c] = r_cb
+                    sgn[a, d] = s_ab; sgn[a, b] = s_ad; sgn[d, a] = s_ab; sgn[b, a] = s_ad
+                    sgn[c, b] = s_cd; sgn[c, d] = s_cb; sgn[b, c] = s_cd; sgn[d, c] = s_cb
+                    break
+
 
 def randmio_und_signed(
     w: np.ndarray, iterations: int, rng: np.random.Generator | None = None,
@@ -28,6 +81,11 @@ def randmio_und_signed(
 
     ``iterations`` is a rewiring-attempts-per-edge multiplier, matching
     MATLAB's ``ITER`` input: total swap attempts = ``iterations * n*(n-1)/2``.
+
+    Uses a numba-compiled inner loop when available (see module note); the
+    pure-NumPy fallback below is behaviourally equivalent (same swap rule,
+    same distinct-quad sampling), just slower. Both preserve the degree
+    sequence exactly by construction — the invariant the port is validated on.
     """
     if rng is None:
         rng = np.random.default_rng()
@@ -37,6 +95,13 @@ def randmio_und_signed(
     total_iter = int(iterations * n * (n - 1) / 2)
     max_attempts = round(n / 2)
 
+    if _HAVE_NUMBA:
+        sgn = np.sign(r).astype(np.int64)
+        seed = int(rng.integers(0, 2**31 - 1))
+        _randmio_signed_core(r, sgn, total_iter, max_attempts, seed)
+        return r
+
+    # ── Pure-NumPy fallback ──────────────────────────────────────────────────
     # rng.choice(n, size=4, replace=False) has surprisingly high per-call
     # overhead (array-machinery setup dominates for such a tiny sample) —
     # profiled at >85% of this function's runtime for realistic network

--- a/src/meanap/pipeline/parallel.py
+++ b/src/meanap/pipeline/parallel.py
@@ -1,0 +1,244 @@
+"""Resource-aware parallel execution helpers for the pipeline.
+
+The pipeline has two very different parallelism profiles, and a single
+"number of workers" knob would be wrong for both:
+
+* **Step 1 (spike detection) is RAM-bound.** Each recording's raw ``dat``
+  array is ~3.8 GB in memory (64 ch x 7.5M samples x float64). Running
+  recordings in separate *processes* would duplicate that per worker, so on
+  a 16 GB machine you could fit only ~2 before swapping. But the per-channel
+  work (``scipy.signal.filtfilt`` + ``numpy.fft``) releases the GIL, so
+  Step 1 parallelizes cleanly across *threads over channels* on one shared
+  copy of ``dat`` — no extra RAM, cores saturated. Use
+  :func:`suggest_thread_count` there.
+
+* **Steps 3/4 are CPU-bound and low-RAM.** They work on spike times and
+  64x64 matrices (tens of MB), and their hot loop (``randmio_und_signed``)
+  is pure Python, so the GIL blocks threads — they need *processes over
+  recordings*. RAM per worker is small, so worker count is CPU-limited. Use
+  :func:`suggest_process_count` there, and :func:`worker_env` to stop each
+  worker's BLAS from spawning its own thread pool (which would oversubscribe
+  cores N-fold).
+
+Everything degrades safely: if ``psutil`` is unavailable the RAM query falls
+back to a conservative assumption, and every ``suggest_*`` returns at least 1.
+Passing ``max_workers=1`` anywhere gives a fully serial path for debugging.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
+from typing import Callable, Optional, TypeVar
+
+try:
+    import psutil
+
+    _HAVE_PSUTIL = True
+except ImportError:  # pragma: no cover - psutil is normally installed
+    _HAVE_PSUTIL = False
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+# Conservative assumption when we cannot measure RAM: pretend a 16 GB machine
+# with ~10 GB actually free. Better to under-parallelize than to OOM.
+_FALLBACK_AVAILABLE_GB = 10.0
+
+
+def physical_cores() -> int:
+    """Physical core count (falls back to logical, then 1)."""
+    if _HAVE_PSUTIL:
+        cores = psutil.cpu_count(logical=False)
+        if cores:
+            return cores
+    return os.cpu_count() or 1
+
+
+def available_ram_gb() -> float:
+    """Currently-available RAM in GB, or a conservative fallback."""
+    if _HAVE_PSUTIL:
+        return psutil.virtual_memory().available / 1e9
+    return _FALLBACK_AVAILABLE_GB
+
+
+def suggest_process_count(
+    n_tasks: int,
+    mem_per_task_gb: float,
+    *,
+    reserve_gb: float = 2.0,
+    cpu_headroom: int = 1,
+    max_workers: Optional[int] = None,
+) -> int:
+    """Pick a process-pool size bounded by cores *and* free RAM.
+
+    Parameters
+    ----------
+    n_tasks : number of independent work items (e.g. recordings). Never
+        spawn more workers than tasks.
+    mem_per_task_gb : peak resident memory one worker needs. This is the
+        knob that keeps a 16 GB machine alive — for Step 1 recording-level
+        work pass ~5.0 (3.8 GB load + filter copies); for Steps 3/4 pass
+        ~0.3.
+    reserve_gb : RAM to leave for the OS / GUI / parent process.
+    cpu_headroom : cores to leave free (keeps the UI responsive; 1 is a good
+        default for a desktop app).
+    max_workers : hard user-facing cap, if any.
+
+    Returns at least 1.
+    """
+    cpu_cap = max(1, physical_cores() - cpu_headroom)
+
+    if mem_per_task_gb and mem_per_task_gb > 0:
+        usable = max(0.0, available_ram_gb() - reserve_gb)
+        mem_cap = max(1, int(usable // mem_per_task_gb))
+    else:
+        mem_cap = cpu_cap
+
+    n = min(n_tasks, cpu_cap, mem_cap)
+    if max_workers is not None:
+        n = min(n, max_workers)
+    return max(1, n)
+
+
+def suggest_thread_count(
+    n_tasks: int,
+    *,
+    cpu_headroom: int = 1,
+    max_workers: Optional[int] = None,
+) -> int:
+    """Pick a thread-pool size for GIL-releasing work (Step 1's channel loop).
+
+    Threads share memory, so RAM is not a factor here — only cores and the
+    task count. Returns at least 1.
+    """
+    cpu_cap = max(1, physical_cores() - cpu_headroom)
+    n = min(n_tasks, cpu_cap)
+    if max_workers is not None:
+        n = min(n, max_workers)
+    return max(1, n)
+
+
+# BLAS/OpenMP libraries default to one thread *per physical core*. Inside a
+# process pool that multiplies: N worker processes x C BLAS threads each =
+# N*C threads fighting over C cores. Pin each worker to a single BLAS thread.
+_BLAS_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",  # Apple Accelerate / M-series
+)
+
+
+def worker_env(threads: str = "1") -> dict[str, str]:
+    """Environment overrides for pool workers: pin BLAS/OpenMP to ``threads``
+    and force matplotlib's headless Agg backend (spawned workers have no Qt
+    event loop, so any GUI backend would error on import). Harmless for
+    non-plotting workers.
+    """
+    env = {var: threads for var in _BLAS_ENV_VARS}
+    env["MPLBACKEND"] = "Agg"
+    return env
+
+
+def pin_blas_threads(threads: str = "1") -> None:
+    """Process-pool ``initializer``: pin this worker's BLAS thread count.
+
+    Must run *before* numpy/scipy/sklearn import their BLAS backend in the
+    worker to take effect, so use it as the pool ``initializer`` (workers are
+    forked/spawned fresh) rather than calling it mid-run.
+    """
+    os.environ.update(worker_env(threads))
+
+
+def map_recordings(
+    worker_fn: Callable[[T], R],
+    tasks: list[T],
+    *,
+    mem_per_task_gb: float,
+    max_workers: Optional[int] = None,
+    on_result: Optional[Callable[[R], None]] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+    blas_threads: Optional[str] = None,
+) -> list[R]:
+    """Run ``worker_fn`` over ``tasks`` in a RAM/CPU-aware process pool.
+
+    This is the "map" half of the pipeline's map→reduce→map structure: each
+    task is one independent recording that writes its own output files and
+    returns a small, picklable result for the caller to aggregate (fold batch
+    bounds, pool PC/Z for cartography, etc.). Because results come back via
+    pickling, keep them small — return scalars/paths, not multi-GB arrays.
+
+    ``worker_fn`` must be importable (module-level), since ``spawn`` re-imports
+    it in each worker. Workers get BLAS pinned to ``blas_threads`` so N
+    processes don't each spin up C BLAS threads.
+
+    ``on_result`` is called in the *parent* as each task finishes (good for
+    streaming log lines back in completion order). ``cancel_check`` (evaluated
+    in the parent between completions) stops new tasks from being dispatched
+    and drops any not-yet-started ones; in-flight tasks run to completion
+    (bounded, cooperative stop). A plain callable works for both the serial
+    and process paths since nothing is passed into workers.
+
+    Falls back to a fully serial loop when the pool would be size 1 — same
+    code path for single-recording runs and for debugging.
+    """
+    n = suggest_process_count(
+        len(tasks), mem_per_task_gb, max_workers=max_workers,
+    )
+
+    # Adaptive BLAS threads: when workers < cores (few recordings, many cores),
+    # pinning each worker's BLAS to 1 would leave most cores idle and throttle
+    # BLAS-heavy work (e.g. sklearn NMF). Give each worker its fair share of
+    # cores instead — cores//n — which fills the machine yet still collapses to
+    # 1 when workers ~= cores (many recordings), avoiding oversubscription.
+    if blas_threads is None:
+        blas_threads = str(max(1, physical_cores() // max(1, n)))
+
+    results: list[R] = []
+
+    if n <= 1 or len(tasks) <= 1:
+        for t in tasks:
+            if cancel_check is not None and cancel_check():
+                break
+            r = worker_fn(t)
+            if on_result is not None:
+                on_result(r)
+            results.append(r)
+        return results
+
+    # spawn: the only start method available on all of macOS/Windows/Linux,
+    # and it guarantees workers re-import cleanly (no inherited fork state).
+    ctx = mp.get_context("spawn")
+    with ProcessPoolExecutor(
+        max_workers=n, mp_context=ctx,
+        initializer=pin_blas_threads, initargs=(blas_threads,),
+    ) as ex:
+        pending = set()
+        it = iter(tasks)
+        # Prime the pool with up to n tasks, then top up as each completes —
+        # this keeps at most n futures alive and lets a cancel drop the rest.
+        for _ in range(n):
+            try:
+                pending.add(ex.submit(worker_fn, next(it)))
+            except StopIteration:
+                break
+        while pending:
+            done, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for fut in done:
+                r = fut.result()
+                if on_result is not None:
+                    on_result(r)
+                results.append(r)
+            if cancel_check is not None and cancel_check():
+                for fut in pending:
+                    fut.cancel()
+                break
+            for _ in range(len(done)):
+                try:
+                    pending.add(ex.submit(worker_fn, next(it)))
+                except StopIteration:
+                    break
+    return results

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -173,7 +173,10 @@ def _run_step1_spike_detection(
         )
 
         log(f"  [{rec.filename}] detecting spikes ({len(channels)} channels)…")
-        result = detect_spikes_recording(dat, channels, fs, detect_params)
+        result = detect_spikes_recording(
+            dat, channels, fs, detect_params,
+            max_workers=params.spike_detection_channel_workers,
+        )
 
         out_path = spike_dir / f"{rec.filename}_spikes.npz"
         save_spike_times_npz(out_path, result.spike_times, channels, fs)

--- a/src/meanap/pipeline/spike_detection.py
+++ b/src/meanap/pipeline/spike_detection.py
@@ -14,12 +14,15 @@ Key differences from MATLAB
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import NamedTuple
 
 import numpy as np
 import pywt
 from scipy.signal import butter, filtfilt, find_peaks
+
+from meanap.pipeline.parallel import suggest_thread_count
 
 
 # ── Bandpass filter ───────────────────────────────────────────────────────────
@@ -461,6 +464,7 @@ def detect_spikes_recording(
     channels: np.ndarray,
     fs: float,
     params: SpikeDetectionParams | None = None,
+    max_workers: int | None = None,
 ) -> SpikeDetectionResult:
     """Run spike detection on all channels of a single recording.
 
@@ -496,9 +500,15 @@ def detect_spikes_recording(
     if any(not w.startswith("thr") for w in all_methods):
         _get_bior15_wavefn()
 
-    for ch_idx in range(n_channels):
+    # Per-channel work is independent and dominated by GIL-releasing
+    # scipy.filtfilt + numpy.fft, so it threads cleanly over the (single,
+    # shared) ~3.8 GB `dat` array without duplicating it — the RAM-safe way
+    # to parallelize Step 1 (see pipeline/parallel.py). Column slices of a
+    # NumPy array are read-only-shared across threads; each channel writes
+    # only its own result dict entry, so no locking is needed.
+    def _process_channel(ch_idx: int):
         if ch_idx in params.grd:
-            continue
+            return None
 
         raw_trace = dat[:, ch_idx].astype(float)
         filtered = bandpass_filter(raw_trace, fs, params.filter_low_pass, params.filter_high_pass)
@@ -552,6 +562,19 @@ def detect_spikes_recording(
             spike_struct[valid_name] = times
             wave_struct[valid_name] = waveforms
 
+        return ch_idx, spike_struct, wave_struct, thr_struct
+
+    n_threads = suggest_thread_count(n_channels, max_workers=max_workers)
+    if n_threads <= 1:
+        results = (_process_channel(ch) for ch in range(n_channels))
+    else:
+        with ThreadPoolExecutor(max_workers=n_threads) as pool:
+            results = pool.map(_process_channel, range(n_channels))
+
+    for res in results:
+        if res is None:
+            continue
+        ch_idx, spike_struct, wave_struct, thr_struct = res
         spike_times[ch_idx] = spike_struct
         spike_waveforms[ch_idx] = wave_struct
         thresholds_out[ch_idx] = thr_struct

--- a/src/meanap/pipeline/step3.py
+++ b/src/meanap/pipeline/step3.py
@@ -1,5 +1,12 @@
 """Step 3: functional connectivity (adjacency matrices), port of the
 ``generateAdjMs.m`` / ``adjM_thr_parallel.m`` portion of ``MEApipeline.m``.
+
+Recordings are independent (each reads its own Step 1 spike ``.npz`` and writes
+its own ``_adjM.npz``), so this step is a pure parallel map over recordings —
+no cross-recording reduce. The per-recording work is CPU-bound and low-RAM
+(spike times + 64x64 matrices), and its hot path (``adjm_thr``'s circular-shift
+surrogates) is pure Python, so it runs in separate *processes* (see
+``pipeline/parallel.py`` for why threads wouldn't help here).
 """
 
 from __future__ import annotations
@@ -13,8 +20,75 @@ import numpy as np
 from meanap.params import Params
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
 from meanap.pipeline.io import load_spike_times_npz
+from meanap.pipeline.parallel import map_recordings
 from meanap.pipeline.probabilistic_threshold import adjm_thr
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
+
+# Peak per-worker RAM for Step 3: spike times (sparse) + a few 64x64xrep_num
+# surrogate stacks (~6 MB at rep_num=200). Tiny — worker count is CPU-limited.
+_STEP3_MEM_PER_TASK_GB = 0.3
+
+
+def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, list[str]]:
+    """Compute + save one recording's adjacency matrices. Module-level and
+    picklable so it can run in a ``spawn``ed worker process. Returns the
+    recording name and the log lines it produced (streamed back and printed
+    in the parent, in completion order)."""
+    params, rec, output_root_str = task
+    output_root = Path(output_root_str)
+    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
+    mat_files_dir = output_root / "ExperimentMatFiles"
+
+    method = params.spikes_method
+    lag_values = params.func_con_lag_val
+    rep_num = params.prob_thresh_rep_num
+    tail = params.prob_thresh_tail
+
+    logs: list[str] = []
+    npz_file = spike_data_dir / f"{rec.filename}_spikes.npz"
+    if not npz_file.exists():
+        logs.append(f"  [{rec.filename}] SKIP: Spike data not found at {npz_file.name}")
+        return rec.filename, logs
+
+    data = np.load(npz_file)
+    fs = float(data["fs"][0])
+    n_channels = len(data["channels"])
+
+    raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
+    try:
+        with h5py.File(raw_path, "r") as f:
+            n_samples = f["dat"].shape[0]
+            if n_samples == n_channels:
+                n_samples = f["dat"].shape[1]
+        duration_s = n_samples / fs
+    except Exception:
+        logs.append(f"  [{rec.filename}] Warning: could not read raw file for duration")
+        return rec.filename, logs
+
+    spike_times_full = load_spike_times_npz(npz_file)
+    spike_times_dict = {
+        ch: spike_times_full.get(ch, {}).get(method, np.array([]))
+        for ch in range(n_channels)
+    }
+    ground_electrodes = parse_ground_electrodes(rec.ground)
+    if ground_electrodes:
+        spike_times_dict = ground_spike_times_dict(spike_times_dict, data["channels"], ground_electrodes)
+
+    out_arrays: dict[str, np.ndarray] = {}
+    rng = np.random.default_rng()
+    for lag_ms in lag_values:
+        logs.append(f"  [{rec.filename}] computing adjacency matrix (lag={lag_ms}ms, "
+                    f"{rep_num} shuffles)...")
+        adj_m, adj_m_ci = adjm_thr(
+            spike_times_dict, n_channels, lag_ms, tail, fs, duration_s, rep_num, rng=rng,
+        )
+        out_arrays[f"adjM{lag_ms}mslag"] = adj_m_ci
+        out_arrays[f"adjM{lag_ms}mslag_raw"] = adj_m
+
+    out_path = mat_files_dir / f"{rec.filename}_adjM.npz"
+    np.savez(out_path, channels=data["channels"], **out_arrays)
+    logs.append(f"  [{rec.filename}] saved → {out_path.relative_to(output_root)}")
+    return rec.filename, logs
 
 
 def _run_step3_functional_connectivity(
@@ -24,7 +98,7 @@ def _run_step3_functional_connectivity(
     log: Callable[[str], None],
     should_cancel: CancelCheck = None,
 ) -> None:
-    """Run Step 3: compute STTC adjacency matrices for each recording/lag.
+    """Run Step 3 over all recordings as a RAM/CPU-aware parallel map.
 
     Saves one ``<recording>_adjM.npz`` per recording under
     ``ExperimentMatFiles/``, with ``adjM{lag}mslag`` (probabilistically
@@ -33,62 +107,23 @@ def _run_step3_functional_connectivity(
     ``params.func_con_lag_val``.
     """
     log("\n=== Step 3: Functional Connectivity ===")
+    check_cancel(should_cancel)
 
-    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
-    mat_files_dir = output_root / "ExperimentMatFiles"
-    mat_files_dir.mkdir(parents=True, exist_ok=True)
+    (output_root / "ExperimentMatFiles").mkdir(parents=True, exist_ok=True)
 
-    method = params.spikes_method
-    lag_values = params.func_con_lag_val
-    rep_num = params.prob_thresh_rep_num
-    tail = params.prob_thresh_tail
+    tasks = [(params, rec, str(output_root)) for rec in recordings]
 
-    for rec in recordings:
-        check_cancel(should_cancel)
-        npz_file = spike_data_dir / f"{rec.filename}_spikes.npz"
-        if not npz_file.exists():
-            log(f"  [{rec.filename}] SKIP: Spike data not found at {npz_file.name}")
-            continue
+    def _emit(result: tuple[str, list[str]]) -> None:
+        for line in result[1]:
+            log(line)
 
-        log(f"  [{rec.filename}] loading spike data...")
-        data = np.load(npz_file)
-        fs = float(data["fs"][0])
-        n_channels = len(data["channels"])
-
-        raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
-        try:
-            with h5py.File(raw_path, "r") as f:
-                n_samples = f["dat"].shape[0]
-                if n_samples == n_channels:
-                    n_samples = f["dat"].shape[1]
-            duration_s = n_samples / fs
-        except Exception:
-            log(f"  [{rec.filename}] Warning: could not read raw file for duration")
-            continue
-
-        spike_times_full = load_spike_times_npz(npz_file)
-        spike_times_dict = {
-            ch: spike_times_full.get(ch, {}).get(method, np.array([]))
-            for ch in range(n_channels)
-        }
-        ground_electrodes = parse_ground_electrodes(rec.ground)
-        if ground_electrodes:
-            spike_times_dict = ground_spike_times_dict(spike_times_dict, data["channels"], ground_electrodes)
-
-        out_arrays: dict[str, np.ndarray] = {}
-        rng = np.random.default_rng()
-        for lag_ms in lag_values:
-            check_cancel(should_cancel)
-            log(f"  [{rec.filename}] computing adjacency matrix (lag={lag_ms}ms, "
-                f"{rep_num} shuffles)...")
-            adj_m, adj_m_ci = adjm_thr(
-                spike_times_dict, n_channels, lag_ms, tail, fs, duration_s, rep_num, rng=rng,
-            )
-            out_arrays[f"adjM{lag_ms}mslag"] = adj_m_ci
-            out_arrays[f"adjM{lag_ms}mslag_raw"] = adj_m
-
-        out_path = mat_files_dir / f"{rec.filename}_adjM.npz"
-        np.savez(out_path, channels=data["channels"], **out_arrays)
-        log(f"  [{rec.filename}] saved → {out_path.relative_to(output_root)}")
+    map_recordings(
+        _step3_one_recording,
+        tasks,
+        mem_per_task_gb=_STEP3_MEM_PER_TASK_GB,
+        max_workers=params.recording_workers,
+        on_result=_emit,
+        cancel_check=(lambda: bool(should_cancel())) if should_cancel else None,
+    )
 
     log("  Step 3 complete.")

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -21,6 +21,7 @@ from meanap.pipeline.io import load_spike_times_npz
 from meanap.pipeline.modularity import mod_consensus_cluster_iterate
 from meanap.pipeline.nmf import cal_nmf
 from meanap.pipeline.null_models import latmio_und_v2, randmio_und_v2
+from meanap.pipeline.parallel import map_recordings
 from meanap.pipeline.plotting_step4 import (
     plot_circular_cartography_network, plot_circular_module_network,
     plot_connectivity_stats, plot_graph_metrics_by_node,
@@ -380,6 +381,133 @@ def _plot_recording_lag(
         log(f"  [{rec.filename}] skipped graph-metrics-by-node plot: {e}")
 
 
+# Peak per-worker RAM for Step 4: NMF's downsampled spike matrix + sklearn NMF
+# working set + (in the plot phase) a matplotlib figure or two. All modest;
+# ~0.6 GB is a safe cap so a 16 GB box still gets several workers.
+_STEP4_MEM_PER_TASK_GB = 0.6
+
+
+def _step4_compute_one(
+    task: tuple[Params, RecordingInfo, str],
+) -> tuple[str, dict | None, np.ndarray | None, list[str]]:
+    """Phase A worker: compute one recording's network metrics (effRank, NMF,
+    per-lag metrics). Module-level/picklable for ``spawn``. Returns the metrics
+    keyed by lag (or ``None`` if skipped), the channel array (needed by the
+    plot phase), and the log lines it produced."""
+    params, rec, output_root_str = task
+    output_root = Path(output_root_str)
+    mat_files_dir = output_root / "ExperimentMatFiles"
+    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
+
+    method = params.spikes_method
+    lag_values = params.func_con_lag_val
+    min_nodes = params.min_number_of_nodes_to_cal_net_met
+    logs: list[str] = []
+
+    adj_path = mat_files_dir / f"{rec.filename}_adjM.npz"
+    spike_path = spike_data_dir / f"{rec.filename}_spikes.npz"
+    if not adj_path.exists():
+        logs.append(f"  [{rec.filename}] SKIP: adjacency matrices not found at {adj_path.name}")
+        return rec.filename, None, None, logs
+    if not spike_path.exists():
+        logs.append(f"  [{rec.filename}] SKIP: spike data not found at {spike_path.name}")
+        return rec.filename, None, None, logs
+
+    # Independent RNG per worker (Step 4's PC-norm/modularity are already
+    # non-bit-reproducible; separate default_rng()s give independent streams).
+    rng = np.random.default_rng()
+
+    logs.append(f"  [{rec.filename}] loading adjacency matrices...")
+    adj_data = np.load(adj_path)
+    spike_data = np.load(spike_path)
+    fs = float(spike_data["fs"][0])
+    channels_arr = spike_data["channels"]
+    n_channels = len(channels_arr)
+
+    raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
+    try:
+        with h5py.File(raw_path, "r") as f:
+            n_samples = f["dat"].shape[0]
+            if n_samples == n_channels:
+                n_samples = f["dat"].shape[1]
+        duration_s = n_samples / fs
+    except Exception:
+        logs.append(f"  [{rec.filename}] SKIP: could not read raw file for duration")
+        return rec.filename, None, None, logs
+
+    spike_times_full = load_spike_times_npz(spike_path)
+    spike_times_dict = {
+        ch: spike_times_full.get(ch, {}).get(method, np.array([]))
+        for ch in range(n_channels)
+    }
+    ground_electrodes = parse_ground_electrodes(rec.ground)
+    if ground_electrodes:
+        spike_times_dict = ground_spike_times_dict(spike_times_dict, channels_arr, ground_electrodes)
+
+    spike_counts = np.array([len(spike_times_dict[ch]) for ch in range(n_channels)])
+    spike_times_list = [spike_times_dict[ch] for ch in range(n_channels)]
+
+    try:
+        eff_rank = nm.effective_rank(
+            spike_times_list, fs, duration_s,
+            params.eff_rank_downsample_freq, params.eff_rank_cal_method
+        )
+    except Exception as e:
+        logs.append(f"  [{rec.filename}] WARNING: could not compute effective rank: {e}")
+        eff_rank = float('nan')
+
+    try:
+        logs.append(f"  [{rec.filename}] computing NMF components...")
+        nmf_result = cal_nmf(
+            spike_times_list, spike_counts, duration_s,
+            params.nmf_downsample_freq, fs,
+            include_nmf_components=params.include_nmf_components, rng=rng,
+        )
+    except Exception as e:
+        logs.append(f"  [{rec.filename}] WARNING: could not compute NMF components: {e}")
+        nmf_result = {}
+
+    rec_results: dict = {}
+    for lag_ms in lag_values:
+        key = f"adjM{lag_ms}mslag"
+        if key not in adj_data:
+            continue
+        logs.append(f"  [{rec.filename}] computing network metrics (lag={lag_ms}ms)...")
+        metrics = compute_network_metrics(
+            adj_data[key], spike_counts, duration_s,
+            params.min_activity_level, min_nodes,
+            exclude_edges_below_threshold=params.exclude_edges_below_threshold,
+            params=params, rng=rng,
+        )
+        metrics["effRank"] = eff_rank
+        metrics.update(nmf_result)
+        rec_results[f"{lag_ms}mslag"] = metrics
+
+    return rec.filename, rec_results, channels_arr, logs
+
+
+def _step4_plot_one(
+    task: tuple[Params, RecordingInfo, dict, np.ndarray, str, dict],
+) -> tuple[str, list[str]]:
+    """Phase C worker: draw one recording's plots (individual- and
+    batch-scaled) now that ``batch_bounds`` are known. Module-level/picklable
+    for ``spawn``; writes its own PNGs and returns its log lines."""
+    params, rec, rec_results, channels_arr, output_root_str, batch_bounds = task
+    out_dir = Path(output_root_str) / "4_NetworkActivity"
+    logs: list[str] = []
+
+    def _log(msg: str) -> None:
+        logs.append(msg)
+
+    for lag_key, metrics in rec_results.items():
+        lag_ms = int(lag_key.replace("mslag", ""))
+        _log(f"  [{rec.filename}] plotting network metrics (lag={lag_ms}ms)...")
+        _plot_recording_lag(
+            rec, lag_ms, metrics, channels_arr, params, out_dir, _log, batch_bounds,
+        )
+    return rec.filename, logs
+
+
 def _run_step4_network_metrics(
     params: Params,
     recordings: list[RecordingInfo],
@@ -389,119 +517,58 @@ def _run_step4_network_metrics(
 ) -> None:
     log("\n=== Step 4: Network Activity ===")
 
-    mat_files_dir = output_root / "ExperimentMatFiles"
-    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
     out_dir = output_root / "4_NetworkActivity"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    method = params.spikes_method
-    lag_values = params.func_con_lag_val
-    min_nodes = params.min_number_of_nodes_to_cal_net_met
-    rng = np.random.default_rng()
+    _cancel = (lambda: bool(should_cancel())) if should_cancel else None
 
+    def _emit(result) -> None:
+        for line in result[-1]:  # log lines are always the last element
+            log(line)
+
+    # ── Phase A: parallel compute over recordings (map) ──────────────────────
+    check_cancel(should_cancel)
+    compute_out = map_recordings(
+        _step4_compute_one,
+        [(params, rec, str(output_root)) for rec in recordings],
+        mem_per_task_gb=_STEP4_MEM_PER_TASK_GB,
+        max_workers=params.recording_workers,
+        on_result=_emit,
+        cancel_check=_cancel,
+    )
     all_results: dict[str, dict] = {}
-    # (rec, lag_ms, metrics, channels_arr) tuples collected in the compute pass
-    # and drawn in a second pass once batch-wide metric bounds are known.
-    plot_jobs: list[tuple] = []
+    channels_by_rec: dict[str, np.ndarray] = {}
+    for filename, rec_results, channels_arr, _logs in compute_out:
+        if rec_results:
+            all_results[filename] = rec_results
+            channels_by_rec[filename] = channels_arr
 
-    for rec in recordings:
-        check_cancel(should_cancel)
-        adj_path = mat_files_dir / f"{rec.filename}_adjM.npz"
-        spike_path = spike_data_dir / f"{rec.filename}_spikes.npz"
-        if not adj_path.exists():
-            log(f"  [{rec.filename}] SKIP: adjacency matrices not found at {adj_path.name}")
-            continue
-        if not spike_path.exists():
-            log(f"  [{rec.filename}] SKIP: spike data not found at {spike_path.name}")
-            continue
-
-        log(f"  [{rec.filename}] loading adjacency matrices...")
-        adj_data = np.load(adj_path)
-        spike_data = np.load(spike_path)
-        fs = float(spike_data["fs"][0])
-        channels_arr = spike_data["channels"]
-        n_channels = len(channels_arr)
-
-        raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
-        try:
-            with h5py.File(raw_path, "r") as f:
-                n_samples = f["dat"].shape[0]
-                if n_samples == n_channels:
-                    n_samples = f["dat"].shape[1]
-            duration_s = n_samples / fs
-        except Exception:
-            log(f"  [{rec.filename}] SKIP: could not read raw file for duration")
-            continue
-
-        spike_times_full = load_spike_times_npz(spike_path)
-        spike_times_dict = {
-            ch: spike_times_full.get(ch, {}).get(method, np.array([]))
-            for ch in range(n_channels)
-        }
-        ground_electrodes = parse_ground_electrodes(rec.ground)
-        if ground_electrodes:
-            spike_times_dict = ground_spike_times_dict(spike_times_dict, channels_arr, ground_electrodes)
-
-        spike_counts = np.array([len(spike_times_dict[ch]) for ch in range(n_channels)])
-        spike_times_list = [spike_times_dict[ch] for ch in range(n_channels)]
-
-
-        try:
-            eff_rank = nm.effective_rank(
-                spike_times_list, fs, duration_s,
-                params.eff_rank_downsample_freq, params.eff_rank_cal_method
-            )
-        except Exception as e:
-            log(f"  [{rec.filename}] WARNING: could not compute effective rank: {e}")
-            eff_rank = float('nan')
-
-        try:
-            log(f"  [{rec.filename}] computing NMF components...")
-            nmf_result = cal_nmf(
-                spike_times_list, spike_counts, duration_s,
-                params.nmf_downsample_freq, fs,
-                include_nmf_components=params.include_nmf_components, rng=rng,
-            )
-        except Exception as e:
-            log(f"  [{rec.filename}] WARNING: could not compute NMF components: {e}")
-            nmf_result = {}
-
-        rec_results = {}
-        for lag_ms in lag_values:
-            check_cancel(should_cancel)
-            key = f"adjM{lag_ms}mslag"
-            if key not in adj_data:
-                continue
-            log(f"  [{rec.filename}] computing network metrics (lag={lag_ms}ms)...")
-            metrics = compute_network_metrics(
-                adj_data[key], spike_counts, duration_s,
-                params.min_activity_level, min_nodes,
-                exclude_edges_below_threshold=params.exclude_edges_below_threshold,
-                params=params, rng=rng,
-            )
-            metrics["effRank"] = eff_rank
-            metrics.update(nmf_result)
-            rec_results[f"{lag_ms}mslag"] = metrics
-            # Defer plotting to a second pass: the "scaled to entire data batch"
-            # variants need batch-wide metric bounds, which aren't known until
-            # every recording has been computed (see below).
-            plot_jobs.append((rec, lag_ms, metrics, channels_arr))
-
-        all_results[rec.filename] = rec_results
-
-    # Second pass: now that all recordings are computed, pool the node-level
-    # metrics to get batch-wide bounds, then draw every recording's plots
-    # (individual-scaled + the batch-scaled ``_scaled`` variants).
+    # ── Phase B: reduce (serial) ─────────────────────────────────────────────
+    # Pool node-level metrics across every recording for the batch-scaled plot
+    # bounds. This is also where cross-recording node-cartography boundaries
+    # (pooled PC/Z density landscape → basins) will be computed once ported —
+    # a second reducer in the same barrier. See PIPELINE_PORT_STATUS.md.
     batch_bounds = {
         m: _batch_metric_bounds(all_results, m)
         for m in ("ND", "NS", "BC", "PC", "Eloc")
     }
-    for rec, lag_ms, metrics, channels_arr in plot_jobs:
-        check_cancel(should_cancel)
-        log(f"  [{rec.filename}] plotting network metrics (lag={lag_ms}ms)...")
-        _plot_recording_lag(
-            rec, lag_ms, metrics, channels_arr, params, out_dir, log, batch_bounds,
-        )
+
+    # ── Phase C: parallel plot over recordings (map) ─────────────────────────
+    check_cancel(should_cancel)
+    plot_tasks = [
+        (params, rec, all_results[rec.filename], channels_by_rec[rec.filename],
+         str(output_root), batch_bounds)
+        for rec in recordings
+        if rec.filename in all_results
+    ]
+    map_recordings(
+        _step4_plot_one,
+        plot_tasks,
+        mem_per_task_gb=_STEP4_MEM_PER_TASK_GB,
+        max_workers=params.recording_workers,
+        on_result=_emit,
+        cancel_check=_cancel,
+    )
 
     try:
         json_results = {

--- a/uv.lock
+++ b/uv.lock
@@ -27,8 +27,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -275,8 +274,7 @@ name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
 wheels = [
@@ -447,6 +445,34 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a0/acc8ffcd5bdc63df0097e22c719bfcd61b604358343089313a8aebbb24ab/llvmlite-0.48.0.tar.gz", hash = "sha256:543b19f9ef8f3c7c60d1468191e4ee1b1537bf9f8a3d56f64c0ddd98de92edd2", size = 184016, upload-time = "2026-07-02T20:20:05.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/55/595981f14fbae9ba966feb12af552b1fe69889e44e64ac883a731ed335e0/llvmlite-0.48.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:56a7e24607d3f02d7b1bae8d29c7e1e423d53143d68b072999777f19678fe77b", size = 40480651, upload-time = "2026-07-01T18:41:18.438Z" },
+    { url = "https://files.pythonhosted.org/packages/26/08/0109d1b9cb3f4603f3890e30bc66c65332b79185f12a045343b2ae431f67/llvmlite-0.48.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6fa532d6bb3fd3f0803567c736401c54aecfe1a396d3ad25d2440d220e09f0e7", size = 59890118, upload-time = "2026-07-01T18:41:28.184Z" },
+    { url = "https://files.pythonhosted.org/packages/02/eb/c5281be180c789cdffbf45b671884c57d7e61345ef3b0f643a4965e108e8/llvmlite-0.48.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:979a66a3f28a02565383ff463527dce78e9b856298872a361283132488e83591", size = 58343458, upload-time = "2026-07-01T18:41:23.397Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f7/b3222b13f2d424dae3c9e63fde476af25ebccf1f3faf0b52d1b79fc15c70/llvmlite-0.48.0-cp311-cp311-win_amd64.whl", hash = "sha256:efaee0276e5e17c2b99b92e0c974bd484ef5977cf5dbc9168e82b71578edb47f", size = 41864734, upload-time = "2026-07-01T18:41:31.932Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a2/28696a9e61e245d1a79816d29d106692a90a2b6e7d78c98b326db70827af/llvmlite-0.48.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:d66c3beb4209087ddd4cf4ed2a0856b6887e6a913bdcf1aacfec9851cf2cba4e", size = 40480651, upload-time = "2026-07-01T18:41:35.694Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f2/72409351db66d0a317ec5087e076f31fb7b773a640db8a90ce6b5cac9edd/llvmlite-0.48.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:416fa4c2c66c2c6dc6d0a402648c19206e548efa0aa1eff01ad5cdad0af8217d", size = 59890118, upload-time = "2026-07-01T18:41:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/27/5ae2f3722606360480707adb47f001ad89df8251d06b14ee80336e660b66/llvmlite-0.48.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5e5a5131045b72345c71062ea1a91910dde913792b6c9b28ebb2c1c0a712e98", size = 58343459, upload-time = "2026-07-01T18:41:40.306Z" },
+    { url = "https://files.pythonhosted.org/packages/16/78/d824ffff7521cd140dc2006e44ce2bc82e64b48d1b32e90e956308c85a74/llvmlite-0.48.0-cp312-cp312-win_amd64.whl", hash = "sha256:d45c7541a80934ec6d8ab0defe67439494ecd2193cbf852a44ba827808976ac1", size = 41865022, upload-time = "2026-07-01T18:41:48.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/23/fe9316d14626b42c73ef0b502e724705a6ee9450afe53759c0a99c37c2d7/llvmlite-0.48.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a83a99ef0c05b4ccddf9b6218ed9fe84b653a0caf7c1d9dbe148d6d16c67f518", size = 40480652, upload-time = "2026-07-01T18:41:52.216Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/90715fa12006d681270b08d881195b6fab3ec39572e048764a1f7f59fed7/llvmlite-0.48.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8761b9e522f55207e24424fcd98370289eec2710bf8e915c82d1053f642450dc", size = 59890120, upload-time = "2026-07-01T18:42:00.748Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5e/7b3e20d64650ca3c80af0cdb664ec4b575ec83d9d4dd05bea8bd31f9bbb6/llvmlite-0.48.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fe5cb59b2063bfa039dcb8ca6481c0181bf552f340d10dcf61d7996a665556e", size = 58343457, upload-time = "2026-07-01T18:41:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/17/97/5a430055d1838cf1fb7a01cfa943300f5e4c026fc6333a522c5e4a03b0c1/llvmlite-0.48.0-cp313-cp313-win_amd64.whl", hash = "sha256:91c7e24e74cde3f02b88aa5acca678373f9e069f3b98531b3dbb3a142d9d10bb", size = 41865022, upload-time = "2026-07-01T18:42:04.57Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/8e/8170f2e0c217f88069c333d85bb976e536b332aecfcce606ddbdb249385f/llvmlite-0.48.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:321f1ac39b462603f0b589751aecf2d237d056f6d005749c1752b6f23ec3f074", size = 40480650, upload-time = "2026-07-01T18:42:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e1/05b50692b647cac3c18200ac485b04f342f00ed173c9cc46767274469a15/llvmlite-0.48.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05f0103c8f2f96a37441337e3643863c01b8e83e530aff38960dcb383c54a065", size = 59890115, upload-time = "2026-07-01T18:42:17.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c3/470b8c4ff9ae2db2f9cf5c3e73de76ed908a32788ae9eb5602d43e6a476b/llvmlite-0.48.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37d66fae72802175b0bfe1ea06e624b51e2d7aee6c3c34bbd09739b8f88e8e0b", size = 58343457, upload-time = "2026-07-01T18:42:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2d/6a5171fb7236ac0895e1a02ccba3735bf291e8597239aa6421894d3c0ba8/llvmlite-0.48.0-cp314-cp314-win_amd64.whl", hash = "sha256:966dcab0a598e2bd8fb5f2cc082cf7b07bae564fc485a3a8692393caf986facf", size = 42986372, upload-time = "2026-07-01T18:42:21.483Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e3/7a93e09c9f94e637ca90209ceef0334a9a1d45b0bdb7c92ff922d25d6187/llvmlite-0.48.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7a5c413317050a1d67c34708bde97707f9b2257ef1017f7532d21fe7d9a9ff30", size = 40480654, upload-time = "2026-07-01T18:42:25.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/98/a29133b4728671a175f7d616fab8b1c6e1d8c269d1523581d3160697bfb1/llvmlite-0.48.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d9f952dff6c350c529997423d4fa43abae9722a884ac7ffafc37a3af676e7db", size = 59890119, upload-time = "2026-07-01T18:42:33.88Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/cf/7aac11a1f1c7ec54b60c7f6814e87561fb6b55b2f290455d7941eb113420/llvmlite-0.48.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:054aa7d46595935565f276cf0c1659b4f10929c996dd4a606875fae26fba2a23", size = 58343460, upload-time = "2026-07-01T18:42:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/db/41/b96f440c7df5ebba07872cad4e30fbc3560387755b1ea0b629adb76d5ca8/llvmlite-0.48.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d0b3c61aac83b42fb48cc96bffbf57c81b82b2aa92276b7ed6420c814629a99a", size = 42986383, upload-time = "2026-07-01T18:42:37.544Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -455,8 +481,7 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -520,11 +545,12 @@ dependencies = [
     { name = "matplotlib" },
     { name = "natsort" },
     { name = "networkx" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numba" },
+    { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pybaselines" },
     { name = "pyqt6" },
     { name = "pyqtdarktheme" },
@@ -550,10 +576,12 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "natsort", specifier = ">=8.4" },
     { name = "networkx", specifier = ">=3.3" },
-    { name = "numpy", specifier = ">=1.26" },
+    { name = "numba", specifier = ">=0.60" },
+    { name = "numpy", specifier = ">=1.26,<2.5" },
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "pillow", specifier = ">=10.0" },
+    { name = "psutil", specifier = ">=5.9" },
     { name = "pybaselines", specifier = ">=1.2.1" },
     { name = "pyqt6", specifier = ">=6.11.0" },
     { name = "pyqtdarktheme", specifier = ">=2.1.0" },
@@ -597,14 +625,41 @@ wheels = [
 ]
 
 [[package]]
+name = "numba"
+version = "0.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a0/570e3dc53e5602b49108f62a13e529f1eec8bfc7ef37d49c825924dcf546/numba-0.66.0.tar.gz", hash = "sha256:b900e63a0e26c05ea9a6d5a3a5a0a177cb64c5011887bf43edb8c3ed2c38d363", size = 2806181, upload-time = "2026-07-01T23:12:46.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/02/970796b4daa709604cde22e87a7cda9bde473c278ea4a75f59fe38cee47f/numba-0.66.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:bbd531c327557a9004507fa6bff06c53ab51a7a5776b75261bb9cef1efe2b2ea", size = 2727049, upload-time = "2026-07-01T23:12:11.296Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/99/33a6ed9c1a0b5e42efa98eb0edf617d61dca576c82625947377b1d4540c9/numba-0.66.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc6629becb21a867d85401ec89f426dd24c484a4193ade8a38309debfd1529ca", size = 3808870, upload-time = "2026-07-01T23:12:12.944Z" },
+    { url = "https://files.pythonhosted.org/packages/04/20/8c51126025211659235b8de2866dfa226984ae0c8273461a3cf374716741/numba-0.66.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aac69f3ccb8af100f5913c1241edc9692bad1cdd2508721713f426eb06c9a659", size = 3514498, upload-time = "2026-07-01T23:12:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c9/9476940bc6d5caf5c0cf2e4c5feecbf01244bbe6f914614082dd7a3e520e/numba-0.66.0-cp311-cp311-win_amd64.whl", hash = "sha256:fb601841d9e02e6237bb6522e36d0741614be3cfe2b482a6f00a41b5ba209443", size = 2780225, upload-time = "2026-07-01T23:12:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a3/70deb7f88461c1cd5d16aa990c2380604102661a427667b8950dcdccc27f/numba-0.66.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:53ca5900b7cab15109796030113a6b28576bae5ad7bb507ad6dd1360ddd81ba4", size = 2727264, upload-time = "2026-07-01T23:12:18.669Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/25c319845e9a4e08f16611ddbda56a192eb7b6ed13e1a2bff2da272ffb97/numba-0.66.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0999e3ee1b18c48e1fb51d11af35ef59852c7f4f50569c9550c25faef0616ad1", size = 3866252, upload-time = "2026-07-01T23:12:20.429Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ef/a82d6fd6bf1b0fe461651e924d3647eeec9ac17f8eee4896264bf7480930/numba-0.66.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efe0d2d5099790df945e0cb6e1b3104bd965d7bbfac50d62f1d5d1d6ade0825d", size = 3566974, upload-time = "2026-07-01T23:12:22.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/eb/9e6171e378822ab191c7abcfd3d8cfc8644516f6c7834c22e210e4acc070/numba-0.66.0-cp312-cp312-win_amd64.whl", hash = "sha256:b075a4e7ebc43dc6294f223e2821659656209fd5e0ce53245877c23d66d6e1a9", size = 2797403, upload-time = "2026-07-01T23:12:23.724Z" },
+    { url = "https://files.pythonhosted.org/packages/03/52/176c02d005c5c5143cde10a85bbcdcb6236d9e34c3aac089380e0506cd1d/numba-0.66.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:380b2556a2019ccd1e956ae77dd257eaa39403f7520768b626d44b755112785e", size = 2727084, upload-time = "2026-07-01T23:12:25.434Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b5/e930010965568fe7f2c6c962fd2849d458cb9f62c3ab7584af8a19a2b40a/numba-0.66.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:939316d5d8619751207b8972a67852b5a7646665298cb4de693cd6bf135152f4", size = 3873663, upload-time = "2026-07-01T23:12:27.308Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ec/5b51457cbe96e4831141d83e892e65191b23a1b78728456c62909d231ace/numba-0.66.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdf506775d9f02eb92a87bf5c5b1e0d25506fd18cafd769f4ed914a8feac73e7", size = 3573529, upload-time = "2026-07-01T23:12:28.944Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7e/cea7710e96913d3c7f2999f16db1b28e6c5be5171cbf40f77f98333a7243/numba-0.66.0-cp313-cp313-win_amd64.whl", hash = "sha256:c5bfe5350284509ab0474390321454c3a8627a188af5b68c910e83df3e2db4a7", size = 2797247, upload-time = "2026-07-01T23:12:30.774Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7a/7e0e73550eb4e41ede6e72fb5371f4539537a4d770a3b73fa9b61aea0622/numba-0.66.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:46ae5f2b19e2af3c33c2df100306a90ea2f981c8158b0390f8bf6c20eee7357e", size = 2727296, upload-time = "2026-07-01T23:12:32.39Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/26/885774c006de6620ed3d10f45d8e20fe0b8e6aad6d573211a2cbc8b3e528/numba-0.66.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e2b101f23b8b63978d334574d2039f27f0dccfe1d891756f33a2e2f3e4c88cf4", size = 3842720, upload-time = "2026-07-01T23:12:33.938Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/edebf7de890b73973d839dd971cf73734adfb81ffa1b4504f84b9059c3e5/numba-0.66.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63b943eb2c9ba371908ce2cd6dfc643db51fc40f7966993376a1701bc922f537", size = 3543537, upload-time = "2026-07-01T23:12:35.566Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/b46ad28ac3681d035ea21365c5e052149062e1a0a9affd0563d2760ea6ff/numba-0.66.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd57790acd20f6a468e0ad333ef6b82355e309a92310fb7dff80e919f01a21a9", size = 2799250, upload-time = "2026-07-01T23:12:37.154Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6f/5e77a7397a37dd16f57a7b72e7e470db5227b68e3639df0d13a8e674883d/numba-0.66.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:db7735d15ea17a283d6485b9fa3504769f78fd86e5146638ad5e8da57c031b9e", size = 2730342, upload-time = "2026-07-01T23:12:38.758Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fd/e9c9680a3813f3d781c20e5d53c1074801b787d4feecca0472fdd7c05ce1/numba-0.66.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:651a2b53298340956db26ecbe7ab043106b50a40c2807e66d617a4917245a4ab", size = 3878695, upload-time = "2026-07-01T23:12:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/61/3a/9b363287b85fcd4537ea3878793822878b2ac1008a78159d2096fea628de/numba-0.66.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c1144ba1720ea59ad79f4f488ed54d149b2613b357f7e445678b7d0739c70e9", size = 3596323, upload-time = "2026-07-01T23:12:42.805Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f2/dca53d50b8f2289dd01954ace9da261e0487d5b74b188b4304e4ecc3492c/numba-0.66.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d426178fb991a85714c43112a8ea7b9d9579ea856ad8dcdb9c1c3941903ba5be", size = 2804772, upload-time = "2026-07-01T23:12:44.399Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.12' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
@@ -681,65 +736,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
-    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
-    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
-    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
-    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
-    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
-    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
-    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
-]
-
-[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -765,8 +761,7 @@ name = "pandas"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
     { name = "python-dateutil" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
@@ -912,12 +907,39 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "pybaselines"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
@@ -1061,8 +1083,7 @@ name = "pywavelets"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/75/50581633d199812205ea8cdd0f6d52f12a624886b74bf1486335b67f01ff/pywavelets-1.9.0.tar.gz", hash = "sha256:148d12203377772bea452a59211d98649c8ee4a05eff019a9021853a36babdc8", size = 3938340, upload-time = "2025-08-04T16:20:04.978Z" }
 wheels = [
@@ -1148,8 +1169,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
     { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "threadpoolctl" },
@@ -1194,8 +1214,7 @@ version = "0.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/75/dcaab14f7e7e1522e9677bc4efb48d41d645ab745fb553377a017991a9cb/sciplotlib-0.0.7.tar.gz", hash = "sha256:e25d8b2bf4ba250057535314da037545c02e64c1d3c16ec717334513c64963db", size = 52276, upload-time = "2023-12-13T18:39:06.637Z" }
 wheels = [
@@ -1212,7 +1231,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -1291,7 +1310,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -1343,8 +1362,7 @@ version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
     { name = "pandas" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }


### PR DESCRIPTION
## Summary

A performance pass on the Python pipeline. A full steps-1–4 run on the test dataset dropped from **1166.9s → 350.0s (3.3×)** — Python is now **~2.66× faster than MATLAB** (931s), where it was previously ~25% slower. Same machine and config as the existing benchmark (2 recordings, 10/25/50 ms lags, 200 threshold reps).

| Step | Before | After | Speedup |
|---|---:|---:|---:|
| 1. Spike detection | 568.8s | **103.6s** | 5.5× |
| 2. Neuronal activity | 6.2s | 6.4s | — |
| 3. Functional connectivity | 80.2s | **42.7s** | 1.9× |
| 4. Network activity | 511.7s | **197.3s** | 2.6× |
| **Total** | **1166.9s** | **350.0s** | **3.3×** |

## What changed

- **Step 1 — channel-level threading** (`detect_spikes_recording(max_workers=)`). Per-channel wavelet CWT + bandpass release the GIL, so threads parallelize over one shared ~3.8 GB `dat` array with **no extra RAM**. Bit-identical output.
- **New `src/meanap/pipeline/parallel.py`** — RAM/CPU-aware worker sizing. Step 1 is RAM-bound → *threads over channels*; steps 3/4 are CPU-bound/low-RAM → *processes over recordings*. Auto-sizes to physical cores + free RAM (`psutil`) with headroom; per-worker BLAS pinned to avoid oversubscription. Override via `params.spike_detection_channel_workers` / `params.recording_workers` (`None` = auto). Serial fallback throughout.
- **numba `@njit` `randmio_und_signed`** (~28× on the PC-norm null models) with a pure-Python fallback, so it runs without numba, just slower. Adds `numba`, pins `numpy<2.5`, adds `psutil`.
- **Collection-based plotting** (`network_plot.py`) — network edges (`LineCollection`) and nodes (`PatchCollection`) were previously hundreds of individual artists per figure × ~380 figures. ~5× on the plot phase (single-threaded, portable), and it removes a `get_text_width_height_descent` layout pathology. Output pixel-validated unchanged.
- **Step 4 restructured** into A (parallel compute) → B (serial batch-bounds reduce) → C (parallel plot). Deterministic metrics are bit-identical serial-vs-parallel; the reduce barrier reserves a slot for the not-yet-ported cross-recording node-cartography boundary clustering.

## Validation

- All step-3/4 parity fixtures pass under numpy 2.4.6.
- Step 1 threaded output bit-identical to serial; Step 3 raw STTC identical; Step 4 deterministic metrics identical serial-vs-parallel; plots pixel-checked.

## Caveats

- Measured on a shared 16-core box where step-4 **process**-parallelism scales poorly (memory-bandwidth/BLAS contention → only ~1.1–1.4× across recordings). Most of step 4's win is the numba + plotting changes, which are single-threaded and portable; a dedicated ~8-core machine should get more from the recording map.
- Remaining portable candidates: numba `randmio_und_v2`/`latmio_und_v2` (small-worldness, same pattern). `init="nndsvda"` for NMF was tried and reverted (~8% slower — the per-rank sweep pays the SVD-init cost on every fit).

See `python/PIPELINE_PORT_STATUS.md` → "Optimization pass — 3.3x faster end-to-end" for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)