### PR TITLE
feat(python): guided GUI tutorial + drop vestigial MEA-NAP folder

### DIFF
--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -9,7 +9,7 @@ from PyQt6.QtWidgets import (
     QTabWidget, QToolBar, QWidget,
 )
 from PyQt6.QtGui import QAction
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QSettings
 
 from meanap.params import Params
 from meanap.pipeline.example_data import download_example_data
@@ -25,6 +25,7 @@ from meanap.gui.panels.stim_preview import StimPreviewPanel
 from meanap.gui.panels.pipeline import PipelinePanel
 from meanap.gui.panels.catnap import CatNapPanel
 from meanap.gui.panels.network_viewer import NetworkViewerPanel
+from meanap.gui.tutorial import TutorialOverlay, TutorialStep, tabbar_target
 
 
 def _scrollable(widget: QWidget) -> QScrollArea:
@@ -45,10 +46,12 @@ class MainWindow(QMainWindow):
         self._last_output_root: Path | None = None
         self._current_theme = "dark"
         self._worker: PipelineWorker | None = None
+        self._tutorial: TutorialOverlay | None = None
 
         self._build_toolbar()
         self._build_tabs()
         self._load_params(self._params)
+        self._maybe_show_tutorial_on_first_launch()
 
     # ── UI construction ───────────────────────────────────────────────────────
 
@@ -74,12 +77,17 @@ class MainWindow(QMainWindow):
         self._act_theme.setToolTip("Toggle light / dark theme")
         self._act_theme.triggered.connect(self._on_toggle_theme)
 
+        act_tutorial = QAction("?  Tutorial", self)
+        act_tutorial.setToolTip("Launch the guided tutorial")
+        act_tutorial.triggered.connect(self._start_tutorial)
+
         tb.addAction(act_new)
         tb.addSeparator()
         tb.addAction(act_open)
         tb.addAction(act_save)
         tb.addSeparator()
         tb.addAction(self._act_theme)
+        tb.addAction(act_tutorial)
 
     def _build_tabs(self) -> None:
         self._tabs = QTabWidget()
@@ -96,14 +104,14 @@ class MainWindow(QMainWindow):
         self._pipeline_panel = PipelinePanel()
         self._network_viewer_panel = NetworkViewerPanel()
 
-        self._tabs.addTab(_scrollable(self._paths_panel), "  Paths  ")
-        self._tabs.addTab(_scrollable(self._recording_panel), "  Recording  ")
-        self._tabs.addTab(_scrollable(self._spike_panel), "  Spike detection  ")
-        self._tabs.addTab(_scrollable(self._connectivity_panel), "  Connectivity  ")
-        self._tabs.addTab(_scrollable(self._stim_panel), "  Stimulation  ")
-        self._tabs.addTab(self._stim_preview_panel, "  Stim Preview  ")
-        self._tabs.addTab(self._catnap_panel, "  CAT-NAP (2P)  ")
-        self._tabs.addTab(self._network_viewer_panel, "  Network Viewer  ")
+        self._tab_paths = self._tabs.addTab(_scrollable(self._paths_panel), "  Paths  ")
+        self._tab_recording = self._tabs.addTab(_scrollable(self._recording_panel), "  Recording  ")
+        self._tab_spike = self._tabs.addTab(_scrollable(self._spike_panel), "  Spike detection  ")
+        self._tab_connectivity = self._tabs.addTab(_scrollable(self._connectivity_panel), "  Connectivity  ")
+        self._tab_stim = self._tabs.addTab(_scrollable(self._stim_panel), "  Stimulation  ")
+        self._tab_stim_preview = self._tabs.addTab(self._stim_preview_panel, "  Stim Preview  ")
+        self._tab_catnap = self._tabs.addTab(self._catnap_panel, "  CAT-NAP (2P)  ")
+        self._tab_network = self._tabs.addTab(self._network_viewer_panel, "  Network Viewer  ")
         self._pipeline_tab_index = self._tabs.addTab(_scrollable(self._pipeline_panel), "  Pipeline  ")
 
         self._catnap_panel.log_message.connect(self._pipeline_panel.append_log)
@@ -125,6 +133,162 @@ class MainWindow(QMainWindow):
         # Secondary-style buttons in CAT-NAP panel
         self._catnap_panel._scan_btn.setObjectName("secondary")
         self._catnap_panel._denoise_btn.setObjectName("secondary")
+
+    # ── Tutorial ──────────────────────────────────────────────────────────────
+
+    def _maybe_show_tutorial_on_first_launch(self) -> None:
+        settings = QSettings("SAND Lab", "MEA-NAP")
+        if not settings.value("tutorial/seen", False, type=bool):
+            self._start_tutorial()
+
+    def _start_tutorial(self) -> None:
+        if self._tutorial is None:
+            self._tutorial = TutorialOverlay(self, self._tabs)
+            self._tutorial.pipeline_chosen.connect(self._on_pipeline_chosen)
+            self._tutorial.finished.connect(self._on_tutorial_finished)
+        self._tutorial.start()
+
+    def _on_pipeline_chosen(self, kind: str) -> None:
+        builders = {
+            "meanap": self._build_meanap_steps,
+            "meastim": self._build_meastim_steps,
+            "catnap": self._build_catnap_steps,
+        }
+        steps = builders[kind]()
+        assert self._tutorial is not None
+        self._tutorial.set_steps(steps)
+        self._tutorial.begin_steps()
+
+    def _on_tutorial_finished(self) -> None:
+        QSettings("SAND Lab", "MEA-NAP").setValue("tutorial/seen", True)
+
+    def _build_meanap_steps(self) -> list[TutorialStep]:
+        paths = self._paths_panel
+        rec = self._recording_panel
+        spike = self._spike_panel
+        conn = self._connectivity_panel
+        pipe = self._pipeline_panel
+        return [
+            TutorialStep(
+                "Raw data folder", "The MEA-NAP pipeline starts on the Paths tab. "
+                "First, choose the folder holding your recordings "
+                "(.mat files, one per recording).",
+                self._tab_paths, lambda: paths.raw_data),
+            TutorialStep(
+                "Recording spreadsheet", "Select the CSV/XLSX that lists each recording, "
+                "its group and its age (DIV). This drives the whole batch.",
+                self._tab_paths, lambda: paths.spreadsheet),
+            TutorialStep(
+                "Spreadsheet range", "The cell range to read from the spreadsheet, "
+                "e.g. A2:A100000 to read every row after the header.",
+                self._tab_paths, lambda: paths.spreadsheet_range),
+            TutorialStep(
+                "Where results go", "Set the output folder and give this analysis run "
+                "a name — a subfolder with that name will hold all results and plots.",
+                self._tab_paths, lambda: paths.output_data_folder),
+            TutorialStep(
+                "Recording settings", "On the Recording tab, set the sampling frequency "
+                "of your acquisition (Hz) so spike detection and downsampling are correct.",
+                self._tab_recording, lambda: rec.fs),
+            TutorialStep(
+                "Channel layout", "Pick the MEA layout that matches your hardware "
+                "(MCS60, Axion64, …). This maps channels to electrode positions.",
+                self._tab_recording, lambda: rec.channel_layout),
+            TutorialStep(
+                "Spike detection", "Step 1 detects spikes. Leave 'Detect spikes' ticked "
+                "for a fresh run; untick it if you already have detected spike data.",
+                self._tab_spike, lambda: spike.detect_spikes),
+            TutorialStep(
+                "Detection thresholds", "These MAD multipliers set how far below the "
+                "median a deflection must go to count as a spike. 3, 4, 5 is a good start.",
+                self._tab_spike, lambda: spike.thresholds),
+            TutorialStep(
+                "Connectivity lags", "Step 3 builds functional networks with the spike "
+                "time tiling coefficient. These lag values (ms) set the coincidence window.",
+                self._tab_connectivity, lambda: conn.lag_vals),
+            TutorialStep(
+                "Choose the steps", "On the Pipeline tab, pick which steps to run "
+                "(1–4). The default runs the whole pipeline end to end.",
+                self._pipeline_tab_index, lambda: pipe.start_step),
+            TutorialStep(
+                "Try it first", "Not sure your setup works? 'Test pipeline' downloads a "
+                "small example dataset and runs all four steps on it.",
+                self._pipeline_tab_index, lambda: pipe.test_btn),
+            TutorialStep(
+                "Run the pipeline", "When your paths are filled in, press Run. Progress "
+                "appears in the status log, and 'View report' opens the results in your browser.",
+                self._pipeline_tab_index, lambda: pipe.run_btn),
+        ]
+
+    def _build_meastim_steps(self) -> list[TutorialStep]:
+        paths = self._paths_panel
+        stim = self._stim_panel
+        pipe = self._pipeline_panel
+        return [
+            TutorialStep(
+                "Raw data folder", "MEA-Stim reuses the same Paths tab. Start by choosing "
+                "the folder with your stimulation recordings.",
+                self._tab_paths, lambda: paths.raw_data),
+            TutorialStep(
+                "Recording spreadsheet", "Select the CSV/XLSX listing each recording, "
+                "its group and DIV.",
+                self._tab_paths, lambda: paths.spreadsheet),
+            TutorialStep(
+                "Where results go", "Set the output folder and a name for this run's "
+                "results subfolder.",
+                self._tab_paths, lambda: paths.output_data_folder),
+            TutorialStep(
+                "Turn on MEA-Stim", "On the Stimulation tab, tick this to run the "
+                "stimulation analysis after spike detection.",
+                self._tab_stim, lambda: stim.stim_mode),
+            TutorialStep(
+                "Detection method", "Choose how stimulation artefacts are found. "
+                "'longblank' and 'blanking' suit blanked recordings; the threshold "
+                "methods detect by amplitude; 'axionStimEvents' reads an Axion CSV.",
+                self._tab_stim, lambda: stim.method),
+            TutorialStep(
+                "Analysis window", "Set the window around each stimulus (seconds) over "
+                "which evoked responses are measured — e.g. −0.03 to 0.03 s.",
+                self._tab_stim, lambda: stim.win_start),
+            TutorialStep(
+                "Significance test", "Responses are tested against shuffled surrogates. "
+                "More shuffles give a tighter p-value but take longer; 500 is a good default.",
+                self._tab_stim, lambda: stim.n_shuffles),
+            TutorialStep(
+                "Preview detection", "The Stim Preview tab lets you check the detected "
+                "stimulus times on an example recording before running the full batch.",
+                self._tab_stim_preview, tabbar_target(self._tabs, self._tab_stim_preview)),
+            TutorialStep(
+                "Run the pipeline", "On the Pipeline tab, press Run. Spike detection runs "
+                "first, then the stimulation analysis and its plots.",
+                self._pipeline_tab_index, lambda: pipe.run_btn),
+        ]
+
+    def _build_catnap_steps(self) -> list[TutorialStep]:
+        cat = self._catnap_panel
+        pipe = self._pipeline_panel
+        return [
+            TutorialStep(
+                "Turn on CAT-NAP", "CAT-NAP analyses two-photon calcium imaging. On the "
+                "CAT-NAP tab, tick this to analyse suite2p output instead of MEA data.",
+                self._tab_catnap, lambda: cat._suite2p_mode),
+            TutorialStep(
+                "suite2p folder", "Point this to the parent folder containing your "
+                "suite2p output (the plane0 folders live beneath it).",
+                self._tab_catnap, lambda: cat._folder_edit),
+            TutorialStep(
+                "Scan for recordings", "Press this to find every suite2p recording under "
+                "that folder. Select one to preview its traces.",
+                self._tab_catnap, lambda: cat._scan_btn),
+            TutorialStep(
+                "Denoising", "Optionally denoise the fluorescence traces before analysis. "
+                "The threshold multiplier and peak windows control event extraction.",
+                self._tab_catnap, lambda: cat._denoise_btn),
+            TutorialStep(
+                "Run the pipeline", "With CAT-NAP mode on and a folder selected, go to "
+                "the Pipeline tab and press Run to analyse the imaging data.",
+                self._pipeline_tab_index, lambda: pipe.run_btn),
+        ]
 
     # ── Param sync ────────────────────────────────────────────────────────────
 
@@ -199,14 +363,12 @@ class MainWindow(QMainWindow):
     # ── Pipeline run / stop ───────────────────────────────────────────────────
 
     def _on_test_pipeline(self) -> None:
-        home_dir = self._paths_panel.home_dir.value
-        if not home_dir:
-            QMessageBox.warning(
-                self, "MEA-NAP folder required",
-                "Please set the MEA-NAP folder (Paths tab) before testing the pipeline.",
-            )
-            self._tabs.setCurrentIndex(0)
-            return
+        # The test run needs somewhere to put the example data and its output.
+        # Default the output folder to ~/MEA-NAP when it hasn't been set.
+        out_folder = self._paths_panel.output_data_folder.value
+        if not out_folder:
+            out_folder = str(Path.home() / "MEA-NAP")
+            self._paths_panel.output_data_folder.set_value(out_folder)
 
         self._tabs.setCurrentIndex(self._pipeline_tab_index)
         self._pipeline_panel.append_log("Downloading example data for pipeline test…")
@@ -217,7 +379,7 @@ class MainWindow(QMainWindow):
             QApplication.processEvents()
 
         try:
-            example_dir = download_example_data(Path(home_dir), log=log)
+            example_dir = download_example_data(Path(out_folder), log=log)
         except Exception as e:
             QMessageBox.critical(self, "Download failed", str(e))
             return
@@ -236,9 +398,6 @@ class MainWindow(QMainWindow):
         except Exception as e:
             log(f"Warning: could not parse custom group order from exampleData.csv: {e}")
 
-        if not self._paths_panel.output_data_folder.value:
-            self._paths_panel.output_data_folder.set_value(home_dir)
-
         # The test run verifies that the full pipeline (steps 1-4) works.
         self._pipeline_panel.start_step.setValue(1)
         self._pipeline_panel.stop_step.setValue(4)
@@ -254,8 +413,6 @@ class MainWindow(QMainWindow):
         self._params = params
 
         missing = []
-        if not params.home_dir:
-            missing.append("MEA-NAP folder")
         if not params.raw_data and not params.prior_analysis:
             missing.append("Raw data folder")
         if not params.output_data_folder:

--- a/src/meanap/gui/panels/paths.py
+++ b/src/meanap/gui/panels/paths.py
@@ -66,7 +66,6 @@ class PathsPanel(QWidget):
         form = QFormLayout(input_box)
         form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
 
-        self.home_dir = PathRow(self)
         self.raw_data = PathRow(self)
         self.spreadsheet = PathRow(self, is_file=True, file_filter="Spreadsheets (*.csv *.xlsx *.xls)")
         self.spreadsheet_range = QLineEdit("A2:A100000")
@@ -74,7 +73,6 @@ class PathsPanel(QWidget):
         self.custom_grp_order = QLineEdit()
         self.custom_grp_order.setToolTip("Comma-separated list of group names (e.g. 'WT,KO')")
 
-        form.addRow("MEA-NAP folder", self.home_dir)
         form.addRow("Raw data folder", self.raw_data)
         form.addRow("Spreadsheet file", self.spreadsheet)
         form.addRow("Spreadsheet range", self.spreadsheet_range)
@@ -106,7 +104,6 @@ class PathsPanel(QWidget):
         layout.addStretch()
 
     def load(self, params: Params) -> None:
-        self.home_dir.set_value(params.home_dir)
         self.raw_data.set_value(params.raw_data)
         self.spreadsheet.set_value(params.spreadsheet_file_name)
         self.spreadsheet_range.setText(params.spreadsheet_range)
@@ -117,7 +114,6 @@ class PathsPanel(QWidget):
         self.prior_analysis_path.set_value(params.prior_analysis_path)
 
     def save(self, params: Params) -> None:
-        params.home_dir = self.home_dir.value
         params.raw_data = self.raw_data.value
         params.spreadsheet_file_name = self.spreadsheet.value
         params.spreadsheet_range = self.spreadsheet_range.text()

--- a/src/meanap/gui/tutorial.py
+++ b/src/meanap/gui/tutorial.py
@@ -1,0 +1,399 @@
+"""Guided coach-mark tutorial for the MEA-NAP GUI.
+
+The tutorial dims the whole window and highlights one real tab/field at a
+time, walking the user through every required setting for the pipeline they
+pick (MEA-NAP, MEA-Stim or CAT-NAP) and landing them on the Pipeline tab
+ready to run. The dimming scrim is purely visual: the highlighted field stays
+fully interactive so users fill in real values as they go.
+
+``TutorialOverlay`` is generic — it consumes a list of :class:`TutorialStep`.
+The step lists themselves live in ``main_window`` where the panel widgets are
+in scope (see ``MainWindow._build_*_steps``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Union
+
+from PyQt6.QtCore import QEvent, QPoint, QRect, Qt, QTimer, pyqtSignal
+from PyQt6.QtGui import QColor, QPainter, QPen, QRegion
+from PyQt6.QtWidgets import (
+    QApplication, QFrame, QHBoxLayout, QLabel, QMainWindow, QPushButton,
+    QScrollArea, QTabWidget, QVBoxLayout, QWidget,
+)
+
+ACCENT = "#4f8ef7"
+
+# A step's target is resolved lazily (after the tab switch) and may be a live
+# widget, a global-coordinate QRect (e.g. a tab-bar tab), or None (centred).
+TargetT = Callable[[], Union[QWidget, QRect, None]]
+
+
+@dataclass
+class TutorialStep:
+    """One coach-mark: switch to *tab_index*, highlight *target*, show text."""
+
+    title: str
+    body: str
+    tab_index: Optional[int] = None
+    target: Optional[TargetT] = None
+
+
+def tabbar_target(tabs: QTabWidget, index: int) -> TargetT:
+    """A target that highlights tab *index* in the tab bar."""
+
+    def resolve() -> QRect:
+        bar = tabs.tabBar()
+        r = bar.tabRect(index)
+        return QRect(bar.mapToGlobal(r.topLeft()), r.size())
+
+    return resolve
+
+
+class TutorialOverlay(QWidget):
+    """Full-window dimming overlay that steps through a list of coach-marks."""
+
+    pipeline_chosen = pyqtSignal(str)  # "meanap" | "meastim" | "catnap"
+    finished = pyqtSignal()
+
+    def __init__(self, host: QMainWindow, tabs: QTabWidget) -> None:
+        super().__init__(host)
+        self._host = host
+        self._tabs = tabs
+        self._steps: list[TutorialStep] = []
+        self._index = 0
+        self._mode = "idle"  # "chooser" | "steps"
+        self._highlight = QRect()
+        self._busy = False
+
+        # Interaction is controlled with a mask (see _update_mask): the
+        # highlighted field is a real hole so clicks reach it, the bubble stays
+        # solid so its buttons work, and the dimmed scrim blocks everything
+        # else. WA_TransparentForMouseEvents is NOT used — it would make Qt skip
+        # the overlay *and its children*, leaving the bubble buttons dead.
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+
+        self._bubble = QFrame(self)
+        self._bubble.setObjectName("tutorialBubble")
+        self._bubble.setStyleSheet(
+            "#tutorialBubble {"
+            "  background-color: #2d323b;"
+            f"  border: 1px solid {ACCENT};"
+            "  border-radius: 10px;"
+            "}"
+            "#tutorialBubble QLabel { color: #f2f4f8; background: transparent; }"
+            "#tutorialBubble QLabel#tutTitle { font-size: 14px; font-weight: 700; }"
+            "#tutorialBubble QLabel#tutBody  { font-size: 12px; }"
+            "#tutorialBubble QLabel#tutCount { color: #9aa4b2; font-size: 11px; }"
+            "#tutorialBubble QPushButton {"
+            "  padding: 6px 14px; border-radius: 6px; font-weight: 600;"
+            "  color: #f2f4f8; background-color: #3a414c; border: none;"
+            "}"
+            "#tutorialBubble QPushButton:hover { background-color: #464e5b; }"
+            f"#tutorialBubble QPushButton#tutPrimary {{ background-color: {ACCENT}; color: white; }}"
+            "#tutorialBubble QPushButton#tutPrimary:hover { background-color: #3a7de0; }"
+            "#tutorialBubble QPushButton#tutLink {"
+            "  background: transparent; color: #9aa4b2; font-weight: 500; padding: 6px 6px;"
+            "}"
+            "#tutorialBubble QPushButton#tutLink:hover { color: #f2f4f8; }"
+        )
+
+        host.installEventFilter(self)
+        self.hide()
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Show the pipeline chooser and begin the tutorial."""
+        self._mode = "chooser"
+        self._highlight = QRect()
+        self.setGeometry(self._host.rect())
+        self.show()
+        self.raise_()
+        self._render_chooser()
+        self.update()
+
+    def set_steps(self, steps: list[TutorialStep]) -> None:
+        self._steps = steps
+
+    def begin_steps(self) -> None:
+        self._mode = "steps"
+        self._index = 0
+        self._show_step()
+
+    # ── Chooser screen ────────────────────────────────────────────────────────
+
+    def _render_chooser(self) -> None:
+        self._clear_bubble()
+        lay = QVBoxLayout(self._bubble)
+        lay.setContentsMargins(22, 20, 22, 18)
+        lay.setSpacing(10)
+
+        title = QLabel("Welcome to MEA-NAP")
+        title.setObjectName("tutTitle")
+        subtitle = QLabel("Which analysis would you like to run? "
+                          "The tutorial will guide you through the settings it needs.")
+        subtitle.setObjectName("tutBody")
+        subtitle.setWordWrap(True)
+        lay.addWidget(title)
+        lay.addWidget(subtitle)
+        lay.addSpacing(4)
+
+        for kind, heading, blurb in (
+            ("meanap", "MEA-NAP  ·  Main pipeline",
+             "Spike detection → activity → connectivity → network analysis for MEA recordings."),
+            ("meastim", "MEA-Stim  ·  Stimulation pipeline",
+             "Detect electrical-stimulation artefacts and analyse evoked responses."),
+            ("catnap", "CAT-NAP  ·  Imaging pipeline",
+             "Analyse two-photon calcium imaging processed with suite2p."),
+        ):
+            btn = QPushButton(f"{heading}\n{blurb}")
+            btn.setObjectName("tutPrimary" if kind == "meanap" else "")
+            btn.setStyleSheet("text-align: left; padding: 10px 14px;")
+            btn.clicked.connect(lambda _=False, k=kind: self._choose(k))
+            lay.addWidget(btn)
+
+        skip = QPushButton("Skip the tour")
+        skip.setObjectName("tutLink")
+        skip.clicked.connect(self._finish)
+        row = QHBoxLayout()
+        row.addStretch()
+        row.addWidget(skip)
+        lay.addLayout(row)
+
+        self._finalize_bubble(560)
+
+    def _choose(self, kind: str) -> None:
+        self.pipeline_chosen.emit(kind)
+
+    # ── Step screens ──────────────────────────────────────────────────────────
+
+    def _show_step(self) -> None:
+        if not (0 <= self._index < len(self._steps)):
+            self._finish()
+            return
+        step = self._steps[self._index]
+
+        self._busy = True
+        if step.tab_index is not None:
+            self._tabs.setCurrentIndex(step.tab_index)
+        QApplication.processEvents()
+
+        # Scroll the target into view inside a scrollable tab, then settle.
+        target_widget = None
+        if step.target is not None:
+            resolved = step.target()
+            if isinstance(resolved, QWidget):
+                target_widget = resolved
+        if target_widget is not None:
+            self._reveal(target_widget)
+            QApplication.processEvents()
+        self._busy = False
+
+        self._highlight = self._resolve_highlight(step)
+        self._update_mask()  # cut the hole now; the bubble is added once shown
+        self._render_step(step)
+        self.raise_()
+        self.update()
+
+    def _render_step(self, step: TutorialStep) -> None:
+        self._clear_bubble()
+        lay = QVBoxLayout(self._bubble)
+        lay.setContentsMargins(18, 16, 18, 14)
+        lay.setSpacing(8)
+
+        title = QLabel(step.title)
+        title.setObjectName("tutTitle")
+        body = QLabel(step.body)
+        body.setObjectName("tutBody")
+        body.setWordWrap(True)
+        lay.addWidget(title)
+        lay.addWidget(body)
+
+        footer = QHBoxLayout()
+        count = QLabel(f"{self._index + 1} / {len(self._steps)}")
+        count.setObjectName("tutCount")
+        footer.addWidget(count)
+        footer.addStretch()
+
+        skip = QPushButton("Exit")
+        skip.setObjectName("tutLink")
+        skip.clicked.connect(self._finish)
+        footer.addWidget(skip)
+
+        if self._index > 0:
+            back = QPushButton("Back")
+            back.clicked.connect(self._back)
+            footer.addWidget(back)
+
+        is_last = self._index == len(self._steps) - 1
+        nxt = QPushButton("Finish" if is_last else "Next")
+        nxt.setObjectName("tutPrimary")
+        nxt.clicked.connect(self._finish if is_last else self._next)
+        footer.addWidget(nxt)
+
+        lay.addLayout(footer)
+
+        self._finalize_bubble(380)
+
+    def _next(self) -> None:
+        self._index += 1
+        self._show_step()
+
+    def _back(self) -> None:
+        self._index -= 1
+        self._show_step()
+
+    def _finish(self) -> None:
+        self.hide()
+        self._mode = "idle"
+        self.finished.emit()
+
+    # ── Geometry helpers ──────────────────────────────────────────────────────
+
+    def _reveal(self, w: QWidget) -> None:
+        area = self._tabs.currentWidget()
+        if isinstance(area, QScrollArea):
+            area.ensureWidgetVisible(w, 60, 60)
+
+    def _resolve_highlight(self, step: TutorialStep) -> QRect:
+        if step.target is None:
+            return QRect()
+        t = step.target()
+        if t is None:
+            return QRect()
+        if isinstance(t, QRect):
+            g = t
+        else:
+            if not t.isVisible():
+                return QRect()
+            g = QRect(t.mapToGlobal(QPoint(0, 0)), t.size())
+        return QRect(self.mapFromGlobal(g.topLeft()), g.size())
+
+    def _position_bubble(self) -> None:
+        margin = 16
+        bw = self._bubble.width()
+        bh = self._bubble.height()
+        W, H = self.width(), self.height()
+
+        if self._highlight.isNull():
+            x = (W - bw) // 2
+            y = (H - bh) // 2
+        else:
+            h = self._highlight
+            # Prefer below the highlight, else above, else centred vertically.
+            if h.bottom() + 12 + bh + margin <= H:
+                y = h.bottom() + 12
+            elif h.top() - 12 - bh >= margin:
+                y = h.top() - 12 - bh
+            else:
+                y = (H - bh) // 2
+            x = h.left()
+            x = max(margin, min(x, W - bw - margin))
+            y = max(margin, min(y, H - bh - margin))
+        self._bubble.move(x, y)
+
+    def _reposition(self) -> None:
+        """Recompute geometry after a resize while a screen is showing."""
+        if not self.isVisible():
+            return
+        self.setGeometry(self._host.rect())
+        if self._mode == "steps" and 0 <= self._index < len(self._steps):
+            self._highlight = self._resolve_highlight(self._steps[self._index])
+        self._position_bubble()
+        self._update_mask()
+        self.update()
+
+    def _update_mask(self) -> None:
+        """Cut a real hole for the highlighted field so clicks reach it, while
+        keeping the bubble and scrim solid. Without this the opaque overlay
+        would swallow every click."""
+        region = QRegion(self.rect())
+        if not self._highlight.isNull():
+            region = region.subtracted(QRegion(self._highlight))
+        if self._bubble.isVisible():
+            region = region.united(QRegion(self._bubble.geometry()))
+        self.setMask(region)
+
+    # ── Painting ──────────────────────────────────────────────────────────────
+
+    def paintEvent(self, _event) -> None:
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing)
+        scrim = QColor(0, 0, 0, 150)
+        W, H = self.width(), self.height()
+
+        if self._highlight.isNull():
+            p.fillRect(0, 0, W, H, scrim)
+            return
+
+        h = self._highlight.adjusted(-6, -6, 6, 6)
+        hx = max(0, h.x())
+        hy = max(0, h.y())
+        hr = min(W, h.x() + h.width())
+        hb = min(H, h.y() + h.height())
+
+        # Four bands around the hole (leaves the target fully visible).
+        p.fillRect(0, 0, W, hy, scrim)                 # top
+        p.fillRect(0, hb, W, H - hb, scrim)            # bottom
+        p.fillRect(0, hy, hx, hb - hy, scrim)          # left
+        p.fillRect(hr, hy, W - hr, hb - hy, scrim)     # right
+
+        pen = QPen(QColor(ACCENT))
+        pen.setWidth(2)
+        p.setPen(pen)
+        p.setBrush(Qt.BrushStyle.NoBrush)
+        p.drawRoundedRect(h, 6, 6)
+
+    # ── Misc ──────────────────────────────────────────────────────────────────
+
+    def _finalize_bubble(self, max_width: int) -> None:
+        # The stylesheet fonts only take effect after the widget is polished on
+        # the next event-loop tick, so the content size isn't known yet. Hide
+        # the bubble now and size + place it once, deferred.
+        self._bubble.setMaximumWidth(max_width)
+        self._bubble.hide()
+        QTimer.singleShot(0, self._apply_bubble_geometry)
+
+    def _apply_bubble_geometry(self) -> None:
+        if self._mode == "idle":
+            return
+        lay = self._bubble.layout()
+        if lay is not None:
+            lay.activate()
+        self._bubble.adjustSize()
+        self._position_bubble()
+        self._bubble.show()
+        self._bubble.raise_()
+        self._update_mask()
+        self.update()
+
+    def _clear_bubble(self) -> None:
+        old = self._bubble.layout()
+        if old is not None:
+            self._drain_layout(old)
+            # Reparent the stale (now empty) layout so a fresh one installs.
+            QWidget().setLayout(old)
+
+    def _drain_layout(self, layout) -> None:
+        """Remove and destroy every widget/sub-layout in *layout*.
+
+        ``setParent(None)`` is essential: ``deleteLater`` alone defers the
+        destruction to the next event loop, leaving stale widgets painted on
+        the bubble in the meantime.
+        """
+        while layout.count():
+            item = layout.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.setParent(None)
+                w.deleteLater()
+            sub = item.layout()
+            if sub is not None:
+                self._drain_layout(sub)
+
+    def eventFilter(self, obj, event) -> bool:
+        if obj is self._host and event.type() == QEvent.Type.Resize and not self._busy:
+            self._reposition()
+        return super().eventFilter(obj, event)

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -8,7 +8,6 @@ from typing import Literal
 @dataclass
 class Params:
     # ── Paths ────────────────────────────────────────────────────────────────
-    home_dir: str = ""
     raw_data: str = ""
     output_data_folder: str = ""
     output_data_folder_name: str = ""

--- a/src/meanap/pipeline/example_data.py
+++ b/src/meanap/pipeline/example_data.py
@@ -16,8 +16,8 @@ DROPBOX_LINKS = {
 }
 
 
-def download_example_data(home_dir: Path, log: Callable[[str], None] | None = None) -> Path:
-    """Download the example recordings into ``home_dir/ExampleData``.
+def download_example_data(dest_root: Path, log: Callable[[str], None] | None = None) -> Path:
+    """Download the example recordings into ``dest_root/ExampleData``.
 
     Skips files that already exist. Returns the path to the ExampleData folder.
     """
@@ -25,7 +25,7 @@ def download_example_data(home_dir: Path, log: Callable[[str], None] | None = No
         if log:
             log(msg)
 
-    example_dir = Path(home_dir) / "ExampleData"
+    example_dir = Path(dest_root) / "ExampleData"
     example_dir.mkdir(parents=True, exist_ok=True)
 
     for name, url in DROPBOX_LINKS.items():


### PR DESCRIPTION
Add a coach-mark tutorial to the Python GUI. On first launch (and from a new "? Tutorial" toolbar button) a welcome card asks whether to run MEA-NAP, MEA-Stim or CAT-NAP, then dims the window and highlights the real tabs/fields one at a time, walking through every required setting for the chosen pipeline and landing on the Pipeline tab ready to run.

- tutorial.py: TutorialOverlay uses setMask() to punch a real hole for the highlighted field (clicks/typing reach it) while keeping the callout bubble clickable and the scrim inert. First-launch shown via QSettings("tutorial/seen").
- main_window.py: toolbar action, first-launch trigger, per-pipeline step lists.

Also remove Params.home_dir. Unlike MATLAB (where HomeDir is mainly for addpath + a default output root), the Python port imports the meanap package directly and never uses it for analysis. It only picked a download/output folder, so the field and its required-path gate are dropped: the test pipeline now downloads example data into <output folder>/ExampleData (defaulting output to ~/MEA-NAP). Legacy params JSON containing home_dir still loads (unknown keys are filtered).


Claude-Session: https://claude.ai/code/session_01Wr8Wmx8hkDyy2w1teEvwav