### PR TITLE
feat(python): resume from a prior run + reproducible random seed

### DIFF
--- a/docs/python/matlab-vs-python.md
+++ b/docs/python/matlab-vs-python.md
@@ -38,6 +38,9 @@ Python port validates that its **formulas** match MATLAB exactly when fed the
 specific RNG stream (which isn't reproducible even between two MATLAB runs).
 This covers significance thresholding (step 3), community detection and the
 normalized participation coefficient, and small-worldness's null models.
+
+Unlike MATLAB, the Python port can make these repeatable **between its own
+runs** — see [Reproducible runs](#reproducible-runs) below.
 :::
 
 :::{grid-item-card} 🧮 Algorithm differs, not just RNG
@@ -57,6 +60,48 @@ different algorithm, not just a different random seed. Treat
 | **2. Neuronal activity** (firing rates, bursts) | Exact parity confirmed field-by-field against MATLAB's own summary CSVs, when fed the same spike times. |
 | **3. Functional connectivity** (STTC) | The STTC computation itself has exact parity. Significance thresholding is inherently non-reproducible between runs (see above) — this is true of MATLAB too. |
 | **4. Network metrics** | Core graph metrics (ND, NS, density, clustering, path length, global/local efficiency, betweenness centrality) have exact parity. Modularity-dependent metrics (participation coefficient, module z-score, rich club, node cartography, hub classification, small-worldness) have exact parity *given the same community assignment* — the community assignment itself is stochastic in both MATLAB and Python. Controllability metrics are fully ported. NMF-based metrics are approximate (different algorithm, see above). |
+
+(reproducible-runs)=
+## Reproducible runs
+
+Steps 3 and 4 are stochastic — edge significance thresholding, community
+detection, the null models behind the normalized participation coefficient and
+small-worldness, and NMF all draw random numbers. By default (and in MATLAB,
+always) those draws are unseeded, so running the same data twice gives slightly
+different `Q`, `nMod`, `SW`, `PC`, `Z` and node-cartography roles.
+
+Tick **Fixed random seed** on the Pipeline tab (or set `Params.random_seed` to
+an integer) and the whole run becomes repeatable: the same input plus the same
+seed produces byte-identical `NetworkActivity_RecordingLevel.csv` and
+`NetworkActivity_NodeLevel.csv`, regardless of how many CPU cores the machine
+has or what order the recordings finish in. Record the seed alongside your
+results when you publish a figure.
+
+This makes the port repeatable against *itself*. It does not make it match
+MATLAB — MATLAB's own numbers aren't repeatable between MATLAB runs either, for
+the same reason.
+
+## Resuming a previous run
+
+Steps don't have to be re-run from scratch. Set **Start at step** to where you
+want to pick up, tick **Use prior analysis**, and point **Previous analysis
+folder** (Paths tab) at an earlier `OutputData…` folder. Whatever the starting
+step needs — spike times from step 1, adjacency matrices from step 3 — is read
+from that folder, and everything from the starting step onwards is recomputed
+into a *new* output folder. The previous run is never modified.
+
+Two useful consequences:
+
+- **The raw recordings don't need to be available** to resume at step 2 or
+  later; the spike files carry everything the later steps need. (Spike files
+  written by versions before this feature are the exception — those still fall
+  back to reading the raw recording for its duration.)
+- **You get told up front** if the previous folder doesn't hold what the
+  starting step needs, instead of the run finishing "successfully" with empty
+  result tables.
+
+If you have spike times from somewhere other than a MEA-NAP run, point
+**Spike-detected data folder** at them instead — it's searched the same way.
 
 ## Known gaps
 

--- a/python/PIPELINE_PORT_STATUS.md
+++ b/python/PIPELINE_PORT_STATUS.md
@@ -854,6 +854,90 @@ which would make the bug not manifest for those files by coincidence, not
 because of different code. Worth checking directly against a real
 stimulation dataset before trusting this hypothesis.
 
+## Resuming from a previous run (`Params.prior_analysis`, 2026-07-31)
+
+MATLAB's `Params.priorAnalysis` + `startAnalysisStep` workflow now works in the
+port. `pipeline/resume.py` owns it. Semantics, mirroring MATLAB: **output still
+goes to this run's own (fresh, dated) folder — the prior run is only ever
+read.**
+
+Only two artefacts cross step boundaries in this port, so resuming is a search
+path over two lookups rather than MATLAB's chained-`.mat` machinery:
+
+| Produced by | Consumed by | File |
+|---|---|---|
+| Step 1 | Steps 2, 3, 4 | `1_SpikeDetection/1A_SpikeDetectedData/<rec>_spikes.npz` |
+| Step 3 | Step 4 | `ExperimentMatFiles/<rec>_adjM.npz` |
+
+`InputLocator` resolves both against, in order: this run's output folder →
+`Params.spike_detected_data` (spike files only, MATLAB's `spikeDetectedData`)
+→ `Params.prior_analysis_path`. It's a frozen dataclass of plain paths so it
+pickles into the `spawn`ed Step 3/4 workers; each step rebuilds its own via
+`build_input_locator(params, output_root)` rather than threading it through the
+task tuples.
+
+Two things this needed on top of the lookup itself:
+
+- **Fail fast.** `runner.py` calls `missing_step_inputs()` before any compute
+  and raises if *no* recording has what the starting step needs (it warns and
+  continues if only some do). Previously a typo'd path just produced "SKIP:
+  spike data not found" per recording and a "successful" run with empty CSVs.
+- **Duration no longer requires the raw recording.** Steps 2/3/4 each used to
+  re-derive `duration_s` by reopening the raw `.mat`, which made resuming
+  useless without the raw data mounted. Step 1 now stores `duration_s` in the
+  spike `.npz` and everything reads it back via `io.resolve_duration_s()`,
+  falling back to the raw file only for `.npz` files written before this
+  change. That also collapsed three divergent implementations into one — step
+  2's had a hardcoded `if n_samples == 64` transposed-check (Axion64-specific,
+  so a channels-major MCS60 file would have given `duration_s = 60/fs` and
+  firing rates wrong by orders of magnitude) while steps 3/4 compared against
+  the real channel count. Step 2 also used to invent a duration (max spike
+  time, else literally 60 s) when the raw file was unreadable; it now skips the
+  recording like steps 3/4 do, since every firing rate scales with this number.
+
+Verified end to end on the example data: steps 1-3 into folder A, then step 3
+alone and step 4 alone resumed from A with `raw_data` pointed at a
+non-existent folder — same seed reproduced A's adjacency bit-for-bit, and step
+4 produced its CSVs from A's spikes + adjacency.
+
+## Random seed (`Params.random_seed`, 2026-07-31)
+
+`pipeline/rng.py`'s `make_rng(seed, *labels)`. `None` (the default) keeps the
+old behaviour — fresh OS entropy per run, matching MATLAB, which seeds nothing.
+Set an integer and every stochastic stage becomes reproducible **within the
+Python port** (this can't and doesn't make anything match MATLAB — see item 4
+under "Known limitations").
+
+Two non-obvious constraints drove the design:
+
+1. **Results must not depend on scheduling.** Steps 3/4 run recordings across a
+   process pool auto-sized from the machine's cores/RAM, so one shared stream
+   would make the numbers depend on the host. Every generator is instead
+   derived from `(seed, "step3"|"step4", rec.filename)` — a recording gets the
+   same stream whether it ran first, last, or alone.
+2. **Labels are hashed with BLAKE2b, not `hash()`.** Python randomizes string
+   hashing per process, so `hash("rec_A")` differs between the parent and a
+   spawned worker — exactly the failure this is meant to prevent. Verified
+   under two `PYTHONHASHSEED` values.
+
+Wired at: `step3.py` (thresholding surrogates), `step4.py` (modularity, PC-norm
+and small-worldness null models, NMF), `plotting.py` (which example channels
+the step-1 check figure shows), `stim_step.py` figures, and the CAT-NAP path.
+
+**One extra fix was needed to make "same seed → same numbers" literally true.**
+`average_controllability`/`modal_controllability` are deterministic metrics, but
+both call `svds(A, 1)`, and ARPACK draws its start vector from NumPy's *global*
+RNG — so they wobbled in the last ~2 ulps between runs on identical input, and
+no `random_seed` could have fixed it (the draw doesn't come from any generator
+this pipeline owns). `_dominant_singular_value()` now pins `v0` to a fixed
+vector. MATLAB parity is unaffected: `parityRun/compare_step4_same_adjacency.py`
+still reports worst-diff 2.842e-14 with `aveControl` at ~2.9e-15, unchanged.
+
+With that in place, two runs at `random_seed=42` produce byte-identical
+`NetworkActivity_RecordingLevel.csv` *and* `NetworkActivity_NodeLevel.csv`
+(all 48 columns, `Q`/`SW`/`PC`/`num_nnmf_components` included); `random_seed=7`
+differs, as it should. No BLAS thread pinning was needed.
+
 ## Spreadsheet range convention
 
 `Params.spreadsheet_range` is a string like `"A2:A100000"`. The parser
@@ -1030,7 +1114,10 @@ of this list did._
    it's inherent to comparing two independently-seeded RNG streams. The
    deterministic STTC computation itself has exact parity. Same situation for
    Step 4's modularity (Ci) and the null-model randomization inside the
-   normalized participation coefficient.
+   normalized participation coefficient. **Run-to-run reproducibility *within*
+   the Python port is now available** via `Params.random_seed` (see the
+   "Random seed" section above) — that is a different guarantee from parity
+   with MATLAB, and it does not move any of these closer to MATLAB's numbers.
 5. **No `Parameters_*.csv/.mat` or `channel_layout.png` generation.** MATLAB
    writes these as part of its run; Python writes `.npz`/`.json` outputs per
    step instead (see "Key files" above for exactly what each step writes) and

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -413,12 +413,29 @@ class MainWindow(QMainWindow):
         self._params = params
 
         missing = []
-        if not params.raw_data and not params.prior_analysis:
-            missing.append("Raw data folder")
+        # Only step 1 reads the raw recordings; later steps work from the spike
+        # files, so a resumed run doesn't need the raw data mounted at all.
+        if not params.raw_data and params.start_analysis_step == 1:
+            missing.append("Raw data folder (needed for step 1 — spike detection)")
         if not params.output_data_folder:
             missing.append("Output data folder")
         if not params.spreadsheet_file_name:
             missing.append("Spreadsheet file")
+        if params.prior_analysis and not params.prior_analysis_path:
+            missing.append("Previous analysis folder (required by 'Use prior analysis')")
+        # Starting mid-pipeline needs the earlier steps' output from somewhere:
+        # a prior analysis folder, an explicit spike-data folder, or an existing
+        # output folder named on the Paths tab (continuing a run in place).
+        if (
+            params.start_analysis_step > 1
+            and not params.prior_analysis
+            and not params.spike_detected_data
+            and not params.output_data_folder_name
+        ):
+            missing.append(
+                f"'Use prior analysis' — starting at step {params.start_analysis_step} needs "
+                "the earlier steps' output, but this run would create an empty output folder"
+            )
 
         if missing:
             QMessageBox.warning(

--- a/src/meanap/gui/panels/pipeline.py
+++ b/src/meanap/gui/panels/pipeline.py
@@ -48,7 +48,12 @@ class PipelinePanel(QWidget):
         )
 
         self.prior_analysis = QCheckBox()
-        self.prior_analysis.setToolTip("Load results from a previous run instead of re-computing")
+        self.prior_analysis.setToolTip(
+            "Resume from an earlier run: steps before 'Start at step' are read from the "
+            "previous analysis folder (set on the Paths tab) instead of being recomputed. "
+            "Results are written to this run's own output folder — the previous run is "
+            "only ever read."
+        )
 
         self.optional_steps = QListWidget()
         self.optional_steps.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
@@ -76,8 +81,30 @@ class PipelinePanel(QWidget):
 
         self.time_processes = QCheckBox()
 
+        # Steps 3 and 4 are stochastic (surrogate thresholding, modularity, null
+        # models, NMF). Off = a fresh seed per run, matching MATLAB; on = the
+        # same inputs give the same numbers every time.
+        self.use_random_seed = QCheckBox()
+        self.use_random_seed.setToolTip(
+            "Make the stochastic steps reproducible. Off: edge thresholding, modularity, "
+            "small-worldness and NMF differ slightly between runs on the same data."
+        )
+        self.random_seed = QSpinBox()
+        self.random_seed.setRange(0, 2_147_483_647)
+        self.random_seed.setValue(1)
+        self.random_seed.setEnabled(False)
+        self.use_random_seed.toggled.connect(self.random_seed.setEnabled)
+
+        seed_row = QWidget()
+        seed_layout = QHBoxLayout(seed_row)
+        seed_layout.setContentsMargins(0, 0, 0, 0)
+        seed_layout.addWidget(self.use_random_seed)
+        seed_layout.addWidget(self.random_seed)
+        seed_layout.addStretch()
+
         form2.addRow("Verbose level", self.verbose_level)
         form2.addRow("Time each step", self.time_processes)
+        form2.addRow("Fixed random seed", seed_row)
 
         # ── Run controls ──────────────────────────────────────────────────────
         run_box = QGroupBox("Run")
@@ -136,6 +163,9 @@ class PipelinePanel(QWidget):
         if idx >= 0:
             self.verbose_level.setCurrentIndex(idx)
         self.time_processes.setChecked(params.time_processes)
+        self.use_random_seed.setChecked(params.random_seed is not None)
+        if params.random_seed is not None:
+            self.random_seed.setValue(int(params.random_seed))
         for i in range(self.optional_steps.count()):
             item = self.optional_steps.item(i)
             item.setSelected(item.text() in params.optional_steps_to_run)
@@ -146,6 +176,9 @@ class PipelinePanel(QWidget):
         params.prior_analysis = self.prior_analysis.isChecked()
         params.verbose_level = self.verbose_level.currentText()
         params.time_processes = self.time_processes.isChecked()
+        params.random_seed = (
+            self.random_seed.value() if self.use_random_seed.isChecked() else None
+        )
         params.optional_steps_to_run = [
             self.optional_steps.item(i).text()
             for i in range(self.optional_steps.count())

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -123,7 +123,15 @@ class Params:
     start_analysis_step: int = 1
     stop_analysis_step: int = 4
     optional_steps_to_run: list[str] = field(default_factory=list)
+    # Resume from an earlier run: read whichever steps' outputs already exist
+    # from ``prior_analysis_path`` (and/or ``spike_detected_data``) instead of
+    # recomputing them. Results still go to this run's own output folder — the
+    # prior run is only ever read. See pipeline/resume.py.
     prior_analysis: bool = False
+    # Seed for every stochastic stage (step-3 thresholding, modularity, null
+    # models, NMF, example-trace picking). None = fresh OS entropy each run,
+    # matching MATLAB, which seeds nothing. See pipeline/rng.py.
+    random_seed: int | None = None
     verbose_level: str = "Normal"
     time_processes: bool = False
     output_spreadsheet_file_type: str = "csv"

--- a/src/meanap/pipeline/io.py
+++ b/src/meanap/pipeline/io.py
@@ -79,6 +79,7 @@ def save_spike_times_npz(
     channels: np.ndarray,
     fs: float,
     params: dict[str, Any] | None = None,
+    duration_s: float | None = None,
 ) -> None:
     """Save spike detection results to a ``.npz`` file.
 
@@ -86,9 +87,14 @@ def save_spike_times_npz(
     ------------
     ``channels`` — channel IDs
     ``fs`` — sampling frequency
+    ``duration_s`` — recording duration in seconds (omitted if not supplied)
     ``spike_times_{ch}_{method}`` — spike times in seconds for each channel/method
 
     Also saves a text file ``{stem}_params.txt`` alongside if ``params`` given.
+
+    ``duration_s`` is stored so Steps 2-4 don't have to re-open the raw
+    recording just to recover it — which is what makes resuming from a previous
+    run work when the raw data isn't mounted (see ``read_duration_npz``).
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -97,6 +103,8 @@ def save_spike_times_npz(
         "channels": channels,
         "fs": np.array([fs]),
     }
+    if duration_s is not None:
+        arrays["duration_s"] = np.array([float(duration_s)])
     for ch_idx, methods in spike_times.items():
         for method, times in methods.items():
             arrays[f"spike_times_{ch_idx}_{method}"] = times
@@ -108,6 +116,39 @@ def save_spike_times_npz(
         with open(params_path, "w") as fh:
             for k, v in params.items():
                 fh.write(f"{k}: {v}\n")
+
+
+def resolve_duration_s(
+    spike_data: "np.lib.npyio.NpzFile",
+    raw_path: str | Path,
+    fs: float,
+    n_channels: int,
+) -> tuple[float | None, str]:
+    """Recording duration in seconds, with the source it came from.
+
+    Prefers the value Step 1 stored in the spike ``.npz``; falls back to the
+    sample count in the raw recording for files written before that field
+    existed (or by an external spike detector). Returns ``(None, "unavailable")``
+    when neither is readable, so callers can decide whether to skip or warn
+    rather than silently inventing a duration — every firing rate in Step 2 and
+    every surrogate in Step 3 scales with this number.
+    """
+    if "duration_s" in spike_data.files:
+        value = float(np.asarray(spike_data["duration_s"]).flatten()[0])
+        if value > 0:
+            return value, "spike file"
+
+    try:
+        with h5py.File(raw_path, "r") as f:
+            shape = f["dat"].shape
+        n_samples = shape[0]
+        # Raw files are (n_samples, n_channels), but some are stored
+        # transposed; the sample axis is whichever one isn't the channel count.
+        if len(shape) > 1 and n_samples == n_channels:
+            n_samples = shape[1]
+        return n_samples / fs, "raw file"
+    except Exception:
+        return None, "unavailable"
 
 
 def load_spike_times_npz(path: str | Path) -> dict[int, dict[str, np.ndarray]]:

--- a/src/meanap/pipeline/network_metrics.py
+++ b/src/meanap/pipeline/network_metrics.py
@@ -689,6 +689,27 @@ def small_worldness_rl_wu(
 
 # ── Controllability ────────────────────────────────────────────────────────
 
+def _dominant_singular_value(adj_m: np.ndarray) -> float:
+    """Largest singular value of ``adj_m`` — the ``svds(A, 1)`` in MATLAB's
+    ``ave_control.m`` / ``modal_control.m``.
+
+    ``v0`` is pinned to a fixed starting vector. Left to itself, ARPACK draws
+    its start from NumPy's *global* RNG, which made average/modal
+    controllability — otherwise fully deterministic metrics — wobble in the
+    last ~2 ulps between runs on identical input, and no ``Params.random_seed``
+    could have fixed it (the draw doesn't come from any generator this pipeline
+    owns). The converged singular value is the same either way, to solver
+    tolerance; only the arithmetic path to it changes.
+    """
+    try:
+        _, s, _ = svds(
+            adj_m.astype(float), k=1, v0=np.ones(min(adj_m.shape), dtype=float),
+        )
+        return float(s[0])
+    except Exception:
+        return float(np.linalg.norm(adj_m, 2))
+
+
 def average_controllability(adj_m: np.ndarray) -> np.ndarray:
     """Returns values of average controllability for each node in a network.
     
@@ -698,16 +719,11 @@ def average_controllability(adj_m: np.ndarray) -> np.ndarray:
     """
     if adj_m.shape[0] == 0:
         return np.array([])
-    
-    try:
-        _, s, _ = svds(adj_m.astype(float), k=1)
-        max_s = s[0]
-    except Exception:
-        max_s = np.linalg.norm(adj_m, 2)
-        
+
+    max_s = _dominant_singular_value(adj_m)
     a_norm = adj_m / (1 + max_s)
     t, u = schur(a_norm, output="real")
-    
+
     mid_mat = (u ** 2).T
     v = np.diag(t)
     p_diag = 1 - v ** 2
@@ -725,13 +741,8 @@ def modal_controllability(adj_m: np.ndarray) -> np.ndarray:
     """
     if adj_m.shape[0] == 0:
         return np.array([])
-        
-    try:
-        _, s, _ = svds(adj_m.astype(float), k=1)
-        max_s = s[0]
-    except Exception:
-        max_s = np.linalg.norm(adj_m, 2)
-        
+
+    max_s = _dominant_singular_value(adj_m)
     a_norm = adj_m / (1 + max_s)
     t, u = schur(a_norm, output="real")
     

--- a/src/meanap/pipeline/plotting.py
+++ b/src/meanap/pipeline/plotting.py
@@ -3,6 +3,7 @@ import numpy as np
 from pathlib import Path
 
 from meanap.params import Params
+from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spike_detection import SpikeDetectionResult, bandpass_filter
 
 
@@ -16,6 +17,10 @@ def plot_spike_detection_checks(
     """Generate diagnostic plots for step 1 (spike detection)."""
     # Use non-interactive backend
     plt.switch_backend("Agg")
+
+    # Which channels/spikes the example-trace panels show is a random choice;
+    # seeded so a re-run of the same recording produces the same figure.
+    rng = make_rng(params.random_seed, "step1-plots", rec_name)
 
     fs = result.fs
     n_samples, n_channels = dat.shape
@@ -107,7 +112,7 @@ def plot_spike_detection_checks(
     # We plot 9 example traces, leaving the 10th axis empty or turning it off
     for i in range(9):
         ax = axes[i]
-        ch = np.random.choice(active_channels)
+        ch = rng.choice(active_channels)
         last_channel = ch
         
         # We need the filtered trace
@@ -122,7 +127,7 @@ def plot_spike_detection_checks(
         # Pick a random spike from the first available method to center the window
         times_s = result.spike_times[ch].get(methods[0], np.array([]))
         if len(times_s) > 0:
-            st = int(round(np.random.choice(times_s) * fs))
+            st = int(round(rng.choice(times_s) * fs))
         else:
             st = n_samples // 2
             

--- a/src/meanap/pipeline/resume.py
+++ b/src/meanap/pipeline/resume.py
@@ -1,0 +1,162 @@
+"""Resuming a run from a previous analysis (``Params.prior_analysis``).
+
+MATLAB's ``MEApipeline.m`` lets you skip already-completed work: set
+``Params.priorAnalysis = 1``, point ``Params.priorAnalysisPath`` at an earlier
+``OutputData…`` folder and ``Params.startAnalysisStep`` at the step to resume
+from. Results still go to a *fresh* output folder — the prior run is only ever
+read — which is the behaviour mirrored here.
+
+Because this port writes discrete per-recording files rather than MATLAB's one
+chained ``.mat`` per recording, resuming reduces to a search path. Only two
+artefacts cross step boundaries:
+
+===========================  ================================================
+Step 1 → Steps 2, 3, 4       ``1_SpikeDetection/1A_SpikeDetectedData/<rec>_spikes.npz``
+Step 3 → Step 4              ``ExperimentMatFiles/<rec>_adjM.npz``
+===========================  ================================================
+
+:class:`InputLocator` resolves those two lookups against, in order:
+
+1. **this run's output folder** — so a step that just ran always wins;
+2. **``Params.spike_detected_data``** (spike files only) — an explicit
+   externally-detected-spikes folder, MATLAB's ``spikeDetectedData``;
+3. **``Params.prior_analysis_path``** — the previous run.
+
+Order 1-before-2 matters only in theory (the output folder is created fresh per
+run, so it holds nothing but this run's own results) but it keeps the rule
+simple to state: *nothing already produced this run is ever shadowed by an
+older file.*
+
+The class is a frozen dataclass of plain paths so it pickles cleanly into the
+``spawn``ed worker processes Steps 3 and 4 use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from meanap.params import Params
+from meanap.pipeline.spreadsheet import RecordingInfo
+
+__all__ = [
+    "InputLocator",
+    "build_input_locator",
+    "missing_step_inputs",
+    "SPIKE_SUBDIR",
+    "ADJM_SUBDIR",
+]
+
+SPIKE_SUBDIR = Path("1_SpikeDetection") / "1A_SpikeDetectedData"
+ADJM_SUBDIR = Path("ExperimentMatFiles")
+
+
+@dataclass(frozen=True)
+class InputLocator:
+    """Where each step should look for the outputs of the steps before it."""
+
+    output_root: Path
+    prior_root: Path | None = None
+    spike_dir: Path | None = None
+
+    # ── lookups ──────────────────────────────────────────────────────────────
+
+    def spike_file(self, recording_name: str) -> Path | None:
+        """Path to a recording's Step-1 spike file, or ``None`` if absent."""
+        name = f"{recording_name}_spikes.npz"
+        candidates = [self.output_root / SPIKE_SUBDIR / name]
+        if self.spike_dir is not None:
+            candidates.append(self.spike_dir / name)
+        if self.prior_root is not None:
+            candidates.append(self.prior_root / SPIKE_SUBDIR / name)
+        return _first_existing(candidates)
+
+    def adjm_file(self, recording_name: str) -> Path | None:
+        """Path to a recording's Step-3 adjacency file, or ``None`` if absent."""
+        name = f"{recording_name}_adjM.npz"
+        candidates = [self.output_root / ADJM_SUBDIR / name]
+        if self.prior_root is not None:
+            candidates.append(self.prior_root / ADJM_SUBDIR / name)
+        return _first_existing(candidates)
+
+    # ── reporting ────────────────────────────────────────────────────────────
+
+    @property
+    def is_resuming(self) -> bool:
+        return self.prior_root is not None or self.spike_dir is not None
+
+    def describe(self) -> list[str]:
+        """Human-readable lines describing the search path, for the run log."""
+        lines = [f"Reading step inputs from: {self.output_root}"]
+        if self.spike_dir is not None:
+            lines.append(f"  … then spike data from: {self.spike_dir}")
+        if self.prior_root is not None:
+            lines.append(f"  … then prior analysis:  {self.prior_root}")
+        return lines
+
+
+def _first_existing(candidates: list[Path]) -> Path | None:
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def build_input_locator(params: Params, output_root: Path) -> InputLocator:
+    """Build the locator for a run, validating the configured paths up front.
+
+    Raises :class:`ValueError` with an actionable message rather than letting a
+    typo'd path degrade into "every recording skipped", which is how a missing
+    input used to present.
+    """
+    prior_root: Path | None = None
+    if params.prior_analysis:
+        if not params.prior_analysis_path:
+            raise ValueError(
+                "'Use prior analysis' is enabled but no previous analysis folder is set. "
+                "Set Params.prior_analysis_path to a previous OutputData… folder, or "
+                "disable prior analysis."
+            )
+        prior_root = Path(params.prior_analysis_path).expanduser()
+        if not prior_root.is_dir():
+            raise ValueError(f"Previous analysis folder does not exist: {prior_root}")
+        if not (prior_root / SPIKE_SUBDIR).is_dir() and not (prior_root / ADJM_SUBDIR).is_dir():
+            raise ValueError(
+                f"{prior_root} does not look like a MEA-NAP output folder — expected it to "
+                f"contain '{SPIKE_SUBDIR}' and/or '{ADJM_SUBDIR}'. Point this at the "
+                "OutputData… folder itself, not at its parent."
+            )
+
+    spike_dir: Path | None = None
+    if params.spike_detected_data:
+        spike_dir = Path(params.spike_detected_data).expanduser()
+        if not spike_dir.is_dir():
+            raise ValueError(f"Spike-detected data folder does not exist: {spike_dir}")
+
+    return InputLocator(
+        output_root=Path(output_root), prior_root=prior_root, spike_dir=spike_dir
+    )
+
+
+def missing_step_inputs(
+    locator: InputLocator,
+    recordings: list[RecordingInfo],
+    start_step: int,
+) -> dict[str, list[str]]:
+    """Which recordings lack the inputs the *starting* step needs.
+
+    Only the starting step is checked: later steps consume what earlier ones
+    produce during this run. Returns ``{recording_name: [missing artefact, …]}``
+    for recordings that would be skipped, so the caller can fail fast (nothing
+    resolvable) or warn (only some missing).
+    """
+    missing: dict[str, list[str]] = {}
+    for rec in recordings:
+        gaps: list[str] = []
+        if start_step >= 2 and locator.spike_file(rec.filename) is None:
+            gaps.append("spike times (step 1)")
+        if start_step >= 4 and locator.adjm_file(rec.filename) is None:
+            gaps.append("adjacency matrices (step 3)")
+        if gaps:
+            missing[rec.filename] = gaps
+    return missing

--- a/src/meanap/pipeline/rng.py
+++ b/src/meanap/pipeline/rng.py
@@ -1,0 +1,74 @@
+"""Deterministic random-number generation for the pipeline.
+
+Several pipeline stages are stochastic: Step 3's probabilistic thresholding
+(circular-shift surrogates), Step 4's modularity/consensus clustering, the
+null-model randomizations behind the normalized participation coefficient and
+small-worldness, NMF initialization, and a couple of "pick an example channel"
+plotting choices. MATLAB's MEA-NAP never seeds any of these, so two MATLAB runs
+on identical data already disagree on ``Q``/``nMod``/``SW``/``PC``/``Z`` and on
+which edges survive thresholding.
+
+This module makes that reproducible *within* the Python port (it cannot make it
+reproducible against MATLAB — see ``python/PIPELINE_PORT_STATUS.md``). Set
+``Params.random_seed`` to an integer and every stochastic stage derives its
+generator from it; leave it ``None`` (the default) to keep the previous
+non-deterministic behaviour.
+
+The key requirement is that a run's numbers must not depend on *how* the work
+was scheduled: Steps 3 and 4 run recordings across a process pool whose worker
+count is auto-sized from the machine's cores/RAM, so drawing from one shared
+stream would make results depend on the host. Instead every generator is
+derived from ``(seed, label…)``, where the labels identify the work item
+(step, recording, and where relevant the lag) — so a given recording gets the
+same stream whether it ran first, last, or alone.
+
+Labels are hashed with BLAKE2b rather than :func:`hash`, because Python
+randomizes string hashing per process (``PYTHONHASHSEED``): ``hash("rec_A")``
+differs between the parent and a spawned worker, which is exactly the
+situation this module exists to avoid.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+
+__all__ = ["make_rng", "derive_seed_int"]
+
+
+def _label_to_int(label: str | int) -> int:
+    """Map a label to a stable 64-bit int (stable across processes and runs)."""
+    if isinstance(label, int):
+        return label & 0xFFFFFFFFFFFFFFFF
+    digest = hashlib.blake2b(str(label).encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big")
+
+
+def make_rng(seed: int | None, *labels: str | int) -> np.random.Generator:
+    """Return the generator for one unit of work.
+
+    Parameters
+    ----------
+    seed
+        ``Params.random_seed``. ``None`` → a fresh, OS-entropy-seeded generator
+        (the port's historical behaviour: every run differs).
+    labels
+        Identify the work item, e.g. ``("step4", rec.filename)``. Two calls with
+        the same seed and labels return generators that produce the same
+        sequence; different labels give independent streams.
+    """
+    if seed is None:
+        return np.random.default_rng()
+    return np.random.default_rng(
+        np.random.SeedSequence([int(seed), *(_label_to_int(x) for x in labels)])
+    )
+
+
+def derive_seed_int(seed: int | None, *labels: str | int) -> int:
+    """A single non-negative 31-bit int derived the same way as :func:`make_rng`.
+
+    For third-party APIs that take a plain integer seed rather than a NumPy
+    generator (``sklearn``'s ``random_state``, numba's ``np.random.seed``).
+    """
+    return int(make_rng(seed, *labels).integers(0, 2**31 - 1))

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -15,6 +15,7 @@ from meanap.pipeline.step2 import _run_step2_neuronal_activity
 from meanap.pipeline.step3 import _run_step3_functional_connectivity
 from meanap.pipeline.step4 import _run_step4_network_metrics
 from meanap.pipeline.output_folders import create_output_folders
+from meanap.pipeline.resume import build_input_locator, missing_step_inputs
 from meanap.pipeline.spike_detection import SpikeDetectionParams, detect_spikes_recording
 from meanap.pipeline.spreadsheet import RecordingInfo, read_recording_csv
 
@@ -41,6 +42,11 @@ def run_pipeline(
     recording inside each step; when it returns ``True`` the run unwinds by
     raising :class:`~meanap.pipeline.cancellation.PipelineCancelled`. Callers
     that offer a Stop button should catch that and treat it as a clean stop.
+
+    When ``params.start_analysis_step > 1`` the inputs the starting step needs
+    are resolved through :mod:`meanap.pipeline.resume` — this run's output
+    folder first, then ``prior_analysis_path``/``spike_detected_data`` — and
+    validated before any compute starts.
     """
     if not params.spreadsheet_file_name:
         raise ValueError("Spreadsheet file must be set")
@@ -59,6 +65,17 @@ def run_pipeline(
     )
     log(f"Output folder ready: {output_root}")
 
+    # Raises on a misconfigured prior-analysis/spike-data path, before any work.
+    locator = build_input_locator(params, output_root)
+    if locator.is_resuming:
+        for line in locator.describe():
+            log(line)
+
+    if params.random_seed is None:
+        log("Random seed: not set — stochastic steps (3, 4) will differ between runs.")
+    else:
+        log(f"Random seed: {params.random_seed} — stochastic steps are reproducible.")
+
     # CAT-NAP (suite2p calcium imaging) path. In MATLAB, Params.suite2pMode == 1
     # replaces spike detection + connectivity (steps 1 & 3) with suite2pToAdjm,
     # swaps step-2 stats for calTwopActivityStats, and feeds the shared step-4
@@ -67,11 +84,38 @@ def run_pipeline(
     if params.suite2p_mode:
         log("\n=== CAT-NAP (suite2p) pipeline ===")
         from meanap.catnap.pipeline import run_catnap_pipeline
-        run_catnap_pipeline(params, recordings, output_root, log, should_cancel)
+        from meanap.pipeline.rng import make_rng
+        run_catnap_pipeline(
+            params, recordings, output_root, log, should_cancel,
+            rng=make_rng(params.random_seed, "catnap"),
+        )
         return output_root
 
     start = params.start_analysis_step
     stop = params.stop_analysis_step
+    if start > stop:
+        raise ValueError(
+            f"Start step ({start}) is after stop step ({stop}) — nothing to run."
+        )
+
+    # Fail fast when resuming with nothing to resume from. Without this a bad
+    # path just makes every recording log "SKIP: spike data not found" and the
+    # run "succeeds" with empty CSVs.
+    if start > 1:
+        missing = missing_step_inputs(locator, recordings, start)
+        if len(missing) == len(recordings):
+            detail = "; ".join(f"{name}: {', '.join(gaps)}" for name, gaps in missing.items())
+            hint = (
+                "Enable 'Use prior analysis' and set the previous analysis folder"
+                if not locator.is_resuming
+                else "Check that the previous analysis folder holds these recordings"
+            )
+            raise ValueError(
+                f"Cannot start at step {start}: no recording has the inputs it needs "
+                f"({detail}). {hint}, or start at step 1."
+            )
+        for name, gaps in missing.items():
+            log(f"  ! {name} will be skipped — missing {', '.join(gaps)}")
 
     # Port of MEApipeline.m's Params.timeProcesses: tic/toc around each step,
     # gated by the same flag, printed in the same "Step N duration (seconds):
@@ -205,7 +249,10 @@ def _run_step1_spike_detection(
         )
 
         out_path = spike_dir / f"{rec.filename}_spikes.npz"
-        save_spike_times_npz(out_path, result.spike_times, channels, fs)
+        save_spike_times_npz(
+            out_path, result.spike_times, channels, fs,
+            duration_s=dat.shape[0] / fs,
+        )
         log(f"  [{rec.filename}] saved → {out_path.relative_to(output_root)}")
 
         # Mirrors MEApipeline.m creating a per-recording checks folder here;

--- a/src/meanap/pipeline/step2.py
+++ b/src/meanap/pipeline/step2.py
@@ -1,15 +1,15 @@
 from pathlib import Path
 from typing import Callable
 
-import h5py
 import numpy as np
 import pandas as pd
 import json
 
 from meanap.params import Params
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
+from meanap.pipeline.resume import build_input_locator
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
-from meanap.pipeline.io import load_spike_times_npz
+from meanap.pipeline.io import load_spike_times_npz, resolve_duration_s
 from meanap.pipeline.firing_rates import firing_rates_bursts
 from meanap.pipeline.plotting_step2 import plot_neuronal_activity_checks
 
@@ -100,7 +100,7 @@ def _run_step2_neuronal_activity(
 
     log("\n=== Step 2: Neuronal Activity & Burst Detection ===")
 
-    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
+    locator = build_input_locator(params, output_root)
     out_dir = output_root / "2_NeuronalActivity"
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -114,11 +114,11 @@ def _run_step2_neuronal_activity(
 
     for rec in recordings:
         check_cancel(should_cancel)
-        npz_file = spike_data_dir / f"{rec.filename}_spikes.npz"
-        if not npz_file.exists():
-            log(f"  [{rec.filename}] SKIP: Spike data not found at {npz_file.name}")
+        npz_file = locator.spike_file(rec.filename)
+        if npz_file is None:
+            log(f"  [{rec.filename}] SKIP: spike data not found ({rec.filename}_spikes.npz)")
             continue
-            
+
         log(f"  [{rec.filename}] loading spike data...")
         try:
             data = np.load(npz_file)
@@ -127,22 +127,22 @@ def _run_step2_neuronal_activity(
         except Exception as e:
             log(f"  [{rec.filename}] ERROR loading npz: {e}")
             continue
-            
-        # Get duration_s by peeking at HDF5 raw data shape
-        raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
-        try:
-            with h5py.File(raw_path, "r") as f:
-                n_samples = f["dat"].shape[0]
-                if n_samples == 64:  # Transposed check
-                    n_samples = f["dat"].shape[1]
-            duration_s = n_samples / fs
-        except Exception:
-            # Fallback if raw file not found/readable
-            log(f"  [{rec.filename}] Warning: could not read raw file, guessing duration from max spike time")
-            duration_s = 0.0
-            
+
+        duration_s, duration_src = resolve_duration_s(
+            data, Path(params.raw_data) / f"{rec.filename}.mat", fs, n_channels,
+        )
+        if duration_s is None:
+            # Every firing rate here is spikes/duration, so a guessed duration
+            # would be silently wrong rather than obviously missing.
+            log(f"  [{rec.filename}] SKIP: recording duration unavailable "
+                f"(no duration in the spike file and the raw recording could not be read)")
+            continue
+        if duration_src == "raw file":
+            log(f"  [{rec.filename}] duration read from the raw recording "
+                f"({duration_s:.1f}s) — spike file predates duration storage")
+
         spike_times_full = load_spike_times_npz(npz_file)
-        
+
         # Filter down to the chosen method
         method = params.spikes_method
         spike_times_dict = {}
@@ -150,15 +150,9 @@ def _run_step2_neuronal_activity(
             # Keys in spike_times_full might be string or int
             # Our loading code casts to int, so ch should match
             if ch in spike_times_full and method in spike_times_full[ch]:
-                times = spike_times_full[ch][method]
-                spike_times_dict[ch] = times
-                if duration_s == 0.0 and len(times) > 0:
-                    duration_s = max(duration_s, np.max(times))
+                spike_times_dict[ch] = spike_times_full[ch][method]
             else:
                 spike_times_dict[ch] = np.array([])
-                
-        if duration_s == 0.0:
-            duration_s = 60.0  # safe fallback
 
         ground_electrodes = parse_ground_electrodes(rec.ground)
         if ground_electrodes:

--- a/src/meanap/pipeline/step3.py
+++ b/src/meanap/pipeline/step3.py
@@ -14,14 +14,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Callable
 
-import h5py
 import numpy as np
 
 from meanap.params import Params
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
-from meanap.pipeline.io import load_spike_times_npz
+from meanap.pipeline.io import load_spike_times_npz, resolve_duration_s
 from meanap.pipeline.parallel import map_recordings
 from meanap.pipeline.probabilistic_threshold import adjm_thr
+from meanap.pipeline.resume import build_input_locator
+from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
 
 # Peak per-worker RAM for Step 3: spike times (sparse) + a few 64x64xrep_num
@@ -36,7 +37,7 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
     in the parent, in completion order)."""
     params, rec, output_root_str = task
     output_root = Path(output_root_str)
-    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
+    locator = build_input_locator(params, output_root)
     mat_files_dir = output_root / "ExperimentMatFiles"
 
     method = params.spikes_method
@@ -46,24 +47,21 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
     plot_checks = bool(getattr(params, "prob_thresh_plot_checks", False))
 
     logs: list[str] = []
-    npz_file = spike_data_dir / f"{rec.filename}_spikes.npz"
-    if not npz_file.exists():
-        logs.append(f"  [{rec.filename}] SKIP: Spike data not found at {npz_file.name}")
+    npz_file = locator.spike_file(rec.filename)
+    if npz_file is None:
+        logs.append(f"  [{rec.filename}] SKIP: spike data not found ({rec.filename}_spikes.npz)")
         return rec.filename, logs
 
     data = np.load(npz_file)
     fs = float(data["fs"][0])
     n_channels = len(data["channels"])
 
-    raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
-    try:
-        with h5py.File(raw_path, "r") as f:
-            n_samples = f["dat"].shape[0]
-            if n_samples == n_channels:
-                n_samples = f["dat"].shape[1]
-        duration_s = n_samples / fs
-    except Exception:
-        logs.append(f"  [{rec.filename}] Warning: could not read raw file for duration")
+    duration_s, _ = resolve_duration_s(
+        data, Path(params.raw_data) / f"{rec.filename}.mat", fs, n_channels,
+    )
+    if duration_s is None:
+        logs.append(f"  [{rec.filename}] SKIP: recording duration unavailable "
+                    f"(not in the spike file, and the raw recording could not be read)")
         return rec.filename, logs
 
     spike_times_full = load_spike_times_npz(npz_file)
@@ -76,7 +74,10 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
         spike_times_dict = ground_spike_times_dict(spike_times_dict, data["channels"], ground_electrodes)
 
     out_arrays: dict[str, np.ndarray] = {}
-    rng = np.random.default_rng()
+    # Derived from the recording name, not from a shared stream, so results
+    # don't depend on how many workers the pool decided to use or what order
+    # recordings completed in.
+    rng = make_rng(params.random_seed, "step3", rec.filename)
     check_dir = output_root / "3_EdgeThresholdingCheck"
     for lag_ms in lag_values:
         logs.append(f"  [{rec.filename}] computing adjacency matrix (lag={lag_ms}ms, "

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -9,7 +9,6 @@ import json
 from pathlib import Path
 from typing import Callable
 
-import h5py
 import numpy as np
 import pandas as pd
 from scipy.spatial.distance import pdist, squareform
@@ -17,7 +16,7 @@ from scipy.spatial.distance import pdist, squareform
 from meanap.params import Params
 from meanap.pipeline import network_metrics as nm
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
-from meanap.pipeline.io import load_spike_times_npz
+from meanap.pipeline.io import load_spike_times_npz, resolve_duration_s
 from meanap.pipeline.modularity import mod_consensus_cluster_iterate
 from meanap.pipeline.nmf import cal_nmf
 from meanap.pipeline.null_models import latmio_und_v2, randmio_und_v2
@@ -27,6 +26,8 @@ from meanap.pipeline.plotting_step4 import (
     plot_connectivity_stats, plot_graph_metrics_by_node,
     plot_node_cartography, plot_spatial_network, plot_spatial_network_combined,
 )
+from meanap.pipeline.resume import build_input_locator
+from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
 
 
@@ -406,26 +407,27 @@ def _step4_compute_one(
     plot phase), and the log lines it produced."""
     params, rec, output_root_str = task
     output_root = Path(output_root_str)
-    mat_files_dir = output_root / "ExperimentMatFiles"
-    spike_data_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
+    locator = build_input_locator(params, output_root)
 
     method = params.spikes_method
     lag_values = params.func_con_lag_val
     min_nodes = params.min_number_of_nodes_to_cal_net_met
     logs: list[str] = []
 
-    adj_path = mat_files_dir / f"{rec.filename}_adjM.npz"
-    spike_path = spike_data_dir / f"{rec.filename}_spikes.npz"
-    if not adj_path.exists():
-        logs.append(f"  [{rec.filename}] SKIP: adjacency matrices not found at {adj_path.name}")
+    adj_path = locator.adjm_file(rec.filename)
+    spike_path = locator.spike_file(rec.filename)
+    if adj_path is None:
+        logs.append(f"  [{rec.filename}] SKIP: adjacency matrices not found "
+                    f"({rec.filename}_adjM.npz)")
         return rec.filename, None, None, logs
-    if not spike_path.exists():
-        logs.append(f"  [{rec.filename}] SKIP: spike data not found at {spike_path.name}")
+    if spike_path is None:
+        logs.append(f"  [{rec.filename}] SKIP: spike data not found ({rec.filename}_spikes.npz)")
         return rec.filename, None, None, logs
 
-    # Independent RNG per worker (Step 4's PC-norm/modularity are already
-    # non-bit-reproducible; separate default_rng()s give independent streams).
-    rng = np.random.default_rng()
+    # Derived from the recording name, not from a shared stream, so the
+    # stochastic metrics (Ci/Q/PC-norm/SW/NMF) don't depend on how many
+    # workers the pool used or what order recordings completed in.
+    rng = make_rng(params.random_seed, "step4", rec.filename)
 
     logs.append(f"  [{rec.filename}] loading adjacency matrices...")
     adj_data = np.load(adj_path)
@@ -434,15 +436,12 @@ def _step4_compute_one(
     channels_arr = spike_data["channels"]
     n_channels = len(channels_arr)
 
-    raw_path = Path(params.raw_data) / f"{rec.filename}.mat"
-    try:
-        with h5py.File(raw_path, "r") as f:
-            n_samples = f["dat"].shape[0]
-            if n_samples == n_channels:
-                n_samples = f["dat"].shape[1]
-        duration_s = n_samples / fs
-    except Exception:
-        logs.append(f"  [{rec.filename}] SKIP: could not read raw file for duration")
+    duration_s, _ = resolve_duration_s(
+        spike_data, Path(params.raw_data) / f"{rec.filename}.mat", fs, n_channels,
+    )
+    if duration_s is None:
+        logs.append(f"  [{rec.filename}] SKIP: recording duration unavailable "
+                    f"(not in the spike file, and the raw recording could not be read)")
         return rec.filename, None, None, logs
 
     spike_times_full = load_spike_times_npz(spike_path)

--- a/src/meanap/pipeline/stim_step.py
+++ b/src/meanap/pipeline/stim_step.py
@@ -23,6 +23,8 @@ from meanap.params import Params
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
 from meanap.pipeline.io import load_raw_recording, load_spike_times_npz
 from meanap.pipeline.channel_layout import get_coords_from_layout
+from meanap.pipeline.resume import build_input_locator
+from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo
 from meanap.stim.detection import detect_stim_times, get_stim_patterns, _matlab_mode
 from meanap.stim.cleaning import clean_spikes_from_stim
@@ -62,7 +64,9 @@ def run_stim_analysis(
         return
 
     raw_dir = Path(params.raw_data)
-    spike_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
+    # Same resolution as the numbered steps, so stim analysis can run against a
+    # previous run's spike detection rather than only this run's.
+    locator = build_input_locator(params, output_root)
     indiv_dir = output_root / "2_NeuronalActivity" / "2A_IndividualNeuronalAnalysis"
     method = params.spikes_method
     base = params.to_stim_params_dict()
@@ -72,12 +76,13 @@ def run_stim_analysis(
     for rec in recordings:
         check_cancel(should_cancel)
         raw_path = raw_dir / f"{rec.filename}.mat"
-        npz_path = spike_dir / f"{rec.filename}_spikes.npz"
+        npz_path = locator.spike_file(rec.filename)
         if not raw_path.exists():
             log(f"  ! [{rec.filename}] raw file not found, skipping: {raw_path.name}")
             continue
-        if not npz_path.exists():
-            log(f"  ! [{rec.filename}] spike times not found ({npz_path.name}); run step 1 first. Skipping.")
+        if npz_path is None:
+            log(f"  ! [{rec.filename}] spike times not found ({rec.filename}_spikes.npz); "
+                f"run step 1 first. Skipping.")
             continue
 
         log(f"  [{rec.filename}] detecting stimulation…")
@@ -116,7 +121,8 @@ def run_stim_analysis(
             dest = indiv_dir / rec.group / rec.filename
             figs = write_stim_figures(dest, stim_info, patterns, spikes, sp_params,
                                       dat, artifact_dur, info,
-                                      rng=np.random.default_rng(1))
+                                      rng=make_rng(params.random_seed or 1,
+                                                   "stim-figures", rec.filename))
             log(f"  [{rec.filename}] wrote {len(figs)} stim figures")
         except Exception as e:   # plotting must never sink the numeric results
             log(f"  [{rec.filename}] Warning: stim plotting failed: {e}")


### PR DESCRIPTION
Two features from the MATLAB pipeline that Params exposed but nothing consumed.

Resume (pipeline/resume.py) — ports Params.priorAnalysis/startAnalysisStep. Output still goes to this run's own fresh folder; the prior run is only ever read. Only two artefacts cross step boundaries (step 1's spike .npz, step 3's adjM .npz), so InputLocator resolves both against this run's output folder, then spike_detected_data, then prior_analysis_path. It's a frozen dataclass of paths so it pickles into the spawned step-3/4 workers. runner.py now validates the configured paths and the starting step's inputs before any compute — a typo'd path used to degrade into a per-recording "SKIP" and a "successful" run with empty CSVs.

Resuming also required decoupling steps 2-4 from the raw recordings: step 1 now stores duration_s in the spike .npz and everything reads it back through one shared io.resolve_duration_s(), falling back to the raw file only for .npz files written before this change. That collapsed three divergent implementations, including step 2's hardcoded `if n_samples == 64` transposed check (Axion64-specific — a channels-major MCS60 file would have yielded duration_s = 60/fs and firing rates wrong by orders of magnitude) and its invented 60 s fallback, which is now a skip like steps 3/4 do.

Random seed (pipeline/rng.py) — Params.random_seed. None (default) keeps the previous behaviour, matching MATLAB, which seeds nothing. Generators are derived from (seed, step, recording) rather than one shared stream, so results don't depend on the auto-sized worker count or completion order; labels are hashed with BLAKE2b rather than hash(), since Python randomizes string hashing per process. Wired into steps 3/4, the step-1 check plots, stim figures and CAT-NAP, and exposed as a checkbox + spinbox on the GUI's Pipeline tab.

One extra fix was needed for "same seed -> same numbers" to hold literally: average/modal controllability are deterministic metrics, but both call svds(A, 1), and ARPACK draws its start vector from NumPy's global RNG, so they wobbled in the last ~2 ulps between runs and no seed could have fixed it. _dominant_singular_value() pins v0. MATLAB parity is unchanged — compare_step4_same_adjacency.py still reports worst-diff 2.842e-14 with aveControl at 2.9e-15.

Verified on the example data: step 3 and step 4 resumed from a prior run with raw_data pointed at a non-existent folder reproduced that run's adjacency bit-for-bit at the same seed; two step-4 runs at random_seed=42 produce byte-identical recording- and node-level CSVs across all 48 columns, and random_seed=7 differs.


Claude-Session: https://claude.ai/code/session_011zwY1zE3VLUne748MatjYf