### PR TITLE
Python pipeline: CAT-NAP calcium-imaging port, cartography fix, 3.3× perf

### DIFF
--- a/python/CATNAP_PORT_PLAN.md
+++ b/python/CATNAP_PORT_PLAN.md
@@ -1,0 +1,171 @@
+# CAT-NAP (calcium imaging) port plan
+
+CAT-NAP is the calcium-imaging analysis pathway — the Python equivalent of
+MATLAB's `suite2pToAdjm.m` → `MEApipeline.m (Params.suite2pMode == 1)` workflow.
+It takes [suite2p](https://github.com/MouseLand/suite2p) output (per-cell
+fluorescence) instead of raw MEA `.mat` recordings, denoises it, extracts
+calcium transients ("peaks"), builds a functional-connectivity adjacency matrix,
+and then reuses the **same** network-metrics machinery as the electrophysiology
+(ephys) side.
+
+This document tracks the port. For the ephys pipeline status see
+`python/PIPELINE_PORT_STATUS.md`.
+
+---
+
+## Already ported (standalone denoising + preview tool)
+
+A complete, GUI-wired **denoising + trace-preview** tool. It can denoise a
+suite2p recording and inspect traces, but is **not yet connected** to the
+network-analysis pipeline.
+
+| Piece | File | Mirrors MATLAB |
+|---|---|---|
+| Folder scanner | `src/meanap/catnap/scanner.py` | `appCheckSuite2pData.m` |
+| Suite2p loader (`Suite2pData`) | `src/meanap/catnap/loader.py` | the NPY reads in `suite2pToAdjm.m` |
+| Denoising + peak detection | `src/meanap/catnap/denoising.py` | `denoiseSuite2pData.py` |
+| GUI panel | `src/meanap/gui/panels/catnap.py` | the CAT-NAP (2P) tab |
+| User docs | `docs/python/catnap.md` | — |
+| Params | `src/meanap/params.py` (twop_* fields) | `getParamsFromApp.m` |
+
+---
+
+## The gap
+
+Everything in `suite2pToAdjm.m` *after* denoising, plus the `suite2pMode == 1`
+branches in `MEApipeline.m`, is unported. When suite2p mode is on, MATLAB:
+
+- **replaces step 1** (spike detection) and **step 3** (connectivity) with
+  `suite2pToAdjm` → produces `adjMs`, `coords`, `channels`, `activityProperties`;
+- **swaps step-2 stats** for `calTwopActivityStats.m`;
+- builds the activity matrix for rasters via `get2pActivityMatrix.m`;
+- maps cell types via `getCellTypeMatrix.m` (from `Info.CellTypes`);
+- feeds the **shared, already-ported step-4** network metrics.
+
+---
+
+## Parity dataset (ground truth)
+
+`local/example2pdataWCellTypes/` is a complete CAT-NAP run. `local/` is
+gitignored, so tests must **skip gracefully** when it is absent.
+
+| Component | Path (under `local/example2pdataWCellTypes/`) |
+|---|---|
+| suite2p inputs (+ precomputed denoising) | `OPME…/suite2p/plane0/` |
+| Cell types | `OPME…/PutativeCellType_…_PositiveOnly.csv` (cols: NeuN+/Mecp2+/PV+/SST+/GAD+) |
+| Metadata (1 rec, HET, DIV21) | `Metadata_…SingleTest…csv` |
+| Full `expData` mat (v7, scipy-readable) | `OutputData22May2026/ExperimentMatFiles/*.mat` |
+| Step-4 `NetMet` mat (v7, scipy-readable) | `OutputData22May2026-step-4/ExperimentMatFiles/*.mat` |
+
+**Run config** (`Params` in the mat): `suite2pMode=1`, `twopActivity='peaks'`,
+`FuncConLagval=[1000, 2500, 5000]` ms, `fs=33.3` Hz, `duration=600.6` s,
+`removeNodesWithNoPeaks=1`, `ProbThreshRepNum=200`, `ProbThreshTail=0.05`,
+`minActivityLevel=0.01`. After iscell + no-peaks filtering: **253 nodes**,
+up to 59 peaks/cell.
+
+**Confirmed parity targets** (verified field names):
+
+- Full `expData` mat: `adjMs.adjM{1000,2500,5000}mslag` (253×253), `coords`
+  (253×2), `channels`, `F`/`denoisedF`/`spks` (20000×253), `spikeTimes`
+  (cell array of structs with `.peak`, in **seconds**), `activityProperties`
+  (`cellsWithPeaks, peakDurationFrames, peakHeights, eventAreas`),
+  `activityStats` (`FR, FRactive, FRmean/std/sem/median/iqr, numActiveElec,
+  ISImean, ISI, unitHeightMean, unitPeakDurMean, unitEventAreaMean,
+  unitEventAreaSum, recHeightMean, recPeakDurMean, recEventAreaMean`).
+- Step-4 mat: `NetMet` per lag (shared step 4, already ported).
+
+> ⚠️ The `peaks` → adjM path uses probabilistic thresholding (RNG via circular
+> shifts), so — exactly like the ephys STTC parity — `adjMs` match only **within
+> the prob-threshold tolerance**, not bit-exact. `activityStats`, `coords`,
+> `activityProperties`, and `spikeTimes` are **deterministic → exact parity**.
+
+---
+
+## Phases
+
+### Phase 0 — Test scaffolding ✅ (this change)
+- `python/test_pipeline_catnap.py`: standalone script (matching the other
+  `test_pipeline_*.py`), skips when the local dataset is absent, loads both
+  ground-truth mats, and asserts the parity targets exist / have expected
+  shapes. Per-phase numeric assertions are filled in as each phase lands.
+
+### Phase 1 — `params.suite2p_mode` + runner guard ✅ (this change)
+- `Params.suite2p_mode: bool` added.
+- `run_pipeline` raises `NotImplementedError` when it is set (fails loudly
+  instead of running ephys steps on 2P data).
+- CAT-NAP GUI panel exposes a "Analyse suite2p data (CAT-NAP)" checkbox, wired
+  through `load()`/`save()`.
+
+### Phase 3 — `catnap/stats.py` ✅
+Ported `calTwopActivityStats` (`calc_twop_activity_stats`) + `getCellTypeMatrix`
+(`get_cell_type_matrix`). `calc_twop_activity_stats` has **exact parity** on all
+17 `activityStats` fields (verified in `test_pipeline_catnap.py`, incl. the
+subtle ones: N−1 std, MATLAB `iqr` via numpy `method="hazen"`, round-half-away
+scalars). `get_cell_type_matrix` logic verified against the PositiveOnly CSV
+(no MATLAB output to compare — `Info.CellTypes` is an opaque MCOS table).
+`get2pActivityMatrix` deferred to Phase 5 (only consumed by the raster plot).
+
+### Phase 2 — `catnap/adjacency.py` ✅
+Ported `suite2pToAdjm.m` (`suite2p_to_adjm`): iscell filter → `channels`/`coords`
+(stat centroids, normalized 0→8 over the full XYloc range) → `removeNodesWithNoPeaks`
+subset → `activityProperties` → adjacency (`corr` for F/spks/denoised F;
+`peaks` reuses `probabilistic_threshold.adjm_thr`/STTC per lag). Verified in
+`test_pipeline_catnap.py`: coords, channels, activityProperties, cellsWithPeaks,
+and spikeTimes (all 253 units) **exact**; the RNG-thresholded `adjMs` checked via
+the deterministic invariant "every surviving (nonzero) edge equals raw STTC" —
+exact on all ~46k/40k/24k surviving edges at the three lags.
+
+**Bug found & fixed** (`pipeline/sttc.py`): the vectorized `_run_p` used
+`np.searchsorted`, which silently assumes sorted spike trains. suite2p/denoising
+peak times can be **unsorted**, and MATLAB's `sttc_m.m run_P` is an
+order-dependent monotonic two-pointer that never sorts — so the vectorized
+version gave wrong STTC for unsorted trains (up to ~0.33 off). Replaced with a
+faithful numba-jitted port of the literal loop (pure-Python fallback). Ephys STTC
+exact parity preserved (max|diff|≈1e-16); full pipeline test suite still green.
+
+### Phase 4 — Runner integration ✅
+`catnap/pipeline.py::run_catnap_pipeline` orchestrates the suite2p path; `run_pipeline`
+branches to it when `suite2p_mode` (replacing the Phase 1 `NotImplementedError`),
+returning before the ephys steps. Per recording: `load_suite2p` → denoise if needed
+(skipped when `Fdenoised.npy` cached) → `suite2p_to_adjm` → `calc_twop_activity_stats`
+→ **shared** `step4.compute_network_metrics` per lag → save `netmet_results.json`,
+`NetworkActivity_{Recording,Node}Level.csv`, and `TwoPhotonActivity_RecordingLevel.csv`.
+Verified two ways: (1) NetMet parity — feeding MATLAB's stored (step-4-mat) adjMs
+into `compute_network_metrics` reproduces `NetMet` **exactly** on all deterministic
+fields (aN, Dens, Eglob, ND, NS, MEW, Eloc, BC, + scalar summaries) across the 3
+lags (36/36 in `test_pipeline_catnap.py`); (2) end-to-end smoke run on the local
+dataset completes and writes correct outputs (TwoPhoton stats match Phase 3;
+NodeLevel = 175 active nodes). **112/112 total test checks pass.**
+
+Network-plot generation (needs suite2p `coords` instead of an MEA channel
+layout) is deferred to Phase 5.
+
+### Phase 5 — Run-time plots ◑ (mostly done)
+- **`plot2ptraces`** ✅ → `catnap/plotting.py::plot_2p_traces`: per-unit 3-panel
+  figure (raw F / min-max-scaled F over denoised / denoised + event-start
+  markers), saved to `2_NeuronalActivity/2A_IndividualNeuronalAnalysis/{grp}/{fn}/
+  unit_<roi>_2ptraces.png`. Visually verified faithful to the MATLAB layout.
+  (Deviation: takes the first N labelled ROIs, not `randsample`, for
+  reproducibility.)
+- **Spatial network plot** ✅ (wiring) → reuses `step4.plot_spatial_network` via
+  a new `coords_override` path (`plotting_step4._prepare_network_plot_data`),
+  feeding suite2p cell centroids instead of an MEA channel layout. Renders the
+  `2_MEA_NetworkPlot.png` per lag. **Known gap:** node-size scaling is tuned for
+  ~60 MEA electrodes, so 175 dense 2P cells overlap; MATLAB's
+  `minNodeSize`/`maxNodeSize`/`nodeScaling*` params aren't ported for the dense
+  2P case — a cosmetic refinement, metrics/coords are correct.
+- **Raster** (`get2pActivityMatrix` → `rasterPlot`) — not yet ported.
+
+Both `plot_2p_traces` and the network plot are wired into `run_catnap_pipeline`
+(`_plot_recording`), guarded so a plotting failure never aborts the run.
+
+---
+
+## Reuse wins
+- Denoising / peak detection (`catnap/denoising.py`) — done.
+- STTC + probabilistic thresholding (`pipeline/probabilistic_threshold.py`) —
+  the `peaks` adjacency path is the same machinery as ephys.
+- Step-4 network metrics (`pipeline/step4.py`, `network_metrics.py`) — shared,
+  already ported.
+- Cell types from a spreadsheet — the network viewer already reads cell types
+  from Excel/CSV rather than the MCOS `MatlabOpaque` table in the mat.

--- a/python/PIPELINE_PORT_STATUS.md
+++ b/python/PIPELINE_PORT_STATUS.md
@@ -599,6 +599,29 @@ whatever's on disk and opens it via `webbrowser.open()`.
   (recording, lag) at real data sizes (100 randomizations × Maslov-Sneppen
   rewiring) — see `null_models.py`'s "Performance" note above if this ever
   needs to be faster.
+- **Auto-set cartography boundaries (`TrialLandscapeDensity.m`) is now
+  ported** — `network_metrics.trial_landscape_density` +
+  `step4._apply_cartography_boundaries` (Phase B reducer, gated on
+  `params.auto_set_cartography_boundaries`, per-lag by default to match
+  `MEApipeline.m`). Before this, `step4.py` classified nodes with the *fixed*
+  default boundaries (`peri_part_coef=0.625` …); against real data almost
+  every node's normalized PC sits below 0.625, so ~62-95% of nodes piled into
+  cartography role 1 (`NCpn1`) and roles 2-6 were near-empty — a systematic,
+  non-RNG divergence from MATLAB's `NCpn1-6` CSV columns (found via end-to-end
+  CSV verification vs `OutputData24Dec2025`). The port pools PC/Z across
+  recordings and re-derives all five boundaries by optimal 1-D k-means
+  (`_optimal_1d_split_boundaries`, a deterministic O(k·n²) DP — MATLAB's
+  `kmeans` is random-seeded and *not* itself bit-reproducible, so exact
+  boundary parity is unavailable, same class as Step 3). Validated against
+  MATLAB's stored per-lag boundaries (several match to ~1e-16 where MATLAB's
+  kmeans also hit the optimum) and by `test_pipeline_landscape.py` (48 checks,
+  incl. a regression guard that data-driven boundaries un-pile role 1 across
+  all 6 fixture recordings/lags). **Deliberate divergence from MATLAB**:
+  `TrialLandscapeDensity.m` line 61 reloads `ExpName{1}` every loop iteration,
+  so MATLAB actually pools only the *first* recording's PC/Z (duplicated) — an
+  upstream bug. The port pools *all* recordings (the documented intent); this
+  is the largest remaining source of NCpn1-3 difference vs MATLAB and is
+  expected/bounded, not a defect.
 - **Found and fixed a real bug from an earlier session (not a MATLAB bug —
   this one was mine): node cartography classification and Hub3/Hub4 were
   wired to the *raw* PC instead of the *normalized* PC** in an earlier
@@ -1069,9 +1092,10 @@ Key pieces (all default-on, with serial fallbacks; see
   unchanged.
 - **Step 4** restructured into A (parallel compute) → B (serial batch-bounds
   reduce) → C (parallel plot). Deterministic metrics bit-identical
-  serial-vs-parallel. Phase B is also where the not-yet-ported cross-recording
-  node-cartography boundary clustering (pooled PC/Z density landscape → basins,
-  `TrialLandscapeDensity.m`/`findBasinsOfAttraction.m`) will live.
+  serial-vs-parallel. Phase B is also where the cross-recording node-cartography
+  boundary clustering runs (`_apply_cartography_boundaries` →
+  `network_metrics.trial_landscape_density`, port of `TrialLandscapeDensity.m`'s
+  default `kmeans` branch — see the node-cartography note below).
 
 Caveats: measured on a shared 16-core box where step-4 *process*-parallelism
 scales poorly (memory-bandwidth/BLAS contention → only ~1.1-1.4x across

--- a/python/test_pipeline_catnap.py
+++ b/python/test_pipeline_catnap.py
@@ -1,0 +1,465 @@
+"""Test CAT-NAP (suite2p calcium imaging) parity with MATLAB.
+
+Run from the repo root::
+
+    uv run python python/test_pipeline_catnap.py
+
+Ground truth comes from a complete MATLAB CAT-NAP run kept in the gitignored
+``local/`` folder (see ``python/CATNAP_PORT_PLAN.md``). Because that data is not
+committed, this test **skips gracefully** when the dataset is absent — so it is
+a no-op in CI and a real parity check on a dev machine that has the folder.
+
+Both ground-truth ``.mat`` files are MATLAB v7 (not v7.3/HDF5), so they load
+with ``scipy.io.loadmat`` — no ``h5py``, no MATLAB needed.
+
+Phase 0 (this file today) validates the *parity contract*: that the dataset is
+present, loadable, and carries every field the port will be checked against,
+with the expected shapes. Numeric assertions for each port phase are added as
+that phase lands:
+
+  - Phase 3 → ``activityStats`` (calTwopActivityStats), exact
+  - Phase 2 → ``adjMs`` (suite2pToAdjm), within prob-threshold tolerance;
+              ``coords`` / ``activityProperties`` exact
+  - Phase 4 → ``NetMet`` end-to-end, within tolerance
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import scipy.io as sio
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+# ── Ground-truth dataset (gitignored; may be absent) ──────────────────────────
+DATASET_DIR = REPO_ROOT / "local" / "example2pdataWCellTypes"
+RECORDING = "OPME230825_1_20230915_P1_pup4A_Het_MOI50000_DIV21"
+SUITE2P_DIR = DATASET_DIR / RECORDING / "suite2p" / "plane0"
+CELLTYPE_CSV = DATASET_DIR / RECORDING / (
+    f"PutativeCellType_{RECORDING}_PositiveOnly.csv"
+)
+EXPDATA_MAT = (
+    DATASET_DIR / "OutputData22May2026" / "ExperimentMatFiles"
+    / f"{RECORDING}_OutputData22May2026.mat"
+)
+NETMET_MAT = (
+    DATASET_DIR / "OutputData22May2026-step-4" / "ExperimentMatFiles"
+    / f"{RECORDING}_OutputData22May2026-step-4.mat"
+)
+
+# Expected run configuration, from the mat's Params — see CATNAP_PORT_PLAN.md.
+EXPECTED_LAGS_MS = [1000, 2500, 5000]
+EXPECTED_N_NODES = 253          # after iscell + removeNodesWithNoPeaks filtering
+EXPECTED_N_FRAMES = 20000
+
+# activityStats (calTwopActivityStats) — every field the Phase 3 port must produce.
+ACTIVITY_STATS_FIELDS = [
+    "FR", "FRactive", "FRmean", "FRstd", "FRsem", "FRmedian", "FRiqr",
+    "numActiveElec", "ISImean", "ISI",
+    "unitHeightMean", "unitPeakDurMean", "unitEventAreaMean", "unitEventAreaSum",
+    "recHeightMean", "recPeakDurMean", "recEventAreaMean",
+]
+ACTIVITY_PROPERTIES_FIELDS = [
+    "cellsWithPeaks", "peakDurationFrames", "peakHeights", "eventAreas",
+]
+
+
+def dataset_available() -> bool:
+    return EXPDATA_MAT.exists() and NETMET_MAT.exists() and SUITE2P_DIR.exists()
+
+
+def _load_mat(path: Path):
+    return sio.loadmat(path, struct_as_record=False, squeeze_me=True)
+
+
+def _extract_spike_times(st_array) -> list[np.ndarray]:
+    """MATLAB ``spikeTimes{u}.peak`` cell array → list of 1-D float arrays."""
+    out = []
+    for u in range(np.size(st_array)):
+        peak = getattr(st_array[u], "peak", np.array([]))
+        out.append(np.atleast_1d(np.asarray(peak, dtype=float)).ravel())
+    return out
+
+
+def _phase3_activity_stats_checks(exp) -> list[tuple[str, bool, str]]:
+    """Phase 3 numeric parity: our calc_twop_activity_stats vs MATLAB activityStats."""
+    from meanap.catnap.stats import calc_twop_activity_stats
+
+    P = exp["Params"]
+    ap = exp["activityProperties"]
+    got = calc_twop_activity_stats(
+        twop_activity=str(P.twopActivity),
+        duration_s=float(exp["Info"].duration_s),
+        fs=float(exp["fs"]),
+        min_activity_level=float(P.minActivityLevel),
+        spike_times=_extract_spike_times(exp["spikeTimes"]),
+        peak_heights=np.asarray(ap.peakHeights, dtype=float),
+        peak_duration_frames=np.asarray(ap.peakDurationFrames, dtype=float),
+        event_areas=np.asarray(ap.eventAreas, dtype=float),
+    )
+
+    ref = exp["activityStats"]
+    # field → absolute tolerance. Rounded scalars are exact; arrays 1e-6.
+    tol = {
+        "FR": 1e-6, "FRactive": 1e-6, "ISI": 1e-6,
+        "unitHeightMean": 1e-6, "unitPeakDurMean": 1e-6,
+        "unitEventAreaMean": 1e-6, "unitEventAreaSum": 1e-6,
+        "FRmean": 1e-9, "FRstd": 1e-9, "FRsem": 1e-9,
+        "FRmedian": 1e-9, "FRiqr": 1e-9, "numActiveElec": 0.0,
+        "ISImean": 1e-6, "recHeightMean": 1e-6,
+        "recPeakDurMean": 1e-6, "recEventAreaMean": 1e-6,
+    }
+    results = []
+    for field, atol in tol.items():
+        py = np.asarray(got[field], dtype=float)
+        ml = np.asarray(getattr(ref, field), dtype=float)
+        ok = np.allclose(py, ml, atol=atol, equal_nan=True) and py.shape == ml.shape
+        detail = ""
+        if not ok:
+            if py.shape != ml.shape:
+                detail = f"shape py{py.shape} vs ml{ml.shape}"
+            else:
+                detail = f"max|diff|={np.nanmax(np.abs(py - ml)):.3e}"
+        results.append((f"activityStats.{field}", ok, detail))
+    return results
+
+
+def _phase3_cell_type_checks(exp) -> list[tuple[str, bool, str]]:
+    """Phase 3: get_cell_type_matrix logic against the PositiveOnly CSV.
+
+    No MATLAB cellTypeMatrix is saved in the mat (Info.CellTypes is an opaque
+    MCOS table), so we verify the invariant independently: each cell type's
+    column sum must equal the count of its (0-indexed CSV id + 1) values that
+    land in ``channels``, and every marked entry sits on the right row.
+    """
+    import pandas as pd
+    from meanap.catnap.stats import get_cell_type_matrix
+
+    df = pd.read_csv(CELLTYPE_CSV)
+    cell_type_ids = {c: df[c].to_numpy(dtype=float) for c in df.columns}
+    channels = np.asarray(exp["channels"]).ravel().astype(int)
+    chan_set = set(channels.tolist())
+
+    matrix, names = get_cell_type_matrix(cell_type_ids, channels)
+    results = []
+
+    results.append(("cellTypeMatrix shape (n_chan, n_types)",
+                    matrix.shape == (channels.size, len(df.columns)),
+                    f"got {matrix.shape}"))
+    results.append(("cellTypeMatrix names match CSV columns",
+                    names == list(df.columns), f"got {names}"))
+
+    for col, name in enumerate(df.columns):
+        ids = df[name].to_numpy(dtype=float)
+        ids = (ids[~np.isnan(ids)].astype(int) + 1)  # 0-idx CSV → 1-idx ROI
+        expected = len({r for r in ids if r in chan_set})
+        got = int(matrix[:, col].sum())
+        results.append((f"cellType[{name}] count={expected}",
+                        got == expected, f"got {got}"))
+    return results
+
+
+def _phase2_adjm_checks(exp) -> list[tuple[str, bool, str]]:
+    """Phase 2 parity: suite2p_to_adjm vs MATLAB suite2pToAdjm.
+
+    Deterministic outputs (coords, channels, spike_times, activity_properties)
+    are checked exactly. The peaks adjacency is RNG-thresholded, so we can't
+    match MATLAB's stored ``adjMci`` bit-for-bit — but thresholding only ever
+    *zeroes* edges, so every **nonzero** entry of MATLAB's matrix must equal the
+    deterministic raw STTC. We recompute raw STTC (``get_sttc``) on the recovered
+    peak times and check exactly on that surviving-edge mask.
+    """
+    from meanap.catnap.loader import load_suite2p
+    from meanap.catnap.adjacency import suite2p_to_adjm
+    from meanap.pipeline.sttc import get_sttc
+
+    P = exp["Params"]
+    lags = list(np.ravel(np.asarray(P.FuncConLagval)).astype(int))
+
+    data = load_suite2p(SUITE2P_DIR)
+    # rep_num=2 keeps this fast: the deterministic outputs we compare here don't
+    # depend on it, and we recompute raw STTC separately below for the adjacency.
+    res = suite2p_to_adjm(
+        data, "peaks", [lags[0]],
+        remove_nodes_with_no_peaks=bool(P.removeNodesWithNoPeaks),
+        prob_thresh_tail=float(P.ProbThreshTail),
+        prob_thresh_rep_num=2,
+        rng=np.random.default_rng(0),
+    )
+    results = []
+
+    # ── coords / channels (exact) ─────────────────────────────────────────────
+    ml_coords = np.asarray(exp["coords"], dtype=float)
+    results.append(("coords match (exact)",
+                    res.coords.shape == ml_coords.shape
+                    and np.allclose(res.coords, ml_coords, atol=1e-6),
+                    f"py{res.coords.shape} vs ml{ml_coords.shape}"))
+    ml_channels = np.asarray(exp["channels"]).ravel().astype(int)
+    results.append(("channels match (exact)",
+                    res.channels.shape == ml_channels.shape
+                    and np.array_equal(res.channels, ml_channels),
+                    f"py{res.channels.shape} vs ml{ml_channels.shape}"))
+
+    # ── activityProperties (exact) ────────────────────────────────────────────
+    ap = exp["activityProperties"]
+    for pykey, mlkey in [("peakHeights", "peakHeights"),
+                         ("peakDurationFrames", "peakDurationFrames"),
+                         ("eventAreas", "eventAreas")]:
+        py = np.asarray(res.activity_properties[pykey], dtype=float)
+        ml = np.asarray(getattr(ap, mlkey), dtype=float)
+        ok = py.shape == ml.shape and np.allclose(py, ml, atol=1e-6, equal_nan=True)
+        results.append((f"activityProperties.{pykey} (exact)", ok,
+                        f"py{py.shape} vs ml{ml.shape}"))
+    ml_cwp = np.asarray(getattr(ap, "cellsWithPeaks")).ravel().astype(int)
+    results.append(("activityProperties.cellsWithPeaks (exact)",
+                    np.array_equal(res.activity_properties["cellsWithPeaks"], ml_cwp),
+                    ""))
+
+    # ── spikeTimes (exact) ────────────────────────────────────────────────────
+    ml_st = _extract_spike_times(exp["spikeTimes"])
+    st_ok = len(res.spike_times) == len(ml_st) and all(
+        py.shape == ml.shape and np.allclose(py, ml, atol=1e-6)
+        for py, ml in zip(res.spike_times, ml_st)
+    )
+    results.append((f"spikeTimes match all {len(ml_st)} units (exact)", st_ok, ""))
+
+    # ── adjMs: raw STTC on surviving (nonzero) edges (exact) ───────────────────
+    n = len(res.spike_times)
+    st_dict = {u: res.spike_times[u] for u in range(n)}
+    duration_s = res.F.shape[0] / res.fs
+    adjMs = exp["adjMs"]
+    for lag in lags:
+        ml_adj = np.asarray(getattr(adjMs, f"adjM{lag}mslag"), dtype=float)
+        raw = get_sttc(st_dict, n, lag, duration_s)
+        mask = np.isfinite(ml_adj) & (ml_adj != 0.0)
+        n_edges = int(mask.sum())
+        ok = n_edges > 0 and np.allclose(raw[mask], ml_adj[mask], atol=1e-6)
+        detail = ""
+        if not ok and n_edges:
+            detail = f"max|diff|={np.nanmax(np.abs(raw[mask] - ml_adj[mask])):.3e}"
+        results.append((f"adjM{lag}mslag STTC on {n_edges} surviving edges (exact)",
+                        ok, detail))
+    return results
+
+
+def _phase4_netmet_checks(exp, net) -> list[tuple[str, bool, str]]:
+    """Phase 4 parity: shared step-4 compute_network_metrics on the CAT-NAP
+    adjacency vs MATLAB's stored NetMet.
+
+    Same isolation strategy as test_pipeline_step4.py: feed the MATLAB stored
+    (thresholded) adjMs — not Python's own RNG-thresholded ones — so we test the
+    step-4 arithmetic on the CAT-NAP handoff (spike_counts from peak counts,
+    duration, active-node inclusion), not the stochastic thresholding. Only
+    deterministic NetMet fields are compared (CC/PL are null-model normalized).
+    """
+    from meanap.pipeline.step4 import compute_network_metrics
+
+    # Everything here must come from the SAME mat as NetMet (the step-4 mat):
+    # its adjMs and spikeTimes are that run's own RNG realization, and NetMet was
+    # computed from them. (The full-run mat has different RNG-thresholded adjMs.)
+    P = net["Params"]
+    lags = list(np.ravel(np.asarray(P.FuncConLagval)).astype(int))
+    duration_s = float(net["Info"].duration_s)
+    min_activity = float(P.minActivityLevel)
+    exclude_edges = bool(P.excludeEdgesBelowThreshold)
+
+    spike_counts = np.array([np.size(st) for st in _extract_spike_times(net["spikeTimes"])],
+                            dtype=float)
+    adjMs = net["adjMs"]
+    netmet = net["NetMet"]
+
+    # (field, tolerance) — deterministic metrics only.
+    scalar_fields = [("aN", 0.0), ("Dens", 1e-6), ("Eglob", 1e-6),
+                     ("NDmean", 1e-4), ("NSmean", 1e-4), ("ElocMean", 1e-5),
+                     ("sigEdgesMean", 1e-5)]
+    array_fields = [("ND", 1e-6), ("NS", 1e-6), ("MEW", 1e-6),
+                    ("Eloc", 1e-5), ("BC", 1e-4)]
+
+    results = []
+    for lag in lags:
+        ml = getattr(netmet, f"adjM{lag}mslag")
+        ml_aN = int(np.ravel(ml.aN)[0])
+        adj = np.asarray(getattr(adjMs, f"adjM{lag}mslag"), dtype=float)
+        # min_nodes = ml_aN so metrics compute but the slow, stochastic
+        # small-worldness block (gated on a_n > min_nodes) is skipped.
+        got = compute_network_metrics(
+            adj, spike_counts, duration_s, min_activity, ml_aN,
+            exclude_edges_below_threshold=exclude_edges, params=None,
+        )
+        ok_aN = int(got.get("aN", -1)) == ml_aN
+        results.append((f"[{lag}ms] aN == {ml_aN}", ok_aN,
+                        f"got {got.get('aN')}"))
+        if not ok_aN:
+            continue  # arrays won't align; other checks meaningless
+        for field, atol in scalar_fields:
+            if field == "aN":
+                continue
+            py = float(np.ravel(np.asarray(got.get(field, np.nan)))[0])
+            mlv = float(np.ravel(np.asarray(getattr(ml, field)))[0])
+            ok = np.allclose(py, mlv, atol=atol, equal_nan=True)
+            results.append((f"[{lag}ms] {field}", ok,
+                            "" if ok else f"py={py:.6g} ml={mlv:.6g}"))
+        for field, atol in array_fields:
+            py = np.asarray(got.get(field), dtype=float)
+            mlv = np.asarray(getattr(ml, field), dtype=float)
+            ok = py.shape == mlv.shape and np.allclose(py, mlv, atol=atol, equal_nan=True)
+            results.append((f"[{lag}ms] {field}", ok,
+                            "" if ok else (f"shape py{py.shape} ml{mlv.shape}"
+                                           if py.shape != mlv.shape
+                                           else f"max|diff|={np.nanmax(np.abs(py-mlv)):.2e}")))
+    return results
+
+
+def main() -> int:
+    print("=" * 70)
+    print("MEA-NAP Python  ▸  CAT-NAP (suite2p) Parity Test")
+    print("=" * 70)
+
+    if not dataset_available():
+        print("\n  ! CAT-NAP ground-truth dataset not found under")
+        print(f"    {DATASET_DIR}")
+        print("    (this data is gitignored — see python/CATNAP_PORT_PLAN.md)")
+        print("\n  → SKIPPED (no dataset). This is expected in CI.")
+        return 0
+
+    checks: list[tuple[str, bool, str]] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        checks.append((name, bool(ok), detail))
+
+    # ── Load ground truth ─────────────────────────────────────────────────────
+    exp = _load_mat(EXPDATA_MAT)
+    net = _load_mat(NETMET_MAT)
+
+    # ── Config sanity ─────────────────────────────────────────────────────────
+    P = exp["Params"]
+    check("suite2pMode == 1", int(P.suite2pMode) == 1, f"got {P.suite2pMode}")
+    check("twopActivity == 'peaks'", str(P.twopActivity) == "peaks",
+          f"got {P.twopActivity!r}")
+    lags = list(np.ravel(np.asarray(P.FuncConLagval)).astype(int))
+    check(f"FuncConLagval == {EXPECTED_LAGS_MS}", lags == EXPECTED_LAGS_MS,
+          f"got {lags}")
+
+    # ── adjMs: Phase 2 target ─────────────────────────────────────────────────
+    adjMs = exp["adjMs"]
+    for lag in EXPECTED_LAGS_MS:
+        field = f"adjM{lag}mslag"
+        has = field in adjMs._fieldnames
+        check(f"adjMs.{field} present", has)
+        if has:
+            A = np.asarray(getattr(adjMs, field))
+            check(f"adjMs.{field} shape {EXPECTED_N_NODES}²",
+                  A.shape == (EXPECTED_N_NODES, EXPECTED_N_NODES),
+                  f"got {A.shape}")
+
+    # ── coords / channels / traces: Phase 2 targets ───────────────────────────
+    coords = np.asarray(exp["coords"])
+    check(f"coords shape ({EXPECTED_N_NODES}, 2)",
+          coords.shape == (EXPECTED_N_NODES, 2), f"got {coords.shape}")
+    check("coords normalized to [0, 8]",
+          coords.min() >= -1e-9 and coords.max() <= 8 + 1e-6,
+          f"range [{coords.min():.3f}, {coords.max():.3f}]")
+    check(f"channels length {EXPECTED_N_NODES}",
+          np.size(exp["channels"]) == EXPECTED_N_NODES)
+    for name in ("F", "denoisedF", "spks"):
+        arr = np.asarray(exp[name])
+        check(f"{name} shape ({EXPECTED_N_FRAMES}, {EXPECTED_N_NODES})",
+              arr.shape == (EXPECTED_N_FRAMES, EXPECTED_N_NODES),
+              f"got {arr.shape}")
+
+    # ── spikeTimes: cell array of structs with .peak (seconds) ────────────────
+    st = exp["spikeTimes"]
+    check(f"spikeTimes length {EXPECTED_N_NODES}",
+          np.size(st) == EXPECTED_N_NODES, f"got {np.size(st)}")
+    check("spikeTimes[0] has .peak field",
+          "peak" in getattr(st[0], "_fieldnames", []))
+
+    # ── activityProperties: Phase 2 target ────────────────────────────────────
+    ap = exp["activityProperties"]
+    for f in ACTIVITY_PROPERTIES_FIELDS:
+        check(f"activityProperties.{f} present", f in ap._fieldnames)
+
+    # ── activityStats: Phase 3 target ─────────────────────────────────────────
+    stats = exp["activityStats"]
+    for f in ACTIVITY_STATS_FIELDS:
+        check(f"activityStats.{f} present", f in stats._fieldnames)
+
+    # ── NetMet: Phase 4 target (shared step 4) ────────────────────────────────
+    netmet = net["NetMet"]
+    for lag in EXPECTED_LAGS_MS:
+        check(f"NetMet.adjM{lag}mslag present",
+              f"adjM{lag}mslag" in netmet._fieldnames)
+
+    # ── Cell types CSV present (Phase 3 getCellTypeMatrix) ────────────────────
+    check("cell-type CSV present", CELLTYPE_CSV.exists(),
+          str(CELLTYPE_CSV.relative_to(REPO_ROOT)))
+
+    # ── Report: parity contract ───────────────────────────────────────────────
+    print(f"\nDataset: {DATASET_DIR.relative_to(REPO_ROOT)}")
+    print(f"Recording: {RECORDING}\n")
+    print("Parity contract (dataset fields & shapes):")
+    n_pass = sum(ok for _, ok, _ in checks)
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+    print(f"  → {n_pass}/{len(checks)} passed")
+
+    # ── Phase 3: activityStats numeric parity ─────────────────────────────────
+    print("\nPhase 3 — calTwopActivityStats numeric parity:")
+    phase3 = _phase3_activity_stats_checks(exp)
+    p3_pass = sum(ok for _, ok, _ in phase3)
+    for name, ok, detail in phase3:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+    print(f"  → {p3_pass}/{len(phase3)} passed")
+
+    # ── Phase 3: getCellTypeMatrix logic ──────────────────────────────────────
+    print("\nPhase 3 — getCellTypeMatrix logic:")
+    phase3ct = _phase3_cell_type_checks(exp)
+    p3ct_pass = sum(ok for _, ok, _ in phase3ct)
+    for name, ok, detail in phase3ct:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+    print(f"  → {p3ct_pass}/{len(phase3ct)} passed")
+
+    # ── Phase 2: suite2p_to_adjm parity ───────────────────────────────────────
+    print("\nPhase 2 — suite2pToAdjm parity (deterministic outputs + raw STTC):")
+    phase2 = _phase2_adjm_checks(exp)
+    p2_pass = sum(ok for _, ok, _ in phase2)
+    for name, ok, detail in phase2:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+    print(f"  → {p2_pass}/{len(phase2)} passed")
+
+    # ── Phase 4: NetMet parity (shared step 4 on CAT-NAP handoff) ─────────────
+    print("\nPhase 4 — NetMet parity (compute_network_metrics on MATLAB adjMs):")
+    phase4 = _phase4_netmet_checks(exp, net)
+    p4_pass = sum(ok for _, ok, _ in phase4)
+    for name, ok, detail in phase4:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+    print(f"  → {p4_pass}/{len(phase4)} passed")
+
+    total_pass = n_pass + p3_pass + p3ct_pass + p2_pass + p4_pass
+    total = len(checks) + len(phase3) + len(phase3ct) + len(phase2) + len(phase4)
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    if total_pass == total:
+        print("  → CAT-NAP contract + Phase 3 (activityStats) match MATLAB.")
+    else:
+        print("  → FAILURES above — see details.")
+    print("=" * 70)
+
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_pipeline_landscape.py
+++ b/python/test_pipeline_landscape.py
@@ -1,0 +1,115 @@
+"""Tests for data-driven node-cartography boundaries (TrialLandscapeDensity port).
+
+Run from the repo root::
+
+    uv run python python/test_pipeline_landscape.py
+
+Covers ``network_metrics._optimal_1d_split_boundaries`` (deterministic optimal
+1-D k-means) and ``network_metrics.trial_landscape_density`` (port of
+``TrialLandscapeDensity.m``, ``boundarySelectionMethod='kmeans'`` branch).
+
+The headline behaviour under test is the bug this port fixes: with the *fixed*
+default boundaries (``peri_part_coef=0.625`` …) almost every node's PC falls
+below the peripheral cutoff, so ~95% of nodes get dumped into cartography
+role 1 (NCpn1). Deriving the boundaries from the data spreads nodes across all
+six roles instead — matching MATLAB's real output shape. We assert exactly
+that regression using the in-repo cartography fixtures (MATLAB-generated PC/Z).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from meanap.pipeline import network_metrics as nm  # noqa: E402
+
+FIX = Path(__file__).resolve().parent / "test_fixtures"
+_checks = 0
+_fails = 0
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    global _checks, _fails
+    _checks += 1
+    _fails += 0 if ok else 1
+    print(f"    {'✓' if ok else '✗'} {name}{'  ' + detail if detail else ''}")
+
+
+def test_optimal_1d_split() -> None:
+    print("[1] _optimal_1d_split_boundaries — synthetic, known answer")
+    # three tight clusters around 0, 5, 10 → boundaries near 2.5 and 7.5
+    rng = np.random.default_rng(0)
+    x = np.concatenate([rng.normal(0, 0.1, 20), rng.normal(5, 0.1, 20), rng.normal(10, 0.1, 20)])
+    b = nm._optimal_1d_split_boundaries(x, 3)
+    check("returns k-1 boundaries", b is not None and len(b) == 2)
+    check("boundaries sorted & between clusters", 2.0 < b[0] < 3.0 and 7.0 < b[1] < 8.0,
+          f"got {b}")
+    # determinism: identical on repeat (no RNG in the DP)
+    b2 = nm._optimal_1d_split_boundaries(x, 3)
+    check("deterministic across calls", np.allclose(b, b2))
+    # k=2 split of a two-cluster set
+    y = np.concatenate([np.zeros(5), np.full(5, 10.0)])
+    b3 = nm._optimal_1d_split_boundaries(y, 2)
+    check("k=2 midpoint correct", b3 is not None and abs(b3[0] - 5.0) < 1e-9, f"got {b3}")
+    # insufficient distinct values → None (caller falls back to defaults)
+    check("fewer than k distinct → None", nm._optimal_1d_split_boundaries(np.ones(10), 3) is None)
+    check("too few points → None", nm._optimal_1d_split_boundaries(np.array([1.0]), 2) is None)
+
+
+def test_trial_landscape_density() -> None:
+    print("\n[2] trial_landscape_density — fixture PC/Z, boundary ordering")
+    defaults = (2.5, 0.625, 0.3, 0.8, 0.75)  # hub, peri, prohub, nonhub, connhub
+    for rec in ("NGN2_20230208_P1_DIV14_A2", "NGN2_20230208_P1_DIV14_A3"):
+        f = np.load(FIX / f"{rec}_cartography_reference.npz")
+        for lag in (10, 25, 50):
+            pc = f[f"lag{lag}_PCnorm"].astype(float)
+            z = f[f"lag{lag}_Z"].astype(float)
+            b = nm.trial_landscape_density(pc, z, *defaults)
+            check(f"{rec[-2:]} lag{lag}: returns 5 boundaries", b is not None and len(b) == 5)
+            hub_b, peri, non_hub_conn, pro_hub, conn_hub = b
+            check(f"{rec[-2:]} lag{lag}: non-hub PC boundaries ordered", peri <= non_hub_conn,
+                  f"peri={peri:.3f} nonHubConn={non_hub_conn:.3f}")
+            check(f"{rec[-2:]} lag{lag}: hub PC boundaries ordered", pro_hub <= conn_hub,
+                  f"proHub={pro_hub:.3f} connHub={conn_hub:.3f}")
+            check(f"{rec[-2:]} lag{lag}: PC boundaries within [0,1]",
+                  all(0.0 <= v <= 1.0 for v in (peri, non_hub_conn, pro_hub, conn_hub)))
+
+
+def test_fixes_role1_pileup() -> None:
+    print("\n[3] regression: data-driven boundaries fix the NCpn1 pile-up")
+    defaults = (2.5, 0.625, 0.3, 0.8, 0.75)
+    for rec in ("NGN2_20230208_P1_DIV14_A2", "NGN2_20230208_P1_DIV14_A3"):
+        f = np.load(FIX / f"{rec}_cartography_reference.npz")
+        for lag in (10, 25, 50):
+            pc = f[f"lag{lag}_PCnorm"].astype(float)
+            z = f[f"lag{lag}_Z"].astype(float)
+            n = len(pc)
+
+            _, pop_fixed = nm.classify_node_cartography(
+                pc, z, defaults[0], defaults[1], defaults[3], defaults[2], defaults[4])
+            frac1_fixed = pop_fixed[0] / n
+
+            hub_b, peri, non_hub_conn, pro_hub, conn_hub = nm.trial_landscape_density(pc, z, *defaults)
+            _, pop_auto = nm.classify_node_cartography(pc, z, hub_b, peri, non_hub_conn, pro_hub, conn_hub)
+            frac1_auto = pop_auto[0] / n
+            roles_used = int(np.sum(pop_auto > 0))
+
+            check(f"{rec[-2:]} lag{lag}: fixed defaults pile into role 1", frac1_fixed >= 0.5,
+                  f"NCpn1(fixed)={frac1_fixed:.2f}")
+            check(f"{rec[-2:]} lag{lag}: auto boundaries spread the pile out", frac1_auto < frac1_fixed,
+                  f"NCpn1 {frac1_fixed:.2f} → {frac1_auto:.2f}, {roles_used}/6 roles used")
+            check(f"{rec[-2:]} lag{lag}: all counts conserved", int(np.sum(pop_auto)) == n)
+
+
+if __name__ == "__main__":
+    test_optimal_1d_split()
+    test_trial_landscape_density()
+    test_fixes_role1_pileup()
+    print("\n" + "=" * 70)
+    print(f"Total checks: {_checks}   Failures: {_fails}")
+    print("=" * 70)
+    print("  → All checks passed" if _fails == 0 else f"  → {_fails} FAILED")
+    sys.exit(1 if _fails else 0)

--- a/src/meanap/catnap/adjacency.py
+++ b/src/meanap/catnap/adjacency.py
@@ -1,0 +1,193 @@
+"""CAT-NAP adjacency-matrix construction.
+
+Port of ``Functions/twoPhoton/suite2pToAdjm.m`` (everything after the denoising
+call — the loading/denoising itself lives in ``loader.py`` / ``denoising.py``).
+
+Takes a loaded :class:`~meanap.catnap.loader.Suite2pData` and produces the
+functional-connectivity adjacency matrices plus the node coordinates, channel
+list, per-unit activity matrices, peak spike times, and event properties that
+the rest of the pipeline consumes.
+
+Determinism: ``coords``, ``channels``, ``activity_properties``, ``spike_times``
+and the ``corr``-based adjacency (``F`` / ``spks`` / ``denoised F``) are exact.
+The ``peaks`` adjacency reuses :func:`meanap.pipeline.probabilistic_threshold.adjm_thr`
+(STTC + circular-shift thresholding), whose thresholding step is RNG-driven and
+therefore only reproducible against MATLAB within tolerance — see that module
+and ``python/test_pipeline_catnap.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from meanap.catnap.loader import Suite2pData
+from meanap.pipeline.probabilistic_threshold import adjm_thr
+
+
+@dataclass
+class Suite2pAdjmResult:
+    """Outputs of :func:`suite2p_to_adjm`, mirroring ``suite2pToAdjm.m``'s returns."""
+
+    adjMs: dict[str, np.ndarray]          # {'adjM{lag}mslag': (n, n)}
+    coords: np.ndarray                    # (n, 2), normalized to [0, 8]
+    channels: np.ndarray                  # (n,) 1-indexed ROI ids
+    F: np.ndarray                         # (n_frames, n) raw fluorescence
+    denoised_F: np.ndarray | None         # (n_frames, n) or None
+    spks: np.ndarray                      # (n_frames, n) suite2p spike prob
+    spike_times: list[np.ndarray] | None  # per-unit peak times (s); None unless 'peaks'
+    fs: float
+    activity_properties: dict             # peakDurationFrames/peakHeights/eventAreas/cellsWithPeaks
+    func_con_lag_val: list[int]           # lags actually used (single deriv. lag for corr paths)
+
+
+def _corr_columns(x: np.ndarray) -> np.ndarray:
+    """MATLAB ``corr(X)`` — Pearson correlation between the columns (units) of X."""
+    if x.shape[1] == 0:
+        return np.zeros((0, 0))
+    return np.corrcoef(x, rowvar=False)
+
+
+def suite2p_to_adjm(
+    data: Suite2pData,
+    twop_activity: str,
+    func_con_lag_val: list[int],
+    *,
+    remove_nodes_with_no_peaks: bool = False,
+    prob_thresh_tail: float = 0.05,
+    prob_thresh_rep_num: int = 200,
+    rng: np.random.Generator | None = None,
+) -> Suite2pAdjmResult:
+    """Port of ``suite2pToAdjm.m``.
+
+    Parameters
+    ----------
+    data
+        Loaded suite2p recording. For ``twop_activity`` in
+        ``{'peaks', 'denoised F', 'spks'}`` the denoising outputs
+        (``F_denoised``, ``peak_start_frames`` …) must already be present
+        (the runner ensures this by denoising first).
+    twop_activity
+        ``'peaks'`` | ``'F'`` | ``'spks'`` | ``'denoised F'``.
+    func_con_lag_val
+        STTC lags (ms) for the ``'peaks'`` path. Ignored by the ``corr`` paths,
+        which derive a single lag ``round(1000 / fs)`` from the frame rate.
+    """
+    fs = float(data.fs)
+    cell_mask = data.cell_mask  # iscell[:, 0] as bool, shape (n_rois,)
+
+    # ── iscell subset (MATLAB `... (iscell(:,1), :)'`) ────────────────────────
+    # Activity matrices are (n_frames, n_cells) to match MATLAB's transpose.
+    F_isc = data.F[cell_mask].T
+    spks_isc = data.spks[cell_mask].T
+
+    # 1-indexed ROI ids among the iscell units (MATLAB `channels(iscell)`).
+    channels = (np.arange(data.F.shape[0]) + 1)[cell_mask]
+
+    # Node coordinates from stat centroids (2, n_rois) → (n_cells, 2).
+    coords = data.xy_loc[:, cell_mask].T.astype(float)
+
+    denoised_isc: np.ndarray | None = None
+    peak_start_isc = peak_dur_isc = peak_height_isc = event_area_isc = None
+    needs_peaks = twop_activity in ("peaks", "denoised F", "spks")
+    if needs_peaks:
+        if data.F_denoised is None or data.peak_start_frames is None:
+            raise ValueError(
+                f"twop_activity={twop_activity!r} needs denoising outputs "
+                "(F_denoised / peak_start_frames …) — run denoising first."
+            )
+        denoised_isc = data.F_denoised[cell_mask].T
+        peak_start_isc = data.peak_start_frames[cell_mask]
+        peak_dur_isc = (data.peak_end_frames - data.peak_start_frames)[cell_mask]
+        peak_height_isc = data.peak_heights[cell_mask]
+        event_area_isc = data.event_areas[cell_mask]
+
+    # ── removeNodesWithNoPeaks: keep only cells with ≥1 detected peak ──────────
+    cells_with_peaks = None
+    if remove_nodes_with_no_peaks:
+        if peak_start_isc is None:
+            raise ValueError(
+                "remove_nodes_with_no_peaks requires the peaks/denoising outputs."
+            )
+        keep = ~np.all(np.isnan(peak_start_isc), axis=1)
+        cells_with_peaks = np.where(keep)[0] + 1  # MATLAB 1-indexed find()
+
+        F_isc = F_isc[:, keep]
+        spks_isc = spks_isc[:, keep]
+        if denoised_isc is not None:
+            denoised_isc = denoised_isc[:, keep]
+        peak_start_isc = peak_start_isc[keep]
+        peak_dur_isc = peak_dur_isc[keep]
+        peak_height_isc = peak_height_isc[keep]
+        event_area_isc = event_area_isc[keep]
+        channels = channels[keep]
+        coords = coords[keep]
+
+    activity_properties: dict = {
+        "peakDurationFrames": peak_dur_isc,
+        "peakHeights": peak_height_isc,
+        "eventAreas": event_area_isc,
+    }
+    if cells_with_peaks is not None:
+        activity_properties["cellsWithPeaks"] = cells_with_peaks
+
+    # ── Normalize coords to [0, 8] using the *full* XYloc range ────────────────
+    # (MATLAB uses max/min over all ROIs' XYloc, not just the kept subset.)
+    xy_all = data.xy_loc.astype(float)
+    min_xy, max_xy = float(xy_all.min()), float(xy_all.max())
+    coords = (coords - min_xy) / (max_xy - min_xy) * 8.0
+
+    # ── Adjacency ─────────────────────────────────────────────────────────────
+    adjMs: dict[str, np.ndarray] = {}
+    spike_times: list[np.ndarray] | None = None
+
+    if twop_activity in ("F", "spks", "denoised F"):
+        lag_val = round(1000.0 / fs)  # single derived lag
+        used_lags = [lag_val]
+        src = {"F": F_isc, "spks": spks_isc, "denoised F": denoised_isc}[twop_activity]
+        adjMs[f"adjM{lag_val}mslag"] = _corr_columns(src)
+
+    elif twop_activity == "peaks":
+        used_lags = list(func_con_lag_val)
+        time_points = (data.time_points if data.time_points is not None
+                       else np.arange(F_isc.shape[0]) / fs)
+        n_units = peak_start_isc.shape[0]
+
+        # Per-unit peak times (s): frame indices (0-indexed) → timePoints.
+        spike_times = []
+        for u in range(n_units):
+            frames = peak_start_isc[u]
+            frames = frames[~np.isnan(frames)].astype(int)
+            spike_times.append(time_points[frames] if frames.size else np.array([]))
+
+        spike_times_dict = {u: spike_times[u] for u in range(n_units)}
+        duration_s = F_isc.shape[0] / fs
+
+        if rng is None:
+            rng = np.random.default_rng()
+        for lag in used_lags:
+            if n_units >= 2:
+                _adj_raw, adj_ci = adjm_thr(
+                    spike_times_dict, n_units, lag, prob_thresh_tail, fs,
+                    duration_s, prob_thresh_rep_num, rng=rng,
+                )
+            else:
+                adj_ci = np.zeros((n_units, n_units))
+            adjMs[f"adjM{lag}mslag"] = adj_ci
+
+    else:
+        raise ValueError(f"Unknown twop_activity: {twop_activity!r}")
+
+    return Suite2pAdjmResult(
+        adjMs=adjMs,
+        coords=coords,
+        channels=channels,
+        F=F_isc,
+        denoised_F=denoised_isc,
+        spks=spks_isc,
+        spike_times=spike_times,
+        fs=fs,
+        activity_properties=activity_properties,
+        func_con_lag_val=used_lags,
+    )

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -1,0 +1,254 @@
+"""CAT-NAP pipeline orchestrator (``Params.suite2pMode == 1`` path).
+
+Mirrors the ``suite2pMode`` branches scattered through ``MEApipeline.m``: for
+each suite2p recording it denoises (if needed), builds the adjacency matrices +
+activity properties (:func:`~meanap.catnap.adjacency.suite2p_to_adjm`), computes
+the two-photon activity stats (:func:`~meanap.catnap.stats.calc_twop_activity_stats`),
+and then feeds the **shared** step-4 network-metric routine
+(:func:`meanap.pipeline.step4.compute_network_metrics`) — the calcium-imaging
+counterpart of running steps 1→4 on electrophysiology data.
+
+Network-plot generation (which needs the suite2p ``coords`` rather than an MEA
+channel layout) is deferred to a later phase; this orchestrator produces the
+metrics, JSON, and CSVs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+from meanap.params import Params
+from meanap.catnap.adjacency import suite2p_to_adjm
+from meanap.catnap.loader import load_suite2p
+from meanap.catnap.stats import calc_twop_activity_stats
+from meanap.pipeline.cancellation import CancelCheck, check_cancel
+from meanap.pipeline.spreadsheet import RecordingInfo
+from meanap.pipeline.step4 import compute_network_metrics, _convert_numpy, _NMF_NON_NODE_KEYS
+
+_NEEDS_DENOISING = ("peaks", "denoised F", "spks")
+
+
+def suite2p_plane0_dir(raw_data: str, filename: str) -> Path:
+    """Location of a recording's suite2p output (mirrors MEApipeline.m)."""
+    return Path(raw_data) / filename / "suite2p" / "plane0"
+
+
+def _spike_counts(res, twop_activity: str) -> np.ndarray:
+    """Per-node activity count used for the active-node inclusion test.
+
+    Peaks → number of detected peaks per unit (matches MATLAB's peak-count
+    firing rate); other activity types → column sum of the activity matrix
+    (``sum(expData.(twopActivity), 1)`` in ``calTwopActivityStats.m``).
+    """
+    if twop_activity == "peaks":
+        return np.array([np.size(st) for st in res.spike_times], dtype=float)
+    src = {"F": res.F, "spks": res.spks, "denoised F": res.denoised_F}[twop_activity]
+    return np.asarray(src, dtype=float).sum(axis=0)
+
+
+def _activity_stats_for(res, params: Params, duration_s: float) -> dict:
+    ap = res.activity_properties
+    kw = dict(
+        twop_activity=params.twop_activity,
+        duration_s=duration_s,
+        fs=res.fs,
+        min_activity_level=params.min_activity_level,
+    )
+    if params.twop_activity == "peaks":
+        kw.update(
+            spike_times=res.spike_times,
+            peak_heights=ap.get("peakHeights"),
+            peak_duration_frames=ap.get("peakDurationFrames"),
+            event_areas=ap.get("eventAreas"),
+        )
+    else:
+        src = {"F": res.F, "spks": res.spks, "denoised F": res.denoised_F}[params.twop_activity]
+        kw.update(activity_matrix=src)
+    return calc_twop_activity_stats(**kw)
+
+
+def run_catnap_pipeline(
+    params: Params,
+    recordings: list[RecordingInfo],
+    output_root: Path,
+    log: Callable[[str], None] = print,
+    should_cancel: CancelCheck = None,
+    rng: np.random.Generator | None = None,
+) -> None:
+    """Run the CAT-NAP path over all recordings, writing NetMet JSON + CSVs."""
+    from meanap.catnap.denoising import process_suite2p_folder
+
+    if rng is None:
+        rng = np.random.default_rng()
+
+    lag_values = params.func_con_lag_val
+    min_nodes = params.min_number_of_nodes_to_cal_net_met
+    net_dir = output_root / "4_NetworkActivity"
+    net_dir.mkdir(parents=True, exist_ok=True)
+
+    all_results: dict[str, dict] = {}
+    all_stats: dict[str, dict] = {}
+    all_coords: dict[str, np.ndarray] = {}
+    all_channels: dict[str, np.ndarray] = {}
+
+    for rec in recordings:
+        check_cancel(should_cancel)
+        plane0 = suite2p_plane0_dir(params.raw_data, rec.filename)
+        if not (plane0 / "stat.npy").exists():
+            log(f"  [{rec.filename}] SKIP: no suite2p output at {plane0}")
+            continue
+
+        log(f"  [{rec.filename}] loading suite2p data…")
+        data = load_suite2p(plane0)
+
+        if params.twop_activity in _NEEDS_DENOISING and (
+            data.F_denoised is None or params.twop_redo_denoising
+        ):
+            log(f"  [{rec.filename}] denoising ({data.F.shape[0]} ROIs)…")
+            process_suite2p_folder(
+                plane0,
+                overwrite=params.twop_redo_denoising,
+                denoising_threshold=params.twop_denoising_threshold,
+                time_before_peak_s=params.twop_denoising_time_before_peak,
+                time_after_peak_s=params.twop_denoising_time_after_peak,
+            )
+            data = load_suite2p(plane0)
+
+        log(f"  [{rec.filename}] building adjacency matrices…")
+        res = suite2p_to_adjm(
+            data, params.twop_activity, lag_values,
+            remove_nodes_with_no_peaks=params.remove_nodes_with_no_peaks,
+            prob_thresh_tail=params.prob_thresh_tail,
+            prob_thresh_rep_num=params.prob_thresh_rep_num,
+            rng=rng,
+        )
+        duration_s = res.F.shape[0] / res.fs
+        spike_counts = _spike_counts(res, params.twop_activity)
+
+        all_stats[rec.filename] = _activity_stats_for(res, params, duration_s)
+        all_coords[rec.filename] = res.coords
+        all_channels[rec.filename] = res.channels
+
+        rec_results: dict = {}
+        for lag_ms in lag_values:
+            key = f"adjM{lag_ms}mslag"
+            if key not in res.adjMs:
+                continue
+            log(f"  [{rec.filename}] network metrics (lag={lag_ms}ms)…")
+            metrics = compute_network_metrics(
+                res.adjMs[key], spike_counts, duration_s,
+                params.min_activity_level, min_nodes,
+                exclude_edges_below_threshold=params.exclude_edges_below_threshold,
+                params=params, rng=rng,
+            )
+            rec_results[f"{lag_ms}mslag"] = metrics
+        all_results[rec.filename] = rec_results
+
+        _plot_recording(params, rec, data, res, rec_results, output_root, log)
+
+    _save_catnap_results(recordings, all_results, all_stats, net_dir, log)
+    log("  CAT-NAP pipeline complete.")
+
+
+def _plot_recording(params, rec, data, res, rec_results, output_root, log) -> None:
+    """Per-unit trace figures + per-lag spatial network plots (Phase 5).
+
+    The network plot reuses the shared step-4 renderer via its
+    ``coords_override`` path, feeding suite2p cell centroids
+    (``res.coords``) instead of an MEA channel layout.
+    """
+    from meanap.catnap.plotting import plot_2p_traces
+    from meanap.pipeline.plotting_step4 import plot_spatial_network
+
+    try:
+        trace_dir = (output_root / "2_NeuronalActivity" / "2A_IndividualNeuronalAnalysis"
+                     / rec.group / rec.filename)
+        log(f"  [{rec.filename}] plotting 2P traces…")
+        plot_2p_traces(data, trace_dir, rec.filename, num_traces=params.num_2p_traces)
+    except Exception as e:
+        log(f"  [{rec.filename}] warning: 2P trace plots failed: {e}")
+
+    for lag_key, metrics in rec_results.items():
+        if "adjMsub" not in metrics:
+            continue
+        lag_ms = int(lag_key.replace("mslag", ""))
+        idx = metrics["activeChannelIndex"]
+        try:
+            plot_spatial_network(
+                metrics["adjMsub"], res.channels[idx], params.channel_layout,
+                metrics["ND"], None, "None", lag_ms, rec.filename,
+                (output_root / "4_NetworkActivity" / "4A_IndividualNetworkAnalysis"
+                 / rec.group / rec.filename / f"{lag_ms}mslag" / "2_MEA_NetworkPlot.png"),
+                z_name="node degree",
+                coords_override=res.coords[idx],
+            )
+        except Exception as e:
+            log(f"  [{rec.filename}] warning: network plot (lag={lag_ms}) failed: {e}")
+
+
+def _save_catnap_results(
+    recordings: list[RecordingInfo],
+    all_results: dict[str, dict],
+    all_stats: dict[str, dict],
+    net_dir: Path,
+    log: Callable[[str], None],
+) -> None:
+    """Write netmet_results.json + NetworkActivity CSVs (compact port of the
+    save block in ``step4._run_step4_network_metrics``)."""
+    try:
+        json_results = {
+            rec_name: {
+                lag: {k: v for k, v in metrics.items() if k != "adjMsub"}
+                for lag, metrics in rec_results.items()
+            }
+            for rec_name, rec_results in all_results.items()
+        }
+        with open(net_dir / "netmet_results.json", "w") as fh:
+            json.dump(_convert_numpy(json_results), fh, indent=2)
+
+        rec_rows, node_rows = [], []
+        for rec in recordings:
+            if rec.filename not in all_results:
+                continue
+            for lag, metrics in all_results[rec.filename].items():
+                base = {"FileName": rec.filename, "Grp": rec.group, "DIV": rec.div, "Lag": lag}
+                rec_row = dict(base)
+                node_metrics = {}
+                for k, v in metrics.items():
+                    if k == "adjMsub" or k in _NMF_NON_NODE_KEYS:
+                        continue
+                    is_array = isinstance(v, (list, np.ndarray))
+                    if not is_array or np.size(v) <= 1:
+                        rec_row[k] = v[0] if is_array and np.size(v) == 1 else v
+                    else:
+                        node_metrics[k] = v
+                rec_rows.append(rec_row)
+                if node_metrics:
+                    num_nodes = len(next(iter(node_metrics.values())))
+                    for ch in range(num_nodes):
+                        node_row = dict(base, Channel=ch + 1)
+                        for k, arr in node_metrics.items():
+                            if len(arr) == num_nodes:
+                                node_row[k] = arr[ch]
+                        node_rows.append(node_row)
+
+        if rec_rows:
+            pd.DataFrame(rec_rows).to_csv(net_dir / "NetworkActivity_RecordingLevel.csv", index=False)
+        if node_rows:
+            pd.DataFrame(node_rows).to_csv(net_dir / "NetworkActivity_NodeLevel.csv", index=False)
+
+        # Two-photon activity stats (step-2 equivalent).
+        stats_rows = [dict({"FileName": r.filename, "Grp": r.group, "DIV": r.div},
+                           **{k: v for k, v in all_stats[r.filename].items()
+                              if np.size(v) <= 1})
+                      for r in recordings if r.filename in all_stats]
+        if stats_rows:
+            pd.DataFrame(stats_rows).to_csv(net_dir.parent / "2_NeuronalActivity"
+                                            / "TwoPhotonActivity_RecordingLevel.csv", index=False)
+    except Exception as e:
+        log(f"  Warning: could not save CAT-NAP results: {e}")

--- a/src/meanap/catnap/plotting.py
+++ b/src/meanap/catnap/plotting.py
@@ -1,0 +1,98 @@
+"""CAT-NAP figures.
+
+Port of ``Functions/twoPhoton/plot2ptraces.m`` — the per-unit raw/denoised
+trace figures saved during a run (the interactive GUI preview in
+``gui/panels/catnap.py`` is separate). The spatial network plots reuse the
+shared step-4 renderer via its ``coords_override`` path (see
+``pipeline/plotting_step4.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from meanap.catnap.loader import Suite2pData
+
+
+def plot_2p_traces(
+    data: Suite2pData,
+    out_dir: Path,
+    recording_name: str,
+    num_traces: int | str = 20,
+) -> list[Path]:
+    """Save a 3-panel raw/denoised trace figure per unit (``plot2ptraces.m``).
+
+    Panels: (1) raw F, (2) min-max-scaled F over the denoised trace, (3) the
+    denoised trace with detected event-start markers. Operates on the labelled
+    (``iscell``) ROIs using their **original** 1-indexed ROI numbers, matching
+    MATLAB's ``unit_<roi>_2ptraces`` naming — i.e. before any
+    ``removeNodesWithNoPeaks`` subsetting.
+
+    ``num_traces`` is ``'all'`` or an integer count. Unlike MATLAB (which
+    ``randsample``s), we take the first ``num_traces`` labelled ROIs so the
+    output is deterministic/reproducible.
+    """
+    if data.F_denoised is None or data.peak_start_frames is None:
+        return []
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fs = float(data.fs)
+    n_frames = data.F.shape[1]
+    t = (np.arange(n_frames) + 1) / fs
+    duration_s = t[-1]
+
+    iscell_rois = np.nonzero(data.cell_mask)[0]  # 0-indexed ROI ids
+    if isinstance(num_traces, str):
+        selected = iscell_rois if num_traces == "all" else iscell_rois
+    else:
+        selected = iscell_rois[: max(0, int(num_traces))]
+
+    saved: list[Path] = []
+    for roi in selected:
+        f_cell = data.F[roi]
+        den_cell = data.F_denoised[roi]
+        peak_frames = data.peak_start_frames[roi]
+        peak_frames = peak_frames[~np.isnan(peak_frames)].astype(int)
+
+        fig, axes = plt.subplots(3, 1, figsize=(7, 5.5), sharex=True)
+
+        # 1: raw fluorescence
+        axes[0].plot(t, f_cell, color="k", lw=1.5, label="Original")
+        axes[0].set_title(f"{recording_name}  cell {roi + 1}", fontsize=9)
+        axes[0].set_ylabel("Fluorescence")
+
+        # 2: min-max-scaled raw over the denoised trace
+        rng = f_cell.max() - f_cell.min()
+        f_scaled = ((f_cell - f_cell.min()) / rng * den_cell.max()
+                    if rng > 0 else np.zeros_like(f_cell))
+        axes[1].plot(t, f_scaled, color="k", lw=1.5, label="Scaled")
+        axes[1].plot(t, den_cell, color="r", lw=1.5, label="Denoised")
+        axes[1].set_ylabel("Arbitrary units")
+
+        # 3: denoised trace + event-start markers
+        axes[2].plot(t, den_cell, color="r", lw=1.5, label="Denoised")
+        if peak_frames.size:
+            axes[2].scatter((peak_frames + 1) / fs, den_cell[peak_frames],
+                            marker="x", color="b", zorder=5, label="Event start")
+        axes[2].set_ylabel("Arbitrary units")
+        axes[2].set_xlabel("Time (s)")
+
+        for ax in axes:
+            ax.set_xlim(0, duration_s)
+            ax.spines[["top", "right"]].set_visible(False)
+            ax.tick_params(direction="out")
+            ax.legend(loc="upper right", fontsize=7, frameon=False)
+
+        fig.tight_layout()
+        out_path = out_dir / f"unit_{roi + 1}_2ptraces.png"
+        fig.savefig(out_path, dpi=120)
+        plt.close(fig)
+        saved.append(out_path)
+
+    return saved

--- a/src/meanap/catnap/stats.py
+++ b/src/meanap/catnap/stats.py
@@ -1,0 +1,199 @@
+"""CAT-NAP activity statistics.
+
+Ports:
+  - ``calTwopActivityStats.m`` → :func:`calc_twop_activity_stats`
+  - ``getCellTypeMatrix.m``    → :func:`get_cell_type_matrix`
+
+The stats are the calcium-imaging counterpart of the electrophysiology
+``Ephys`` struct (see ``pipeline/step2.py``); they are returned as a dict keyed
+by the same MATLAB field names, so downstream CSV writing lines up with the
+ephys path. Everything here is deterministic — exact parity with MATLAB is
+expected (see ``python/test_pipeline_catnap.py``).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+
+def _round3(x: float) -> float:
+    """MATLAB ``round(x, 3)`` — round half **away from zero** (not banker's).
+
+    numpy's ``round`` uses round-half-to-even, which can disagree with MATLAB
+    at exact 0.0005 ties; MATLAB rounds halves away from zero.
+    """
+    if not np.isfinite(x):
+        return float(x)
+    factor = 1000.0
+    return float(np.sign(x) * np.floor(np.abs(x) * factor + 0.5) / factor)
+
+
+def _iqr(x: np.ndarray) -> float:
+    """MATLAB ``iqr`` = Q3 − Q1 using MATLAB's quantile convention.
+
+    MATLAB's ``quantile`` places the sorted samples at plotting positions
+    ``(i - 0.5) / n`` and linearly interpolates (clamping at the extremes) —
+    equivalent to numpy's ``method="hazen"``.
+    """
+    x = np.asarray(x, dtype=float)
+    x = x[~np.isnan(x)]
+    if x.size == 0:
+        return float("nan")
+    q1, q3 = np.quantile(x, [0.25, 0.75], method="hazen")
+    return float(q3 - q1)
+
+
+def _nanmean_over_events(mat: np.ndarray | None) -> np.ndarray | None:
+    """``nanmean(mat, 2)`` in MATLAB — mean over the event axis (axis=1 here),
+    one value per unit. All-NaN rows yield NaN (no warning)."""
+    if mat is None:
+        return None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # all-NaN slice → NaN
+        return np.nanmean(np.asarray(mat, dtype=float), axis=1)
+
+
+def _nansum_over_events(mat: np.ndarray | None) -> np.ndarray | None:
+    if mat is None:
+        return None
+    return np.nansum(np.asarray(mat, dtype=float), axis=1)
+
+
+def _nanmean_scalar(x: np.ndarray | None) -> float:
+    if x is None or np.size(x) == 0:
+        return float("nan")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        return float(np.nanmean(x))
+
+
+def calc_twop_activity_stats(
+    twop_activity: str,
+    duration_s: float,
+    fs: float,
+    min_activity_level: float,
+    *,
+    spike_times: list[np.ndarray] | None = None,
+    activity_matrix: np.ndarray | None = None,
+    peak_heights: np.ndarray | None = None,
+    peak_duration_frames: np.ndarray | None = None,
+    event_areas: np.ndarray | None = None,
+) -> dict:
+    """Port of ``calTwopActivityStats.m``.
+
+    Parameters mirror the fields MATLAB reads off ``expData``:
+
+    - ``twop_activity`` — ``'peaks'`` | ``'F'`` | ``'spks'`` | ``'denoised F'``.
+    - ``spike_times`` — for the ``'peaks'`` path: a list (one per unit) of peak
+      times **in seconds** (MATLAB ``spikeTimes{u}.peak``).
+    - ``activity_matrix`` — for the other paths: ``(n_frames, n_units)`` array
+      (MATLAB ``expData.(twopActivity)``); firing rate is its column sum / duration.
+    - ``peak_heights`` / ``peak_duration_frames`` / ``event_areas`` —
+      ``(n_units, max_events)`` NaN-padded arrays from ``activityProperties``.
+
+    Returns a dict keyed by the MATLAB ``activityStats`` field names.
+
+    Notes / deviations: the ISI and 2P-specific (height/duration/area) metrics
+    are only defined by MATLAB for the ``'peaks'`` path (they read
+    ``spikeTimes`` / ``activityProperties``, which only exist then). For the
+    other activity types those inputs are ``None`` and the corresponding fields
+    come back as NaN rather than erroring.
+    """
+    stats: dict = {}
+
+    # ── Firing rate (metric shared with ephys) ────────────────────────────────
+    if twop_activity == "peaks":
+        if spike_times is None:
+            raise ValueError("spike_times is required for twop_activity='peaks'")
+        n_units = len(spike_times)
+        num_peaks = np.array([np.size(st) for st in spike_times], dtype=float)
+        peak_isi = np.full(n_units, np.nan)
+        for u, st in enumerate(spike_times):
+            st = np.asarray(st, dtype=float).ravel()
+            if st.size >= 2:
+                peak_isi[u] = np.mean(np.diff(st))
+        firing_rates = num_peaks / duration_s
+    else:
+        if activity_matrix is None:
+            raise ValueError(
+                "activity_matrix is required for twop_activity != 'peaks'"
+            )
+        # MATLAB sum(expData.(twopActivity), 1): sum over time (rows) → per unit.
+        firing_rates = np.asarray(activity_matrix, dtype=float).sum(axis=0) / duration_s
+        peak_isi = np.full(firing_rates.shape[0], np.nan)
+
+    active_index = firing_rates >= min_activity_level
+    active_fr = firing_rates[active_index]
+
+    stats["FR"] = firing_rates
+
+    # FR with sub-threshold units set to NaN.
+    fr_active_full = np.full(firing_rates.shape[0], np.nan)
+    fr_active_full[active_index] = active_fr
+    stats["FRactive"] = fr_active_full
+
+    # Recording-level FR summaries, computed on active units only, rounded to 3dp.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # empty active set → NaN
+        stats["FRmean"] = _round3(float(np.mean(active_fr)) if active_fr.size else float("nan"))
+        stats["FRstd"] = _round3(float(np.std(active_fr, ddof=1)) if active_fr.size > 1 else float("nan"))
+        sem = (float(np.std(active_fr, ddof=1)) / np.sqrt(active_fr.size)) if active_fr.size > 1 else float("nan")
+        stats["FRsem"] = _round3(sem)
+        stats["FRmedian"] = _round3(float(np.median(active_fr)) if active_fr.size else float("nan"))
+    stats["FRiqr"] = _round3(_iqr(active_fr))
+    stats["numActiveElec"] = int(active_fr.size)
+
+    stats["ISImean"] = _nanmean_scalar(peak_isi)
+    stats["ISI"] = peak_isi
+
+    # ── Two-photon-specific metrics ───────────────────────────────────────────
+    # unit level
+    stats["unitHeightMean"] = _nanmean_over_events(peak_heights)
+    dur_mean = _nanmean_over_events(peak_duration_frames)
+    stats["unitPeakDurMean"] = None if dur_mean is None else dur_mean / fs
+    area_mean = _nanmean_over_events(event_areas)
+    stats["unitEventAreaMean"] = None if area_mean is None else area_mean / fs
+    area_sum = _nansum_over_events(event_areas)
+    stats["unitEventAreaSum"] = None if area_sum is None else area_sum / fs
+
+    # recording level
+    stats["recHeightMean"] = _nanmean_scalar(stats["unitHeightMean"])
+    stats["recPeakDurMean"] = _nanmean_scalar(stats["unitPeakDurMean"])
+    stats["recEventAreaMean"] = _nanmean_scalar(stats["unitEventAreaMean"])
+
+    return stats
+
+
+def get_cell_type_matrix(
+    cell_type_ids: dict[str, np.ndarray],
+    channels: np.ndarray,
+) -> tuple[np.ndarray, list[str]]:
+    """Port of ``getCellTypeMatrix.m``.
+
+    MATLAB reads ``Info.CellTypes`` (a table); here we take a dict mapping each
+    cell-type name to an array of **0-indexed** ROI ids (as stored in the
+    ``PutativeCellType_*.csv`` files — the ``+1`` in the MATLAB code converts
+    those to the 1-indexed ROI numbers held in ``channels``).
+
+    Returns ``(cell_type_matrix, cell_type_names)`` where ``cell_type_matrix``
+    is ``(n_channels, n_cell_types)`` with a 1 wherever a channel's ROI id is
+    listed under that cell type.
+    """
+    channels = np.asarray(channels).ravel()
+    names = list(cell_type_ids.keys())
+    matrix = np.zeros((channels.size, len(names)), dtype=float)
+
+    # channel value → row index (channels are 1-indexed ROI numbers)
+    chan_to_row = {int(c): i for i, c in enumerate(channels)}
+
+    for col, name in enumerate(names):
+        ids = np.asarray(cell_type_ids[name], dtype=float).ravel()
+        ids = ids[~np.isnan(ids)].astype(int) + 1  # 0-indexed CSV → 1-indexed ROI
+        for roi in ids:
+            row = chan_to_row.get(int(roi))
+            if row is not None:
+                matrix[row, col] = 1.0
+
+    return matrix, names

--- a/src/meanap/gui/panels/catnap.py
+++ b/src/meanap/gui/panels/catnap.py
@@ -219,6 +219,14 @@ class CatNapPanel(QWidget):
         info_form.addRow("Duration:", self._info_duration)
         info_form.addRow("Denoised data:", self._info_denoised)
 
+        # Pipeline mode: master switch mirroring MATLAB Params.suite2pMode.
+        # When ticked, a pipeline run analyses suite2p data via the CAT-NAP path
+        # rather than raw MEA recordings.
+        mode_box = QGroupBox("Pipeline mode")
+        mode_form = QFormLayout(mode_box)
+        self._suite2p_mode = QCheckBox()
+        mode_form.addRow("Analyse suite2p data (CAT-NAP)", self._suite2p_mode)
+
         # Denoising settings
         denoise_box = QGroupBox("Denoising settings")
         denoise_form = QFormLayout(denoise_box)
@@ -261,6 +269,7 @@ class CatNapPanel(QWidget):
 
         layout.addWidget(scan_box)
         layout.addWidget(info_box)
+        layout.addWidget(mode_box)
         layout.addWidget(denoise_box)
         layout.addWidget(self._denoise_btn)
         layout.addStretch()
@@ -419,6 +428,7 @@ class CatNapPanel(QWidget):
 
     def load(self, params: Params) -> None:
         self._folder_edit.setText(params.raw_data)
+        self._suite2p_mode.setChecked(params.suite2p_mode)
         idx = self._activity_combo.findText(params.twop_activity)
         if idx >= 0:
             self._activity_combo.setCurrentIndex(idx)
@@ -430,6 +440,7 @@ class CatNapPanel(QWidget):
 
     def save(self, params: Params) -> None:
         params.raw_data = self._folder_edit.text()
+        params.suite2p_mode = self._suite2p_mode.isChecked()
         params.twop_activity = self._activity_combo.currentText()
         params.twop_redo_denoising = self._redo_denoising.isChecked()
         params.remove_nodes_with_no_peaks = self._remove_no_peaks.isChecked()

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -77,8 +77,11 @@ class Params:
 
     # ── Node cartography ─────────────────────────────────────────────────────
     auto_set_cartography_boundaries: bool = True
-    auto_set_cartography_boundaries_per_lag: bool = False
-    cartography_lag_val: list[int] = field(default_factory=lambda: [25])
+    # MEApipeline.m defaults autoSetCartographyBoudariesPerLag = 1 with
+    # cartographyLagVal = [10, 25, 50]; per-lag derives separate boundaries
+    # from each lag's pooled PC/Z, non-per-lag uses cartography_lag_val[0].
+    auto_set_cartography_boundaries_per_lag: bool = True
+    cartography_lag_val: list[int] = field(default_factory=lambda: [10, 25, 50])
     hub_boundary_wm_d_deg: float = 2.5
     peri_part_coef: float = 0.625
     pro_hub_part_coef: float = 0.3

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -137,6 +137,11 @@ class Params:
     recording_workers: int | None = None
 
     # ── Two-photon / CAT-NAP ─────────────────────────────────────────────────
+    # Master switch (MATLAB ``Params.suite2pMode``): when True the pipeline
+    # analyses suite2p calcium-imaging output instead of raw MEA recordings.
+    # The CAT-NAP execution path (steps 2-4) is being ported — see
+    # python/CATNAP_PORT_PLAN.md.
+    suite2p_mode: bool = False
     twop_activity: str = "peaks"
     twop_redo_denoising: bool = False
     remove_nodes_with_no_peaks: bool = False

--- a/src/meanap/pipeline/network_metrics.py
+++ b/src/meanap/pipeline/network_metrics.py
@@ -431,6 +431,134 @@ def rich_club_wu(adj_m: np.ndarray, k_level: int | None = None) -> np.ndarray:
 
 # ── Node cartography classification (NodeCartography.m) ────────────────────
 
+def _optimal_1d_split_boundaries(x: np.ndarray, k: int) -> np.ndarray | None:
+    """Boundaries (``k-1`` midpoints) of an optimal 1-D k-means clustering.
+
+    Port of MATLAB ``TrialLandscapeDensity``'s use of ``kmeans`` to carve a
+    1-D set of values (Z, or PC within a hub/non-hub band) into ``k`` groups,
+    then place each boundary halfway between the max of the "left" group and
+    the min of the "right" group.
+
+    MATLAB's ``kmeans`` (Lloyd from a random ``k-means++`` seed, 1 replicate)
+    is *not* deterministic — two runs of the same data can land in different
+    local minima, so its stored boundaries aren't uniquely reproducible. We
+    instead compute the *globally optimal* 1-D partition via the classic
+    O(k·n²) dynamic program (Ckmeans.1d.dp). Optimal 1-D k-means clusters are
+    always contiguous once the data is sorted, so each boundary is simply the
+    midpoint of an adjacent sorted pair at the optimal split — which matches
+    MATLAB's "(left max + right min) / 2" whenever its ``kmeans`` also finds
+    the optimum. This makes the Python boundaries reproducible run-to-run.
+
+    Returns the sorted ``(k-1,)`` boundary array, or ``None`` if there are
+    fewer than ``k`` distinct finite values to split (caller falls back to the
+    fixed default boundaries, mirroring MATLAB's ``< num_partitions`` guard).
+    """
+    x = np.asarray(x, dtype=float)
+    x = x[np.isfinite(x)]
+    if len(x) < k or len(np.unique(x)) < k:
+        return None
+    xs = np.sort(x)
+    n = len(xs)
+    # prefix sums for O(1) segment cost: cost(i,j) = sum sq dev of xs[i..j]
+    p1 = np.concatenate([[0.0], np.cumsum(xs)])
+    p2 = np.concatenate([[0.0], np.cumsum(xs * xs)])
+
+    def seg_cost(i: int, j: int) -> float:  # inclusive, 0-indexed
+        m = j - i + 1
+        s = p1[j + 1] - p1[i]
+        return (p2[j + 1] - p2[i]) - s * s / m
+
+    INF = float("inf")
+    # D[m][j] = min cost to split xs[0..j] into m+1 clusters; B = split backptr
+    D = [[INF] * n for _ in range(k)]
+    B = [[0] * n for _ in range(k)]
+    for j in range(n):
+        D[0][j] = seg_cost(0, j)
+    for m in range(1, k):
+        for j in range(m, n):
+            best, arg = INF, m
+            for i in range(m, j + 1):
+                c = D[m - 1][i - 1] + seg_cost(i, j)
+                if c < best:
+                    best, arg = c, i
+            D[m][j] = best
+            B[m][j] = arg
+
+    # backtrack split start-indices, then boundary = midpoint across each split
+    splits = []
+    j = n - 1
+    for m in range(k - 1, 0, -1):
+        i = B[m][j]
+        splits.append(i)
+        j = i - 1
+    splits.sort()
+    return np.array([(xs[i - 1] + xs[i]) / 2 for i in splits], dtype=float)
+
+
+def trial_landscape_density(
+    pc: np.ndarray,
+    z: np.ndarray,
+    hub_boundary_default: float,
+    peri_part_coef_default: float,
+    pro_hub_part_coef_default: float,
+    non_hub_connector_part_coef_default: float,
+    connector_hub_part_coef_default: float,
+) -> tuple[float, float, float, float, float] | None:
+    """Data-driven node-cartography boundaries (port of ``TrialLandscapeDensity.m``).
+
+    Given participation-coefficient ``pc`` and within-module z-score ``z``
+    pooled across recordings (for one lag), derive the five cartography
+    boundaries used by :func:`classify_node_cartography`, using the default
+    ``boundarySelectionMethod = 'kmeans'`` branch:
+
+    1. 2-means on ``z`` → the hub/non-hub z boundary.
+    2. 3-means on the PC of hub nodes (``z >= z_boundary``) → the
+       provincial/connector and connector/kinless hub PC boundaries.
+    3. 3-means on the PC of non-hub nodes → the peripheral/non-hub-connector
+       and non-hub-connector/kinless PC boundaries; falls back to the passed
+       defaults when there are fewer than 3 non-hub nodes (as MATLAB does).
+
+    Returns ``(hub_boundary_wm_d_deg, peri_part_coef,
+    non_hub_connector_part_coef, pro_hub_part_coef, connector_hub_part_coef)``
+    or ``None`` when there are fewer than 2 finite ``z`` values (MATLAB returns
+    all-NaN there and the caller keeps the fixed defaults).
+
+    .. note::
+       MATLAB's loop reloads ``ExpName{1}`` on every iteration, so it actually
+       pools only the *first* recording's PC/Z (duplicated), despite the
+       docstring saying "across recordings" — an upstream bug. This port does
+       the intended thing and pools *all* recordings, so its boundaries can
+       differ from MATLAB's stored per-lag values.
+    """
+    pc = np.asarray(pc, dtype=float)
+    z = np.asarray(z, dtype=float)
+    finite = np.isfinite(pc) & np.isfinite(z)
+    pc, z = pc[finite], z[finite]
+    if np.sum(np.isfinite(z)) < 2:
+        return None
+
+    z_split = _optimal_1d_split_boundaries(z, 2)
+    if z_split is None:
+        return None
+    z_boundary = float(z_split[0])
+
+    hub_bounds = _optimal_1d_split_boundaries(pc[z >= z_boundary], 3)
+    if hub_bounds is None:
+        pro_hub = pro_hub_part_coef_default
+        connector_hub = connector_hub_part_coef_default
+    else:
+        pro_hub, connector_hub = float(hub_bounds[0]), float(hub_bounds[1])
+
+    non_hub_bounds = _optimal_1d_split_boundaries(pc[z < z_boundary], 3)
+    if non_hub_bounds is None:
+        peri = peri_part_coef_default
+        non_hub_connector = non_hub_connector_part_coef_default
+    else:
+        peri, non_hub_connector = float(non_hub_bounds[0]), float(non_hub_bounds[1])
+
+    return (z_boundary, peri, non_hub_connector, pro_hub, connector_hub)
+
+
 def classify_node_cartography(
     pc: np.ndarray,
     z: np.ndarray,

--- a/src/meanap/pipeline/plotting_step4.py
+++ b/src/meanap/pipeline/plotting_step4.py
@@ -111,6 +111,7 @@ def plot_spatial_network(
     z_scale_override: float | None = None,
     z2_bounds_override: tuple[float, float] | None = None,
     edge_bounds_override: tuple[float, float] | None = None,
+    coords_override: np.ndarray | None = None,
 ) -> None:
     """Spatial network plot, port of the base ``2_MEA_NetworkPlot.png`` from
     ``StandardisedNetworkPlot.m`` (reuses ``network_plot.py``'s
@@ -130,7 +131,7 @@ def plot_spatial_network(
     ``network_plot.py``'s ``plot_network`` docstring).
     """
     prepared = _prepare_network_plot_data(
-        adj_m_sub, channels_active, channel_layout, z, z2,
+        adj_m_sub, channels_active, channel_layout, z, z2, coords_override,
     )
     if prepared is None:
         return
@@ -158,15 +159,25 @@ def _prepare_network_plot_data(
     channel_layout: str,
     z: np.ndarray,
     z2: np.ndarray | None,
+    coords_override: np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray | None] | None:
-    """Map active channels to layout coordinates and subset the adjacency
-    matrix / per-node metrics to the channels that have a coordinate.
+    """Map active channels to coordinates and subset the adjacency matrix /
+    per-node metrics to the channels that have one.
+
+    ``coords_override`` (an ``(n_active, 2)`` array aligned with
+    ``channels_active``) supplies coordinates directly instead of the MEA
+    ``channel_layout`` lookup — used by the CAT-NAP path, whose node positions
+    come from suite2p cell centroids rather than an electrode grid. In that
+    case every active node has a coordinate, so nothing is dropped.
 
     Returns ``(sub_adj, coords, z_sub, z2_sub)`` or ``None`` if no active
     channel has a coordinate (e.g. an all-grounded layout). Shared by
     ``plot_spatial_network`` and ``plot_spatial_network_combined`` so both
     subset identically.
     """
+    if coords_override is not None:
+        return adj_m_sub, np.asarray(coords_override, dtype=float), z, z2
+
     layout_channels, layout_coords = get_coords_from_layout(channel_layout)
     coord_by_channel = dict(zip(layout_channels.tolist(), map(tuple, layout_coords)))
 

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -59,6 +59,17 @@ def run_pipeline(
     )
     log(f"Output folder ready: {output_root}")
 
+    # CAT-NAP (suite2p calcium imaging) path. In MATLAB, Params.suite2pMode == 1
+    # replaces spike detection + connectivity (steps 1 & 3) with suite2pToAdjm,
+    # swaps step-2 stats for calTwopActivityStats, and feeds the shared step-4
+    # network metrics. We run that whole flow here instead of the ephys steps —
+    # the raw MEA .mat files those steps expect don't exist for 2P data.
+    if params.suite2p_mode:
+        log("\n=== CAT-NAP (suite2p) pipeline ===")
+        from meanap.catnap.pipeline import run_catnap_pipeline
+        run_catnap_pipeline(params, recordings, output_root, log, should_cancel)
+        return output_root
+
     start = params.start_analysis_step
     stop = params.stop_analysis_step
 

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -508,6 +508,84 @@ def _step4_plot_one(
     return rec.filename, logs
 
 
+def _apply_cartography_boundaries(
+    params: Params,
+    all_results: dict[str, dict],
+    log: Callable[[str], None],
+) -> None:
+    """Re-derive node-cartography boundaries from pooled PC/Z and re-classify.
+
+    Port of MEApipeline.m's ``autoSetCartographyBoundaries`` step: after every
+    recording's metrics are computed, pool the participation coefficient (PC)
+    and within-module z-score (Z) across recordings and run
+    :func:`nm.trial_landscape_density` to place the six cartography boundaries
+    where the data actually clusters, rather than at the fixed
+    ``params.peri_part_coef`` etc. Then overwrite ``NdCartDiv`` / ``NCpn*`` for
+    every recording at each affected lag. Mutates ``all_results`` in place.
+
+    With ``auto_set_cartography_boundaries_per_lag`` each lag gets its own
+    boundaries from that lag's pooled PC/Z (MEApipeline default); otherwise a
+    single set from ``cartography_lag_val[0]`` is applied to all lags.
+    """
+    lag_keys = sorted(
+        {lag for rec in all_results.values() for lag in rec},
+        key=lambda k: int(k.replace("mslag", "")),
+    )
+    if not lag_keys:
+        return
+
+    if params.auto_set_cartography_boundaries_per_lag:
+        # each lag: derive from its own pooled PC/Z, apply to itself
+        plans = [(lk, [lk]) for lk in lag_keys]
+    else:
+        ref = f"{params.cartography_lag_val[0]}mslag"
+        source = ref if ref in lag_keys else lag_keys[0]
+        plans = [(source, lag_keys)]  # one boundary set → all lags
+
+    for source_lag, target_lags in plans:
+        pc_pool, z_pool = [], []
+        for rec in all_results.values():
+            m = rec.get(source_lag)
+            if m and "PC" in m and "Z" in m:
+                pc_pool.append(np.asarray(m["PC"], dtype=float))
+                z_pool.append(np.asarray(m["Z"], dtype=float))
+        if not pc_pool:
+            continue
+
+        bounds = nm.trial_landscape_density(
+            np.concatenate(pc_pool), np.concatenate(z_pool),
+            params.hub_boundary_wm_d_deg, params.peri_part_coef,
+            params.pro_hub_part_coef, params.non_hub_connector_part_coef,
+            params.connector_hub_part_coef,
+        )
+        if bounds is None:
+            log(f"  Cartography: too few PC/Z values at {source_lag}; "
+                "keeping fixed boundaries.")
+            continue
+        hub_b, peri, non_hub_conn, pro_hub, conn_hub = bounds
+        log(f"  Cartography boundaries from {source_lag} pooled PC/Z: "
+            f"Zhub={hub_b:.3f} peri={peri:.3f} nonHubConn={non_hub_conn:.3f} "
+            f"proHub={pro_hub:.3f} connHub={conn_hub:.3f}")
+
+        for lag_key in target_lags:
+            for rec in all_results.values():
+                m = rec.get(lag_key)
+                if not m or "PC" not in m or "Z" not in m:
+                    continue
+                pc = np.asarray(m["PC"], dtype=float)
+                z = np.asarray(m["Z"], dtype=float)
+                a_n = len(pc)
+                if a_n == 0:
+                    continue
+                nd_cart_div, pop_num_nc = nm.classify_node_cartography(
+                    pc, z, hub_b, peri, non_hub_conn, pro_hub, conn_hub,
+                )
+                m["NdCartDiv"] = nd_cart_div
+                for i in range(6):
+                    m[f"NCpn{i + 1}"] = float(pop_num_nc[i] / a_n)
+                    m[f"NCpn{i + 1}count"] = int(pop_num_nc[i])
+
+
 def _run_step4_network_metrics(
     params: Params,
     recordings: list[RecordingInfo],
@@ -544,10 +622,15 @@ def _run_step4_network_metrics(
             channels_by_rec[filename] = channels_arr
 
     # ── Phase B: reduce (serial) ─────────────────────────────────────────────
+    # Data-driven node-cartography boundaries: pool PC/Z across every recording
+    # and re-derive the cartography boundaries (TrialLandscapeDensity), then
+    # re-classify every node. Mirrors MEApipeline.m's autoSetCartographyBoundaries
+    # barrier between per-recording ExtractNetMet and calNodeCartography.
+    if params.auto_set_cartography_boundaries:
+        _apply_cartography_boundaries(params, all_results, log)
+
     # Pool node-level metrics across every recording for the batch-scaled plot
-    # bounds. This is also where cross-recording node-cartography boundaries
-    # (pooled PC/Z density landscape → basins) will be computed once ported —
-    # a second reducer in the same barrier. See PIPELINE_PORT_STATUS.md.
+    # bounds.
     batch_bounds = {
         m: _batch_metric_bounds(all_results, m)
         for m in ("ND", "NS", "BC", "PC", "Eloc")

--- a/src/meanap/pipeline/sttc.py
+++ b/src/meanap/pipeline/sttc.py
@@ -9,6 +9,43 @@ from __future__ import annotations
 
 import numpy as np
 
+# ``run_P`` (below) is a monotonic two-pointer whose result is *order-dependent*
+# on the input spike trains — it does not sort. For spike-detection data the
+# trains are already sorted, but CAT-NAP peak times can arrive unsorted (see
+# ``catnap/adjacency.py``), and MATLAB's ``sttc_m.m`` runs on them as-is, so we
+# must replicate the literal loop rather than assume sorted order. Compile it
+# with numba when available (same optional pattern as ``null_models.py``); the
+# pure-Python fallback is identical, just slower.
+try:
+    from numba import njit
+
+    _HAVE_NUMBA = True
+except Exception:  # pragma: no cover - numba optional / version-gated
+    _HAVE_NUMBA = False
+
+
+def _run_p_impl(t1: np.ndarray, t2: np.ndarray, dt: float) -> int:
+    """Literal port of ``run_P`` in ``sttc_m.m``: count spikes in ``t1`` that
+    have a coincident spike in ``t2`` within ``dt``, using MATLAB's monotonic,
+    non-resetting ``j`` pointer (does not assume either train is sorted)."""
+    n1 = t1.shape[0]
+    n2 = t2.shape[0]
+    nab = 0
+    j = 0
+    for i in range(n1):
+        while j < n2:
+            if abs(t1[i] - t2[j]) <= dt:
+                nab += 1
+                break
+            elif t2[j] > t1[i]:
+                break
+            else:
+                j += 1
+    return nab
+
+
+_run_p_jit = njit(cache=True)(_run_p_impl) if _HAVE_NUMBA else _run_p_impl
+
 
 def _run_t(dt: float, t_start: float, t_end: float, times: np.ndarray) -> float:
     """Fraction-of-recording (unnormalised) tiled by ``times`` +/- ``dt``.
@@ -46,18 +83,16 @@ def _run_t(dt: float, t_start: float, t_end: float, times: np.ndarray) -> float:
 def _run_p(t1: np.ndarray, t2: np.ndarray, dt: float) -> int:
     """Count of spikes in ``t1`` with >=1 coincident spike in ``t2`` within ``dt``.
 
-    Vectorised equivalent of the monotonic two-pointer ``run_P`` in
-    ``sttc_m.m``: for each spike in ``t1`` only its immediate neighbours in
-    the sorted ``t2`` array can be within ``dt`` (both arrays are sorted
-    ascending), so a single ``searchsorted`` call suffices.
+    Faithful port of the monotonic two-pointer ``run_P`` in ``sttc_m.m`` (see
+    :func:`_run_p_impl`). For sorted trains this equals the nearest-neighbour
+    count; for unsorted trains it reproduces MATLAB's exact, order-dependent
+    result — required for CAT-NAP peak-time parity.
     """
     if len(t1) == 0 or len(t2) == 0:
         return 0
-    idx = np.searchsorted(t2, t1)
-    idx_hi = np.clip(idx, 0, len(t2) - 1)
-    idx_lo = np.clip(idx - 1, 0, len(t2) - 1)
-    coincident = (np.abs(t2[idx_hi] - t1) <= dt) | (np.abs(t2[idx_lo] - t1) <= dt)
-    return int(np.sum(coincident))
+    return int(_run_p_jit(np.ascontiguousarray(t1, dtype=np.float64),
+                          np.ascontiguousarray(t2, dtype=np.float64),
+                          float(dt)))
 
 
 def sttc_pair(spike_times_1: np.ndarray, spike_times_2: np.ndarray, dt: float,


### PR DESCRIPTION
This branch is 3 commits ahead of `main`. All three are Python-pipeline work and will merge together.

## 1. CAT-NAP (calcium imaging / suite2p) port — `feat(catnap)`
Wires the MATLAB `Params.suite2pMode==1` path end-to-end in Python: suite2p data → denoise → adjacency → activity stats → shared step-4 network metrics, plus per-unit trace figures and spatial network plots.

- `params.suite2p_mode` master switch + CAT-NAP GUI checkbox; `run_pipeline` branches to the new `catnap/pipeline.py` instead of the ephys steps.
- `catnap/adjacency.py` — port of `suite2pToAdjm.m` (coords, channels, activityProperties; `corr`/STTC adjacency, reusing `probabilistic_threshold`).
- `catnap/stats.py` — port of `calTwopActivityStats.m` + `getCellTypeMatrix.m`.
- `catnap/plotting.py` — port of `plot2ptraces.m`; spatial network plot reuses the step-4 renderer via a new `coords_override` path.
- **Bug fix** in `sttc._run_p`: it assumed sorted spike trains (`np.searchsorted`), but suite2p peak times can be unsorted and MATLAB's `sttc_m` `run_P` is an order-dependent monotonic two-pointer. Replaced with a numba-jitted literal port (pure-Python fallback); **ephys STTC parity preserved** (~1e-16).

**Parity:** `python/test_pipeline_catnap.py` passes **112/112** against a MATLAB ground-truth run — `activityStats` exact (17 fields), `suite2pToAdjm` outputs exact (coords/channels/spikeTimes/properties + raw STTC on every surviving edge), `NetMet` exact on all deterministic fields across 3 lags. RNG-thresholded `adjMs` verified via the deterministic surviving-edge invariant (same approach as the ephys step-4 test). See `python/CATNAP_PORT_PLAN.md`.

Known follow-ups (documented in the plan): 2P raster plot, and network-plot node-size tuning for dense recordings (the latter tracked as an interactive-preview GUI idea).

## 2. TrialLandscapeDensity port — `feat(python)`
Ports `TrialLandscapeDensity` to fix the node-cartography `NCpn` columns.

## 3. Pipeline perf — `perf(python)`
~3.3× faster pipeline via threading, numba, and collection-based plotting.

## Testing
Full Python parity suite green (step1–4, cartography, nmf, null-models, small-worldness, channel layout, landscape, CAT-NAP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8FNXWVEN9WGsHMwYxnZAn