### PR TITLE
feat(python): interactive network viewer — layouts, edge subsampling,…

### DIFF
--- a/docs/python/network-viewer.md
+++ b/docs/python/network-viewer.md
@@ -6,23 +6,78 @@ It's the Python equivalent of MATLAB's `runMEANAPviewer.m`.
 
 ## Using the Network Viewer tab
 
+When the tab first opens it shows a **built-in example network** so every
+control is usable immediately — no file needed. To explore your own data:
+
 1. Click **Browse…** and select a MEA-NAP output `.mat` file from the
    `ExperimentMatFiles/` subfolder of an output directory, e.g.
    `OutputData.../ExperimentMatFiles/<recording>_OutputData....mat`.
+   (**Use example network** reloads the synthetic demo at any time.)
 2. The network renders immediately. Recording metadata (name, DIV, group,
-   active node count) appears in the left panel.
-3. Adjust settings to update the plot in real time:
+   active node count, edges shown) appears in the left panel.
+3. Adjust **Network settings** to update the plot in real time:
    - **Lag** — which functional connectivity lag value to view (e.g. `1000
      ms`, `2500 ms`, `5000 ms`).
-   - **Edge threshold** — minimum correlation weight required to draw an edge.
-   - **Node color metric** — color nodes by any node-level metric present in
-     the file (betweenness centrality, node strength, z-score, ...), or leave
-     as **None** for flat cyan nodes.
+   - **Edge threshold by** / **Edge threshold** — how the minimum edge weight
+     is chosen (see [Edge subsampling & thresholding](#edge-subsampling-thresholding)).
+   - **Node size metric** — drive node size by any node-level metric present
+     in the file (defaults to node degree, ND).
+   - **Node color metric** — color nodes by any node-level metric (betweenness
+     centrality, node strength, z-score, ...), or leave as **None** for flat
+     cyan nodes.
 4. (Optional) Click **Load cell types from file…** to overlay cell-type
    information — see below.
 
-Node **size** is always proportional to node degree (ND). Node **color** uses
-the viridis colormap, with a colorbar legend on the right.
+Node **color** uses the viridis colormap, with a colorbar legend on the right.
+
+## Display controls
+
+The **Display** group changes how the network is drawn — none of these alter
+the underlying metrics, only the appearance:
+
+- **Node layout** — where nodes are placed:
+  - **Original (electrodes)** — the physical electrode coordinates (default).
+  - **Circular**, **Spring (force)**, **Kamada-Kawai**, **Spectral**,
+    **Shell** — positions derived from network topology (via networkx). These
+    port MATLAB's `getNodeCoords.m` layout options and the `circular` plot
+    type. Every derived layout is rescaled into the electrode bounding box so
+    node, edge and legend sizing stay consistent.
+- **Node size scale** — a multiplier applied to every node (MATLAB's
+  `maxNodeSize`); increase it to enlarge all nodes at once.
+- **Node scaling** — how the size metric maps onto node radius: **Linear**,
+  **Log2**, **Log10**, **Square**, or **Cube** (port of MATLAB's
+  `nodeScalingMethod` in `getNodeSize.m`).
+- **Min edge width** / **Max edge width** — the line width (in points) of the
+  weakest and strongest drawn edges. The viewer keeps max ≥ min automatically.
+
+## Edge subsampling & thresholding
+
+Dense networks can render as an unreadable hairball. Two independent controls
+limit what's drawn (neither changes node degree or any other metric — they are
+plotting-only, mirroring `PlotIndvNetMet.m`):
+
+- **Max edges** (Display group) — draw only the strongest *N* edges by absolute
+  weight, keeping the rest hidden (port of `limitEdgesForPlotting.m`,
+  `HighToLow`). `0` (shown as *Unlimited*) draws every edge.
+- **Edge threshold by** (Network settings) — how the threshold weight is chosen
+  (port of `getEdgeThreshold.m`):
+  - **Absolute value** — draw edges with weight ≥ the value you set (0–1).
+  - **Percentile** — threshold at the Nth percentile of **all** adjacency
+    entries, *including zeros* (MATLAB-faithful: on a sparse matrix a low
+    percentile does nothing, so you typically need a high value).
+  - **Percentile (nonzero edges)** — threshold at the Nth percentile of only
+    the **actual** edge weights, so e.g. `80 %` keeps the strongest ~20 % of
+    edges — the intuitive behaviour.
+
+The **Edges shown** field updates live so you can see the effect of each control.
+
+## Saving the plot
+
+Click **Save plot…** (Display group) to export the current figure. Choose
+**PNG** (raster, saved at **600 dpi** for publication-quality output) or
+**SVG** (vector, resolution-independent). If you omit the extension it is
+inferred from the selected file type. The export preserves the on-screen white
+background and trims surrounding whitespace.
 
 ## Cell-type overlay
 

--- a/src/meanap/gui/panels/network_viewer.py
+++ b/src/meanap/gui/panels/network_viewer.py
@@ -9,15 +9,22 @@ from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtWidgets import (
     QComboBox, QDoubleSpinBox, QFileDialog, QFormLayout, QGroupBox,
     QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem,
-    QPushButton, QSizePolicy, QSplitter, QTextEdit, QVBoxLayout, QWidget,
+    QPushButton, QSizePolicy, QSpinBox, QSplitter, QTextEdit, QVBoxLayout,
+    QWidget,
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
 from meanap.network_plot import (
-    MatData, build_cell_type_matrix, filter_by_cell_types,
-    load_cell_type_file, plot_network,
+    EDGE_THRESHOLD_METHODS, LAYOUT_OPTIONS, MatData, build_cell_type_matrix,
+    compute_node_coords, count_edges_shown, filter_by_cell_types,
+    get_edge_threshold, limit_edges_for_plotting, load_cell_type_file,
+    make_example_network, plot_network,
 )
+
+# Node-size scaling methods exposed in the UI — mirror MATLAB's nodeScalingMethod
+# options (see getNodeSize.m). The value is passed straight to plot_network.
+NODE_SCALING_METHODS = ["Linear", "Log2", "Log10", "Square", "Cube"]
 
 
 # ── Background workers ────────────────────────────────────────────────────────
@@ -70,6 +77,12 @@ class _NetworkCanvas(FigureCanvasQTAgg):
         cell_type_names: list[str] | None,
         min_node_size: float,
         title: str,
+        *,
+        z_name: str = "node degree",
+        min_ew: float = 0.001,
+        max_ew: float = 4.0,
+        node_size_scale: float = 1.0,
+        node_scaling_method: str = "Linear",
     ) -> None:
         self._fig.clear()
         ax = self._fig.add_subplot(111)
@@ -77,8 +90,22 @@ class _NetworkCanvas(FigureCanvasQTAgg):
         plot_network(
             ax, adjM, coords, edge_thresh, z, z2, z2_name,
             cell_type_matrix, cell_type_names, min_node_size, title,
+            z_name=z_name,
+            min_ew=min_ew, max_ew=max_ew,
+            node_size_scale=node_size_scale,
+            node_scaling_method=node_scaling_method,
         )
         self.draw()
+
+    def save_figure(self, path: str, dpi: int = 600) -> None:
+        """Save the current figure to *path* (format inferred from extension).
+
+        ``dpi`` only affects raster formats (PNG); SVG is resolution-independent.
+        The white facecolor is preserved so the export matches the on-screen plot.
+        """
+        self._fig.savefig(
+            path, dpi=dpi, facecolor=self._fig.get_facecolor(), bbox_inches="tight",
+        )
 
 
 # ── Main panel ────────────────────────────────────────────────────────────────
@@ -94,6 +121,11 @@ class NetworkViewerPanel(QWidget):
         self._cell_type_names: list[str] | None = None
         self._load_worker: _LoadMatWorker | None = None
 
+        # Data source: "example" uses a built-in synthetic network so the
+        # display controls are usable immediately; "mat" uses a loaded file.
+        self._source = "example"
+        self._example: dict | None = None
+
         main_layout = QHBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
         splitter = QSplitter(Qt.Orientation.Horizontal)
@@ -101,7 +133,10 @@ class NetworkViewerPanel(QWidget):
 
         splitter.addWidget(self._build_left())
         splitter.addWidget(self._build_right())
-        splitter.setSizes([300, 700])
+        splitter.setSizes([320, 700])
+
+        # Start on the example network so every control does something on launch.
+        self._load_example_network()
 
     # ── Left panel ────────────────────────────────────────────────────────────
 
@@ -124,17 +159,27 @@ class NetworkViewerPanel(QWidget):
         path_row.addWidget(self._mat_path)
         path_row.addWidget(browse_btn)
 
+        example_btn = QPushButton("Use example network")
+        example_btn.setToolTip(
+            "Load a built-in synthetic network to experiment with the display "
+            "controls without needing a MEA-NAP output file."
+        )
+        example_btn.clicked.connect(self._load_example_network)
+
         info_form = QFormLayout()
         self._info_fn = QLabel("—")
         self._info_div = QLabel("—")
         self._info_grp = QLabel("—")
         self._info_nodes = QLabel("—")
+        self._info_edges = QLabel("—")
         info_form.addRow("Recording:", self._info_fn)
         info_form.addRow("DIV:", self._info_div)
         info_form.addRow("Group:", self._info_grp)
         info_form.addRow("Active nodes:", self._info_nodes)
+        info_form.addRow("Edges shown:", self._info_edges)
 
         file_layout.addLayout(path_row)
+        file_layout.addWidget(example_btn)
         file_layout.addLayout(info_form)
 
         # Network settings
@@ -145,6 +190,12 @@ class NetworkViewerPanel(QWidget):
         self._lag_combo.setEnabled(False)
         self._lag_combo.currentIndexChanged.connect(self._on_settings_changed)
 
+        self._edge_thresh_method = QComboBox()
+        self._edge_thresh_method.addItems(EDGE_THRESHOLD_METHODS)
+        self._edge_thresh_method.currentIndexChanged.connect(self._on_edge_thresh_method_changed)
+
+        # One spinbox whose meaning depends on the method: a weight (0–1) for
+        # "Absolute value", or a percentile (0–100 %) for "Percentile".
         self._edge_thresh = QDoubleSpinBox()
         self._edge_thresh.setRange(0.0, 1.0)
         self._edge_thresh.setSingleStep(0.05)
@@ -158,9 +209,68 @@ class NetworkViewerPanel(QWidget):
         self._node_color_metric.setEnabled(False)
         self._node_color_metric.currentIndexChanged.connect(self._on_settings_changed)
 
+        self._node_size_metric = QComboBox()
+        self._node_size_metric.addItem("node degree")
+        self._node_size_metric.currentIndexChanged.connect(self._on_settings_changed)
+
         net_form.addRow("Lag", self._lag_combo)
+        net_form.addRow("Edge threshold by", self._edge_thresh_method)
         net_form.addRow("Edge threshold", self._edge_thresh)
+        net_form.addRow("Node size metric", self._node_size_metric)
         net_form.addRow("Node color metric", self._node_color_metric)
+
+        # ── Display settings (live-updating visual controls) ───────────────────
+        disp_box = QGroupBox("Display")
+        disp_form = QFormLayout(disp_box)
+
+        self._layout_combo = QComboBox()
+        self._layout_combo.addItems(LAYOUT_OPTIONS)
+        self._layout_combo.currentIndexChanged.connect(self._on_settings_changed)
+
+        # Max edges to draw — keeps the strongest N by |weight| (HighToLow),
+        # a plotting-only subsample so dense networks stay readable. 0 = unlimited.
+        self._max_edges = QSpinBox()
+        self._max_edges.setRange(0, 100000)
+        self._max_edges.setSingleStep(25)
+        self._max_edges.setSpecialValueText("Unlimited")
+        self._max_edges.setValue(0)
+        self._max_edges.valueChanged.connect(self._on_settings_changed)
+
+        self._node_scale = QDoubleSpinBox()
+        self._node_scale.setRange(0.1, 8.0)
+        self._node_scale.setSingleStep(0.1)
+        self._node_scale.setValue(1.0)
+        self._node_scale.valueChanged.connect(self._on_settings_changed)
+
+        self._node_scaling_method = QComboBox()
+        self._node_scaling_method.addItems(NODE_SCALING_METHODS)
+        self._node_scaling_method.currentIndexChanged.connect(self._on_settings_changed)
+
+        self._min_ew = QDoubleSpinBox()
+        self._min_ew.setRange(0.0, 5.0)
+        self._min_ew.setSingleStep(0.1)
+        self._min_ew.setDecimals(3)
+        self._min_ew.setValue(0.001)
+        self._min_ew.valueChanged.connect(self._on_edge_width_changed)
+
+        self._max_ew = QDoubleSpinBox()
+        self._max_ew.setRange(0.1, 15.0)
+        self._max_ew.setSingleStep(0.5)
+        self._max_ew.setDecimals(2)
+        self._max_ew.setValue(4.0)
+        self._max_ew.valueChanged.connect(self._on_edge_width_changed)
+
+        disp_form.addRow("Node layout", self._layout_combo)
+        disp_form.addRow("Max edges", self._max_edges)
+        disp_form.addRow("Node size scale", self._node_scale)
+        disp_form.addRow("Node scaling", self._node_scaling_method)
+        disp_form.addRow("Min edge width", self._min_ew)
+        disp_form.addRow("Max edge width", self._max_ew)
+
+        self._save_btn = QPushButton("Save plot…")
+        self._save_btn.setToolTip("Save the current network plot as a PNG (600 dpi) or SVG file.")
+        self._save_btn.clicked.connect(self._on_save_plot)
+        disp_form.addRow(self._save_btn)
 
         # Cell types
         ct_box = QGroupBox("Cell types")
@@ -208,6 +318,7 @@ class NetworkViewerPanel(QWidget):
 
         layout.addWidget(file_box)
         layout.addWidget(net_box)
+        layout.addWidget(disp_box)
         layout.addWidget(ct_box)
         layout.addWidget(log_box)
         layout.addStretch()
@@ -239,6 +350,7 @@ class NetworkViewerPanel(QWidget):
 
     def _on_mat_loaded(self, data: MatData) -> None:
         self._mat_data = data
+        self._source = "mat"
         info = data.info
 
         self._info_fn.setText(str(info.get("FN", "—")))
@@ -252,17 +364,27 @@ class NetworkViewerPanel(QWidget):
             self._lag_combo.addItem(f"{data.lag_ms(key)} ms", userData=key)
         self._lag_combo.blockSignals(False)
 
-        # Populate node color metric dropdown (node SIZE is always ND)
+        metrics = sorted(data.available_node_metrics)
+
+        # Node SIZE metric — default to node degree (ND) if present, as in MATLAB
+        self._node_size_metric.blockSignals(True)
+        self._node_size_metric.clear()
+        self._node_size_metric.addItems(metrics)
+        if "ND" in metrics:
+            self._node_size_metric.setCurrentText("ND")
+        self._node_size_metric.blockSignals(False)
+
+        # Node COLOR metric (or None for flat cyan)
         self._node_color_metric.blockSignals(True)
         self._node_color_metric.clear()
         self._node_color_metric.addItem("None")
-        metrics = data.available_node_metrics
-        self._node_color_metric.addItems(sorted(metrics))
+        self._node_color_metric.addItems(metrics)
         self._node_color_metric.blockSignals(False)
 
         # Enable controls
         self._lag_combo.setEnabled(True)
         self._edge_thresh.setEnabled(True)
+        self._node_size_metric.setEnabled(True)
         self._node_color_metric.setEnabled(True)
         self._load_ct_btn.setEnabled(True)
 
@@ -280,8 +402,121 @@ class NetworkViewerPanel(QWidget):
         self._refresh_plot()
 
     def _on_settings_changed(self) -> None:
-        if self._mat_data is not None:
-            self._refresh_plot()
+        self._refresh_plot()
+
+    def _on_edge_thresh_method_changed(self) -> None:
+        """Reconfigure the threshold spinbox to match the selected method."""
+        self._edge_thresh.blockSignals(True)
+        if self._edge_thresh_method.currentText().startswith("Percentile"):
+            self._edge_thresh.setRange(0.0, 100.0)
+            self._edge_thresh.setDecimals(1)
+            self._edge_thresh.setSingleStep(5.0)
+            self._edge_thresh.setSuffix(" %")
+            self._edge_thresh.setValue(90.0)
+        else:  # Absolute value
+            self._edge_thresh.setRange(0.0, 1.0)
+            self._edge_thresh.setDecimals(3)
+            self._edge_thresh.setSingleStep(0.05)
+            self._edge_thresh.setSuffix("")
+            self._edge_thresh.setValue(0.0)
+        self._edge_thresh.blockSignals(False)
+        self._refresh_plot()
+
+    def _on_edge_width_changed(self, _value: float) -> None:
+        # Keep max ≥ min so edge widths never invert; then re-render.
+        if self._max_ew.value() < self._min_ew.value():
+            blocker = self._max_ew if self.sender() is self._min_ew else self._min_ew
+            blocker.blockSignals(True)
+            if self.sender() is self._min_ew:
+                self._max_ew.setValue(self._min_ew.value())
+            else:
+                self._min_ew.setValue(self._max_ew.value())
+            blocker.blockSignals(False)
+        self._refresh_plot()
+
+    def _on_save_plot(self) -> None:
+        # Suggest a filename from the current recording / example.
+        base_name = self._info_fn.text() if self._source == "mat" else "example_network"
+        safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in base_name).strip("_")
+        default = f"{safe or 'network'}.png"
+
+        path, selected = QFileDialog.getSaveFileName(
+            self, "Save network plot", default,
+            "PNG image (*.png);;SVG image (*.svg)",
+        )
+        if not path:
+            return
+
+        # Ensure the extension matches the chosen filter if the user omitted one.
+        ext = Path(path).suffix.lower()
+        if ext not in (".png", ".svg"):
+            ext = ".svg" if "svg" in selected.lower() else ".png"
+            path = str(Path(path).with_suffix(ext))
+
+        try:
+            self._canvas.save_figure(path, dpi=600)
+            self._log_msg(f"Saved plot to {path}"
+                          + (" (600 dpi)" if ext == ".png" else ""))
+        except Exception as exc:
+            self._log_msg(f"Save error: {exc}")
+
+    # ── Example network ─────────────────────────────────────────────────────────
+
+    def _load_example_network(self) -> None:
+        """Generate the built-in synthetic network and make it the active source."""
+        adjM, coords = make_example_network()
+        binar = (adjM > 0)
+        node_degree = binar.sum(axis=1).astype(float)
+        node_strength = adjM.sum(axis=1).astype(float)
+
+        self._example = {
+            "adjM": adjM,
+            "coords": coords,
+            "metrics": {
+                "node degree": node_degree,
+                "node strength": node_strength,
+            },
+            "ct_matrix": None,
+            "ct_names": None,
+            "min_node_size": 0.01,
+            "title": "Example synthetic network",
+        }
+        self._source = "example"
+        self._mat_data = None
+        self._mat_path.clear()
+
+        self._info_fn.setText("Example network")
+        self._info_div.setText("—")
+        self._info_grp.setText("—")
+
+        # Lag is meaningless for the example; disable it.
+        self._lag_combo.blockSignals(True)
+        self._lag_combo.clear()
+        self._lag_combo.blockSignals(False)
+        self._lag_combo.setEnabled(False)
+
+        metric_names = list(self._example["metrics"].keys())
+        self._node_size_metric.blockSignals(True)
+        self._node_size_metric.clear()
+        self._node_size_metric.addItems(metric_names)
+        self._node_size_metric.blockSignals(False)
+
+        self._node_color_metric.blockSignals(True)
+        self._node_color_metric.clear()
+        self._node_color_metric.addItem("None")
+        self._node_color_metric.addItems(metric_names)
+        self._node_color_metric.blockSignals(False)
+
+        self._edge_thresh.setEnabled(True)
+        self._node_size_metric.setEnabled(True)
+        self._node_color_metric.setEnabled(True)
+        # Cell types require channel numbers from a real recording.
+        self._load_ct_btn.setEnabled(False)
+        if self._cell_type_matrix is not None:
+            self._on_clear_cell_types()
+
+        self._log_msg("Loaded built-in example network — adjust the Display controls to explore.")
+        self._refresh_plot()
 
     def _on_load_cell_types(self) -> None:
         path, _ = QFileDialog.getOpenFileName(
@@ -340,63 +575,117 @@ class NetworkViewerPanel(QWidget):
     # ── Plot refresh ──────────────────────────────────────────────────────────
 
     def _refresh_plot(self) -> None:
+        """Build the current network (example or loaded file), apply the display
+        controls, and render. Shared by both data sources."""
+        if self._source == "mat":
+            base = self._mat_base()
+        else:
+            base = self._example_base()
+        if base is None:
+            return
+
+        metrics = base["metrics"]
+
+        # Node SIZE metric (falls back to node degree if the selection is gone)
+        size_name = self._node_size_metric.currentText()
+        z = metrics.get(size_name)
+        if z is None:
+            size_name = "ND" if "ND" in metrics else next(iter(metrics), None)
+            z = metrics.get(size_name) if size_name else None
+        if z is None:
+            self._log_msg("No node-size metric available for this network.")
+            return
+        z_name = "node degree" if size_name == "ND" else size_name
+
+        # Node COLOR metric (or None for flat cyan)
+        color_metric = self._node_color_metric.currentText()
+        z2 = metrics.get(color_metric) if color_metric != "None" else None
+
+        # Edge subsampling (plotting-only): cap to the strongest N edges, then
+        # derive the threshold on that limited matrix — mirrors PlotIndvNetMet.m.
+        max_edges = self._max_edges.value() or None
+        adjM = limit_edges_for_plotting(base["adjM"], max_edges)
+
+        method = self._edge_thresh_method.currentText()
+        thresh_val = self._edge_thresh.value()
+        is_percentile = method.startswith("Percentile")
+        edge_thresh = get_edge_threshold(
+            adjM,
+            method=method,
+            threshold=0.0 if is_percentile else thresh_val,
+            percentile=thresh_val if is_percentile else 90.0,
+        )
+
+        # Node layout (electrode coords, or derived from the limited topology)
+        coords = compute_node_coords(
+            adjM, base["coords"], self._layout_combo.currentText()
+        )
+
+        self._info_nodes.setText(str(len(adjM)))
+        self._info_edges.setText(str(count_edges_shown(adjM, edge_thresh)))
+
+        self._canvas.render(
+            adjM, coords, edge_thresh,
+            z, z2, color_metric,
+            base["ct_matrix"], base["ct_names"],
+            base["min_node_size"], base["title"],
+            z_name=z_name,
+            min_ew=self._min_ew.value(),
+            max_ew=self._max_ew.value(),
+            node_size_scale=self._node_scale.value(),
+            node_scaling_method=self._node_scaling_method.currentText(),
+        )
+
+    def _example_base(self) -> dict | None:
+        return self._example
+
+    def _mat_base(self) -> dict | None:
         data = self._mat_data
         if data is None or not data.lag_keys:
-            return
-
+            return None
         lag_key = self._lag_combo.currentData()
         if not lag_key:
-            return
-
-        edge_thresh = self._edge_thresh.value()
-        color_metric = self._node_color_metric.currentText()
+            return None
 
         adjM_full = data.get_adjM(lag_key)
         active_idx = data.get_active_indices(lag_key)
 
-        # Node SIZE is always ND (node degree)
-        z = data.get_metric(lag_key, "ND")
-        if z is None:
-            self._log_msg("ND metric not found in file.")
-            return
+        # All node-level metrics for this lag, aligned to active_idx order.
+        metrics = {
+            name: data.get_metric(lag_key, name)
+            for name in data.available_node_metrics
+        }
+        metrics = {k: v for k, v in metrics.items() if v is not None}
 
-        # Node COLOR is the user-selected metric (or None for flat cyan)
-        z2 = data.get_metric(lag_key, color_metric) if color_metric != "None" else None
-
-        # Build active cell-type matrix (rows correspond to active_idx)
+        # Cell-type overlay / intersection filter (rows correspond to active_idx)
         ct_matrix_active = None
         ct_names = self._cell_type_names
+        keep = np.arange(len(active_idx))
 
         if self._cell_type_matrix is not None and ct_names is not None:
             ct_matrix_active = self._cell_type_matrix[active_idx, :]
-
             selected = [item.text() for item in self._ct_list.selectedItems()]
             if selected:
-                filtered_idx, ct_matrix_active = filter_by_cell_types(
-                    np.arange(len(active_idx)),
-                    ct_matrix_active,
-                    ct_names,
-                    selected,
+                keep, ct_matrix_active = filter_by_cell_types(
+                    keep, ct_matrix_active, ct_names, selected,
                 )
-                active_idx = active_idx[filtered_idx]
-                z = z[filtered_idx]
-                if z2 is not None:
-                    z2 = z2[filtered_idx]
 
-        self._info_nodes.setText(str(len(active_idx)))
+        active_idx = active_idx[keep]
+        metrics = {name: arr[keep] for name, arr in metrics.items()}
 
         adjM_sub = adjM_full[np.ix_(active_idx, active_idx)]
         coords_sub = data.coords[active_idx]
-        min_node_size = float(data.params.get("minNodeSize", 0.01))
 
         fn = data.info.get("FN", "")
-        title = f"{fn}  —  {data.lag_ms(lag_key)} ms lag"
-
-        self._canvas.render(
-            adjM_sub, coords_sub, edge_thresh, z, z2, color_metric,
-            ct_matrix_active, ct_names,
-            min_node_size, title,
-        )
+        return {
+            "adjM": adjM_sub,
+            "coords": coords_sub,
+            "metrics": metrics,
+            "ct_matrix": ct_matrix_active,
+            "ct_names": ct_names,
+            "min_node_size": float(data.params.get("minNodeSize", 0.01)),
+            "title": f"{fn}  —  {data.lag_ms(lag_key)} ms lag",
+        }
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/src/meanap/network_plot.py
+++ b/src/meanap/network_plot.py
@@ -153,10 +153,251 @@ def filter_by_cell_types(
     return active_indices[keep], cell_type_matrix[keep, :]
 
 
+# ── Node layout ───────────────────────────────────────────────────────────────
+
+# User-facing layout names → the networkx layout used to compute coordinates.
+# "Original (electrodes)" keeps the MEA electrode coordinates untouched; the rest
+# mirror MATLAB's getNodeCoords / plotType='circular' options, computed here with
+# networkx instead of MATLAB's graph plot layouts.
+LAYOUT_OPTIONS = [
+    "Original (electrodes)",
+    "Circular",
+    "Spring (force)",
+    "Kamada-Kawai",
+    "Spectral",
+    "Shell",
+]
+
+
+def _rescale_to_box(pts: np.ndarray, ref: np.ndarray) -> np.ndarray:
+    """Uniformly scale/centre *pts* so they fill the bounding box of *ref*.
+
+    Layout algorithms return coordinates in an arbitrary range (typically
+    [-1, 1]). Node radii, edge widths and legend offsets in ``plot_network`` are
+    all expressed in data units tuned to the electrode-grid coordinate span, so
+    a raw [-1, 1] layout would render nodes the size of the whole plot. Fitting
+    every layout into the same box (preserving aspect ratio) keeps the visual
+    scale consistent no matter which layout is chosen.
+    """
+    pts = np.asarray(pts, dtype=float)
+    ref = np.asarray(ref, dtype=float)
+    ref_min, ref_max = ref.min(axis=0), ref.max(axis=0)
+    ref_span = ref_max - ref_min
+    ref_span[ref_span == 0] = 1.0
+
+    p_min, p_max = pts.min(axis=0), pts.max(axis=0)
+    p_span = p_max - p_min
+    p_span[p_span == 0] = 1.0
+
+    scale = float(np.min(ref_span / p_span))  # uniform → preserve aspect ratio
+    centred = (pts - (p_min + p_max) / 2) * scale
+    return centred + (ref_min + ref_max) / 2
+
+
+def compute_node_coords(
+    adjM: np.ndarray,
+    coords: np.ndarray,
+    layout: str = "Original (electrodes)",
+) -> np.ndarray:
+    """Return node coordinates for the chosen *layout*.
+
+    Python port of MATLAB's ``getNodeCoords`` (and the ``plotType='circular'``
+    branch of ``StandardisedNetworkPlot``). ``"Original (electrodes)"`` returns
+    the electrode coordinates unchanged; every other option derives positions
+    from the network topology using networkx, then rescales the result into the
+    electrode bounding box so node/edge/legend sizing stays consistent.
+    """
+    coords = np.asarray(coords, dtype=float)
+    if layout in ("Original (electrodes)", "Original", "MEA", None):
+        return coords
+
+    import networkx as nx
+
+    n = coords.shape[0]
+    A = np.abs(np.asarray(adjM, dtype=float)).copy()
+    np.fill_diagonal(A, 0.0)
+    A[~np.isfinite(A)] = 0.0
+    G = nx.from_numpy_array(A)
+    has_edges = G.number_of_edges() > 0
+
+    if layout == "Circular":
+        pos = nx.circular_layout(G)
+    elif layout == "Spring (force)":
+        pos = nx.spring_layout(G, weight="weight", seed=0)
+    elif layout == "Kamada-Kawai":
+        pos = nx.kamada_kawai_layout(G, weight="weight") if has_edges \
+            else nx.circular_layout(G)
+    elif layout == "Spectral":
+        pos = nx.spectral_layout(G, weight="weight")
+    elif layout == "Shell":
+        pos = nx.shell_layout(G)
+    else:
+        return coords
+
+    new = np.array([pos[i] for i in range(n)], dtype=float)
+    return _rescale_to_box(new, coords)
+
+
+# ── Example (synthetic) network ───────────────────────────────────────────────
+
+def make_example_network(
+    n_nodes: int = 40, grid: int = 8, seed: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Generate a synthetic MEA-like weighted network for the interactive demo.
+
+    Nodes are placed on a *grid* × *grid* electrode lattice; edge weights fall
+    off with inter-electrode distance (plus noise) so the result looks like a
+    real functional-connectivity matrix. Returns ``(adjM, coords)`` with the
+    weighted symmetric adjacency normalised to ``[0, 1]``.
+    """
+    rng = np.random.default_rng(seed)
+    gx, gy = np.meshgrid(np.arange(1, grid + 1), np.arange(1, grid + 1))
+    lattice = np.column_stack([gx.ravel(), gy.ravel()]).astype(float)
+    n = min(n_nodes, len(lattice))
+    coords = lattice[rng.choice(len(lattice), size=n, replace=False)]
+
+    d = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+    w = np.exp(-d / 2.5) * rng.uniform(0.2, 1.0, size=d.shape)
+    w = (w + w.T) / 2.0
+    np.fill_diagonal(w, 0.0)
+
+    nz = w[w > 0]
+    if nz.size:
+        w[w < np.quantile(nz, 0.82)] = 0.0  # keep the strongest ~18% of edges
+    if w.max() > 0:
+        w = w / w.max()
+    return w, coords
+
+
+# ── Edge subsampling / thresholding ───────────────────────────────────────────
+
+EDGE_THRESHOLD_METHODS = [
+    "Absolute value",
+    "Percentile",
+    "Percentile (nonzero edges)",
+]
+
+
+def limit_edges_for_plotting(
+    adjM: np.ndarray,
+    max_edges: int | None = None,
+    method: str = "HighToLow",
+) -> np.ndarray:
+    """Keep only the strongest *max_edges* edges, zeroing the rest.
+
+    Python port of MATLAB's ``limitEdgesForPlotting`` — a plotting-only
+    subsample so dense networks don't render as an unreadable hairball. The
+    ``HighToLow`` method keeps the ``max_edges`` edges with the largest absolute
+    weight. Node metrics are unaffected (this only changes which edges are drawn).
+
+    ``max_edges=None`` (or 0) returns a cleaned copy with no limiting.
+    """
+    A = np.asarray(adjM, dtype=float).copy()
+    A[~np.isfinite(A)] = 0.0
+    if not max_edges:  # None or 0 → unlimited
+        return A
+
+    n = A.shape[0]
+    np.fill_diagonal(A, 0.0)
+    is_undirected = np.allclose(A, A.T)
+    mask = np.triu(np.ones((n, n), dtype=bool), k=1) if is_undirected \
+        else ~np.eye(n, dtype=bool)
+
+    weights = A[mask]
+    valid = np.nonzero(weights != 0)[0]
+    out = np.zeros((n, n), dtype=float)
+    if valid.size == 0:
+        return out
+
+    if valid.size <= max_edges:
+        kept = valid
+    elif method.lower().replace("_", "").replace(" ", "") == "hightolow":
+        order = np.argsort(np.abs(weights[valid]))[::-1]  # strongest first
+        kept = valid[order[:max_edges]]
+    else:
+        raise ValueError(f"Unknown edge subsampling method: {method}")
+
+    filtered = np.zeros_like(weights)
+    filtered[kept] = weights[kept]
+    out[mask] = filtered
+    if is_undirected:
+        out = np.maximum(out, out.T)
+    out[~np.isfinite(out)] = 0.0
+    return out
+
+
+def get_edge_threshold(
+    adjM: np.ndarray,
+    method: str = "Absolute value",
+    threshold: float = 0.0,
+    percentile: float = 90.0,
+) -> float:
+    """Return the edge-weight threshold for plotting (port of ``getEdgeThreshold``).
+
+    - ``"Absolute value"`` returns *threshold* verbatim.
+    - ``"Percentile"`` returns the *percentile*-th percentile of ALL adjacency
+      entries (MATLAB's ``prctile(adjM(:), p)`` — zeros/diagonal included, so a
+      low percentile does nothing on a sparse matrix; kept for MATLAB parity).
+    - ``"Percentile (nonzero edges)"`` returns the *percentile*-th percentile of
+      only the actual (nonzero, finite, off-diagonal) edge weights, so e.g. 80
+      keeps the strongest ~20 % of edges — the intuitive behaviour.
+    """
+    A = np.asarray(adjM, dtype=float)
+    if method == "Percentile":
+        return float(np.percentile(A.ravel(), percentile))
+    if method == "Percentile (nonzero edges)":
+        n = A.shape[0]
+        offdiag = ~np.eye(n, dtype=bool)
+        w = A[offdiag]
+        w = w[np.isfinite(w) & (w != 0)]
+        if w.size == 0:
+            return 0.0
+        return float(np.percentile(w, percentile))
+    return float(threshold)
+
+
+def count_edges_shown(adjM: np.ndarray, edge_thresh: float) -> int:
+    """Number of undirected edges that will be drawn at *edge_thresh*."""
+    A = np.asarray(adjM, dtype=float)
+    n = A.shape[0]
+    mask = np.triu(np.ones((n, n), dtype=bool), k=1)
+    w = A[mask]
+    return int(np.count_nonzero(np.isfinite(w) & (w >= edge_thresh) & (w != 0)))
+
+
 # ── Network rendering ─────────────────────────────────────────────────────────
 
-def _get_node_size(z_i: float, node_scale_f: float, min_node_size: float = 0.01) -> float:
-    return max(min_node_size, z_i / node_scale_f)
+def _get_node_size(
+    z_i: float,
+    node_scale_f: float,
+    min_node_size: float = 0.01,
+    *,
+    method: str = "Linear",
+    power: float = 1.0,
+    size_mult: float = 1.0,
+) -> float:
+    """Map a per-node metric value to a node radius-driving size.
+
+    Port of MATLAB's ``getNodeSize``: the scaling *method* (Linear / Log2 /
+    Log10 / Square / Cube / Power) reshapes how ``z_i`` maps onto ``[0, 1]``
+    relative to ``node_scale_f``, and *size_mult* is a final user-facing
+    multiplier (MATLAB's ``maxNodeSize``) for making every node bigger/smaller.
+    """
+    nsf = max(float(node_scale_f), 1e-9)
+    zi = max(float(z_i), 0.0)
+    if method == "Log2":
+        base = np.log2(zi + 1) / np.log2(nsf + 1)
+    elif method == "Log10":
+        base = np.log10(zi + 1) / np.log10(nsf + 1)
+    elif method == "Square":
+        base = (zi ** 2) / (nsf ** 2)
+    elif method == "Cube":
+        base = (zi ** 3) / (nsf ** 3)
+    elif method == "Power":
+        base = (zi ** power) / (nsf ** power)
+    else:  # Linear
+        base = zi / nsf
+    return max(min_node_size, size_mult * float(base))
 
 
 def plot_network(
@@ -175,6 +416,11 @@ def plot_network(
     z_scale_override: float | None = None,
     z2_bounds_override: tuple[float, float] | None = None,
     edge_bounds_override: tuple[float, float] | None = None,
+    min_ew: float = 0.001,
+    max_ew: float = 4.0,
+    node_size_scale: float = 1.0,
+    node_scaling_method: str = "Linear",
+    node_scaling_power: float = 1.0,
 ) -> None:
     """Render the MEA network onto *ax*.
 
@@ -207,6 +453,15 @@ def plot_network(
     edge_bounds_override : if given, ``(min, max)`` for edge-weight width/shade
         scaling instead of this recording's own nonzero-edge range. MATLAB
         fixes this to ``EW = [0.1, 1]`` for the scaled variants.
+    min_ew, max_ew : minimum / maximum edge line width in points. The strongest
+        edge is drawn at ``max_ew`` and the weakest at ``min_ew`` (MATLAB
+        defaults: 4.0 / 0.001 for the MEA plot type). User-adjustable in the
+        interactive viewer.
+    node_size_scale : final multiplier applied to every node size (MATLAB's
+        ``maxNodeSize``); 1.0 reproduces the original scaling, >1 enlarges nodes.
+    node_scaling_method : one of Linear / Log2 / Log10 / Square / Cube / Power —
+        how ``z`` maps onto node size (MATLAB ``nodeScalingMethod``).
+    node_scaling_power : exponent used when ``node_scaling_method == "Power"``.
     """
     import matplotlib
     import matplotlib.patches as mpatches
@@ -260,9 +515,15 @@ def plot_network(
 
     default_node_color = (0.020, 0.729, 0.859)
 
+    # ── Node-size helper (captures scaling config) ─────────────────────────────
+    def node_size_of(z_i: float) -> float:
+        return _get_node_size(
+            z_i, node_scale_f, min_node_size,
+            method=node_scaling_method, power=node_scaling_power,
+            size_mult=node_size_scale,
+        )
+
     # ── Edges ─────────────────────────────────────────────────────────────────
-    max_ew = 4.0
-    min_ew = 0.001
     light_c = np.array([0.8, 0.8, 0.8])
 
     if edge_bounds_override is not None:
@@ -336,7 +597,7 @@ def plot_network(
         if zi <= 0:
             continue
 
-        node_size = _get_node_size(zi, node_scale_f, min_node_size)
+        node_size = node_size_of(zi)
         fc = node_facecolor(i)
         outer_patches.append(mpatches.Circle(
             (xc[i], yc[i]), node_size / 2,
@@ -387,7 +648,7 @@ def plot_network(
         leg_label = lambda v: f"{v:.4f}"
     leg_y = y_max - 0.5
     for lv in leg_vals:
-        ls = _get_node_size(lv, node_scale_f, min_node_size)
+        ls = node_size_of(lv)
         circ = mpatches.Circle(
             (legend_x + 0.5, leg_y - ls / 2),
             ls / 2,
@@ -434,7 +695,7 @@ def plot_network(
         leg_y_ct = y_min - 0.8
         n_ct = len(cell_type_names)
         ct_x_positions = np.linspace(x_min, x_max, n_ct) if n_ct > 1 else [x_min]
-        leg_node_size = _get_node_size(leg_vals[1], node_scale_f, min_node_size)
+        leg_node_size = node_size_of(leg_vals[1])
         ct_sizes = np.linspace(0.9, 0.3, n_ct) * leg_node_size
 
         for k, ct_name in enumerate(cell_type_names):


### PR DESCRIPTION
… save

Extend the PyQt6 Network Viewer tab into a live-updating, tunable network plot, and port the remaining StandardisedNetworkPlot display features.

network_plot.py:
- min_ew/max_ew, node_size_scale, and node_scaling_method (Linear/Log2/ Log10/Square/Cube/Power) as parameters (port of getNodeSize.m)
- compute_node_coords(): Original/Circular/Spring/Kamada-Kawai/Spectral/ Shell layouts via networkx, rescaled to the electrode box (port of getNodeCoords.m)
- make_example_network(): built-in synthetic network for the demo
- limit_edges_for_plotting() (port of limitEdgesForPlotting.m, HighToLow), get_edge_threshold() (port of getEdgeThreshold.m; Absolute value, Percentile [MATLAB-faithful], and Percentile-of-nonzero-edges), and count_edges_shown()

network_viewer.py:
- loads the example network on launch so controls work with no file
- Display group: node layout, node size scale, node scaling, min/max edge width, max edges, and a Save plot button (PNG @ 600 dpi or SVG)
- selectable node size metric; edge-threshold method with a reconfiguring spinbox; live "Edges shown" readout
- unified render path shared by example and loaded-.mat sources

docs: document all of the above in docs/python/network-viewer.md


Claude-Session: https://claude.ai/code/session_0196FdEu14tgcbj1fhCdTHQL