### PR TITLE
feat(catnap): cell-type subnetwork analysis + GUI group editor

### DIFF
--- a/docs/python/catnap.md
+++ b/docs/python/catnap.md
@@ -72,6 +72,149 @@ uv run pip install git+https://github.com/j-friedrich/OASIS.git
 ```
 :::
 
+## Cell-type subnetworks
+
+If a recording folder contains a putative-cell-type spreadsheet, CAT-NAP can
+split the network by cell type and analyse each type separately — for example
+comparing the excitatory and inhibitory subnetworks.
+
+### The spreadsheet
+
+MEA-NAP looks for a single `.csv` (or `.xlsx`) inside the recording folder,
+alongside `suite2p/` — the same rule the MATLAB pipeline uses:
+
+```
+raw_data/
+└── MyRecording_DIV21/
+    ├── PutativeCellType_MyRecording_DIV21.csv
+    └── suite2p/plane0/…
+```
+
+One column per marker; each column lists the **0-indexed suite2p ROI ids**
+positive for that marker, padded with blanks to the longest column:
+
+| NeuN+ | Mecp2+ | PV+ | GAD+ |
+|---|---|---|---|
+| 68 | 53 | 26 | 7 |
+| 78 | 97 | 267 | 8 |
+| 117 | 270 | | 9 |
+
+### Defining subnetworks in the GUI
+
+The **Cell-type subnetworks** box on the CAT-NAP tab does all of this without
+writing expressions.
+
+1. Tick **Analyse cell-type subnetworks**.
+2. Leave **Cell-type file** blank to auto-detect a spreadsheet in each
+   recording's folder, or browse to a specific one. Markers load automatically
+   after a scan or when you select a recording; **Load markers** forces it.
+3. Pick a **Grouping**:
+   - *One subnetwork per marker* — no further setup.
+   - *Excitatory vs inhibitory* — derived from the inhibitory markers present.
+   - *Custom groups* — the grid below.
+   - *Custom groups (expressions)* — free text, for shapes the grid can't express.
+
+In the grid, each row is a subnetwork and each column a marker. Set every cell
+to **include**, **exclude**, or **—** (irrelevant), and use **Match** to say
+whether the *included* markers combine as "any of" (OR) or "all of" (AND);
+excluded markers must always be absent. **Add group** appends as many
+subnetworks as you want — the two starting rows are just a convenience for the
+excitatory/inhibitory case, not a limit.
+
+The **Expression** column shows exactly what each row compiles to, and the line
+underneath reports how many labelled cells each group would capture, so an empty
+or over-broad group is obvious before you run anything.
+
+### Defining subnetworks in code
+
+Set `twop_subnetwork_analysis = True`, then choose how the columns become
+groups with `twop_subnetwork_groups`:
+
+| Value | Meaning |
+|---|---|
+| `None` (default) | one subnetwork per spreadsheet column |
+| `"E/I"` | excitatory vs inhibitory, derived from whichever inhibitory markers (`GAD+`, `PV+`, `SST+`, `VIP+`, `GABA+`) are present |
+| a dict | your own named boolean combinations |
+
+```python
+from meanap.params import Params
+
+params = Params(
+    suite2p_mode=True,
+    twop_subnetwork_analysis=True,
+    twop_subnetwork_groups={
+        "Excitatory": "NeuN+ & ~GAD+ & ~PV+ & ~SST+",
+        "Inhibitory": "GAD+ | PV+ | SST+",
+        "Mecp2 positive": "Mecp2+",
+    },
+)
+```
+
+Expressions support `&` (and), `|` (or), `~` or `!` (not) and parentheses, with
+`&` binding tighter than `|` as in Python. Groups may overlap — a cell can be
+both `NeuN+` and `Mecp2+` — and any group that ends up empty is dropped, so a
+spec written for a rich marker panel still runs on a sparser recording.
+
+### What comes out
+
+Two complementary comparisons are produced for every recording and lag.
+
+**Induced subgraphs** keep only one cell type's nodes and the edges *among*
+them, then re-run the full step-4 metric suite on that subgraph. This answers
+"is the inhibitory network denser / more efficient / more small-world than the
+excitatory one?". Note these metrics are size-dependent, so read them alongside
+each group's node count (the figures annotate it).
+
+**Split whole-network metrics** leave the graph intact and just label each node
+with its cell type, then compare the node-level distributions. This answers "are
+inhibitory cells more hub-like *within the whole network*?" — usually the more
+interesting question, and not the same as the first.
+
+Figures land in
+`4_NetworkActivity/4A_IndividualNetworkAnalysis/{group}/{recording}/{lag}mslag/cellTypeSubnetworks/`:
+
+| File | Content |
+|---|---|
+| `1_CellTypeNetwork.png` | whole network, nodes coloured by cell type, within-type edges highlighted over pale between-type ones |
+| `2_SubnetworkGraphs.png` | one panel per cell type showing just its induced subgraph, on shared axes |
+| `3_NodeMetricsByCellType.png` | half-violin distributions of whole-network node metrics, split by cell type |
+| `4_SubnetworkMetrics.png` | graph-level metrics of each induced subgraph, versus the whole network |
+| `5_EdgeMixing.png` | cell type × cell type edge-density and mean-weight heatmaps |
+
+2P peak/STTC networks are often more than 80% dense, so the two graph figures
+draw only the strongest 3000 edges per group and say so in the panel caption.
+Metrics are always computed on the complete graph.
+
+Batch CSVs land in `4_NetworkActivity/`:
+
+| File | One row per |
+|---|---|
+| `Subnetwork_RecordingLevel.csv` | recording × lag × cell type — subgraph metrics (`Dens`, `Eglob`, `SW`, `Q`, plus `*_mean` collapses of the node metrics) |
+| `Subnetwork_NodeLevel.csv` | recording × lag × node × cell type — whole-network node metrics plus `WithinGroupStrengthFrac` |
+| `Subnetwork_EdgeMix.csv` | recording × lag × cell-type pair — `Density`, `MeanWeightNonzero`, `MeanWeightAll` |
+
+`Subnetwork_NodeLevel.csv` is long format: a node positive for two markers
+appears once per group, so each group's distribution is complete. Nodes in no
+group appear once under `Unassigned`.
+
+### Using it directly
+
+```python
+from meanap.catnap import subnetwork as sn
+
+table = sn.load_cell_type_table("PutativeCellType_MyRecording.csv")
+groups = sn.resolve_groups(table, channels, "E/I")
+print(groups.counts())          # {'Excitatory': 142, 'Inhibitory': 61}
+
+results = sn.compute_subnetwork_metrics(adjM, spike_counts, duration_s,
+                                        groups, params)
+mix = sn.compute_edge_mix(adjM, groups)
+nodes = sn.split_node_metrics(full_metrics, groups, channels, adj_m=adjM)
+```
+
+`python/run_catnap_subnetwork_demo.py` runs the whole thing end-to-end on the
+example dataset if you want a worked example to inspect.
+
 ## Using CAT-NAP from Python
 
 The scanner, loader, and denoising pipeline are all usable without the GUI:

--- a/python/CATNAP_PORT_PLAN.md
+++ b/python/CATNAP_PORT_PLAN.md
@@ -161,6 +161,70 @@ Both `plot_2p_traces` and the network plot are wired into `run_catnap_pipeline`
 
 ---
 
+### Phase 6 — Cell-type subnetworks ✅ (feature extension, no MATLAB counterpart)
+
+MATLAB only uses `Info.CellTypes` cosmetically (concentric rings around nodes in
+`StandardisedNetworkPlot.m`). This phase turns it into an analysis — the first
+CAT-NAP capability that goes **beyond** the MATLAB pipeline rather than porting
+it, so there is no parity ground truth; `python/test_catnap_subnetwork.py`
+checks correctness/self-consistency instead (45/45).
+
+| Piece | File |
+|---|---|
+| Group resolution, expressions, subgraph metrics, edge mixing, node split | `src/meanap/catnap/subnetwork.py` |
+| Figures (spatial, per-group panels, metric comparisons, mixing heatmaps) | `src/meanap/catnap/subnetwork_plotting.py` |
+| Runner wiring + 3 batch CSVs | `src/meanap/catnap/pipeline.py` (`_run_subnetwork_analysis`) |
+| Params (`twop_subnetwork_analysis` / `_groups` / `twop_cell_type_file`) | `src/meanap/params.py` |
+| GUI group editor (grid of groups × markers) | `src/meanap/gui/panels/cell_type_groups.py` |
+| GUI wiring (file picker, mode combo, live validation) | `src/meanap/gui/panels/catnap.py` |
+| Tests / demo run | `python/test_catnap_subnetwork.py`, `python/test_gui_cell_type_groups.py`, `python/run_catnap_subnetwork_demo.py` |
+| User docs | `docs/python/catnap.md` § Cell-type subnetworks |
+
+Two complementary comparisons, both requested and both shipped:
+
+1. **Induced subgraphs** — restrict `adjM` to one cell type's nodes and re-run
+   the *shared* `step4.compute_network_metrics`. Comparable across groups but
+   size-dependent, so every figure annotates `aN`.
+2. **Split whole-network node metrics** — leave the graph intact, label nodes
+   by type, compare ND/NS/PC/BC/Eloc distributions. Long format (one row per
+   node × group) because marker membership legitimately overlaps.
+
+Plus **edge mixing**: a group × group density / mean-weight matrix and a
+per-node `WithinGroupStrengthFrac`.
+
+Groups come from the recording folder's cell-type spreadsheet (MATLAB's
+`rawData/<FN>/*.csv` rule, extended to xlsx). Default is one group per marker
+column; `twop_subnetwork_groups="E/I"` derives excitatory/inhibitory from the
+inhibitory markers present; a dict takes boolean expressions
+(`"NeuN+ & ~GAD+ & ~PV+"`, `&` binding tighter than `|`).
+
+**GUI.** The CAT-NAP tab edits those expressions through a grid — rows are
+groups, columns are the spreadsheet's markers, each cell is include / exclude /
+irrelevant, plus a per-row any-of vs all-of match. Unlimited groups via **Add
+group** (two rows by default only because E/I is the common case).
+`build_group_expression` / `parse_group_expression_terms` in `subnetwork.py`
+round-trip the grid ↔ expression mapping exactly, including both shipped
+presets; anything the grid cannot represent (nested parens, mixed operators, a
+marker absent from the loaded file) makes `set_groups` return `False` and the
+panel falls back to a free-text mode, so a hand-written expression is never
+silently dropped. Group sizes are counted live from the spreadsheet as an upper
+bound on what a run will see.
+
+> ⚠️ **Two upstream hangs fixed in `pipeline/null_models.py`.** Small
+> subnetworks (`SST+` has 4 cells in the example data) reach graph shapes MEA
+> arrays never produce, and both BCT-derived rewiring routines spin forever
+> there — faithfully ported from MATLAB, which has the same bug:
+> - `randmio_und_signed` (via `participation_coef_norm`) draws 4 distinct nodes
+>   in a bare `while 1` → never terminates for `n < 4`. Now returns the input
+>   unchanged when `n < 4`.
+> - `_valid_quad_stream` (via `latmio_und_v2` / `randmio_und_v2`) searches for
+>   two edges with 4 distinct endpoints in a bare `while 1` → never terminates
+>   on a triangle, a star, or any degenerate component. Now bounded by a
+>   k²-scaled draw budget, after which the caller stops rewiring.
+>
+> Both only change behaviour where MATLAB would hang; ephys parity is
+> unaffected (null-model, small-worldness and step-4 suites still green).
+
 ## Reuse wins
 - Denoising / peak detection (`catnap/denoising.py`) — done.
 - STTC + probabilistic thresholding (`pipeline/probabilistic_threshold.py`) —

--- a/python/run_catnap_subnetwork_demo.py
+++ b/python/run_catnap_subnetwork_demo.py
@@ -1,0 +1,105 @@
+"""End-to-end CAT-NAP run with cell-type subnetwork analysis on the example data.
+
+Run from the repo root::
+
+    uv run python python/run_catnap_subnetwork_demo.py [--groups E/I|columns] [--out DIR]
+
+Uses the gitignored ``local/example2pdataWCellTypes`` dataset (the same one
+``python/test_pipeline_catnap.py`` checks parity against) and writes a full
+output tree — including the new
+``4A_IndividualNetworkAnalysis/.../cellTypeSubnetworks/`` figures and the three
+``Subnetwork_*.csv`` batch tables — so the feature can be inspected on real
+data. Skips with a clear message when the dataset is absent.
+
+Denoising output is already cached in the dataset, but a single-lag run still
+takes tens of minutes: probabilistic thresholding does 200 circular-shift
+repeats, and the step-4 metric suite (null models, modularity, normalized
+participation coefficient) then runs once for the whole network *and* once per
+cell-type subnetwork. Add lags only if you want them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import numpy as np  # noqa: E402
+
+from meanap.catnap.pipeline import run_catnap_pipeline  # noqa: E402
+from meanap.catnap.subnetwork import EXCITATORY_INHIBITORY_PRESET  # noqa: E402
+from meanap.params import Params  # noqa: E402
+from meanap.pipeline.spreadsheet import RecordingInfo  # noqa: E402
+
+DATASET_DIR = REPO_ROOT / "local" / "example2pdataWCellTypes"
+RECORDING = "OPME230825_1_20230915_P1_pup4A_Het_MOI50000_DIV21"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--groups", default="E/I",
+                    help="'E/I', 'columns' (one subnetwork per marker), or 'preset'")
+    ap.add_argument("--groups-json", default=None,
+                    help="JSON object (or path to one) of {group name: expression}, "
+                         "as the GUI's custom-group editor produces. Overrides --groups.")
+    ap.add_argument("--out", default=str(REPO_ROOT / "local" / "catnap_subnetwork_demo"))
+    ap.add_argument("--lags", type=int, nargs="+", default=[1000],
+                    help="lags in ms (default: just 1000 for a quick run)")
+    args = ap.parse_args()
+
+    if not (DATASET_DIR / RECORDING / "suite2p" / "plane0" / "stat.npy").exists():
+        print(f"SKIP: example dataset not found at {DATASET_DIR}")
+        return 0
+
+    if args.groups_json:
+        raw = args.groups_json
+        if Path(raw).exists():
+            raw = Path(raw).read_text()
+        groups = json.loads(raw)
+    else:
+        groups = {"E/I": "E/I", "columns": None,
+                  "preset": EXCITATORY_INHIBITORY_PRESET}[args.groups]
+    print(f"Groups: {groups}")
+
+    params = Params(
+        raw_data=str(DATASET_DIR),
+        suite2p_mode=True,
+        twop_activity="peaks",
+        func_con_lag_val=args.lags,
+        min_activity_level=0.01,
+        remove_nodes_with_no_peaks=True,
+        prob_thresh_rep_num=200,
+        prob_thresh_tail=0.05,
+        min_number_of_nodes_to_cal_net_met=25,
+        exclude_edges_below_threshold=True,
+        num_2p_traces=0,          # trace figures are not what we're inspecting here
+        twop_subnetwork_analysis=True,
+        twop_subnetwork_groups=groups,
+        random_seed=42,
+    )
+
+    recordings = [RecordingInfo(filename=RECORDING, div=21, group="HET")]
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    start = time.time()
+    run_catnap_pipeline(
+        params, recordings, out_root,
+        log=lambda m: print(m, flush=True),
+        rng=np.random.default_rng(params.random_seed),
+    )
+    print(f"\nDone in {time.time() - start:.0f}s → {out_root}")
+
+    for path in sorted(out_root.rglob("*")):
+        if path.is_file():
+            print(f"  {path.relative_to(out_root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_catnap_subnetwork.py
+++ b/python/test_catnap_subnetwork.py
@@ -1,0 +1,322 @@
+"""Test the CAT-NAP cell-type subnetwork analysis.
+
+Run from the repo root::
+
+    uv run python python/test_catnap_subnetwork.py
+
+This feature has **no MATLAB counterpart** (MATLAB only draws cell types as
+rings on the network plot), so unlike the other ``test_pipeline_*`` scripts
+there is no parity ground truth. Instead these are correctness and
+self-consistency checks:
+
+  - group expressions parse and evaluate with the right precedence;
+  - the marker membership matrix matches the source spreadsheet row-for-row;
+  - induced subgraphs really are the ``adjM`` restricted to their nodes, and
+    the metrics come out of the *shared* step-4 routine;
+  - edge-mix blocks partition every edge of the network exactly once;
+  - the long-format node table accounts for every active node, including
+    nodes with overlapping memberships.
+
+Section A runs on synthetic data and always executes. Section B runs against
+the real example dataset in the gitignored ``local/`` folder and **skips
+gracefully** when it is absent (so this is a no-op in CI).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.catnap import subnetwork as sn  # noqa: E402
+from meanap.params import Params  # noqa: E402
+
+DATASET_DIR = REPO_ROOT / "local" / "example2pdataWCellTypes"
+RECORDING = "OPME230825_1_20230915_P1_pup4A_Het_MOI50000_DIV21"
+CELLTYPE_CSV = DATASET_DIR / RECORDING / f"PutativeCellType_{RECORDING}_PositiveOnly.csv"
+SUITE2P_DIR = DATASET_DIR / RECORDING / "suite2p" / "plane0"
+EXPDATA_MAT = (DATASET_DIR / "OutputData22May2026" / "ExperimentMatFiles"
+               / f"{RECORDING}_OutputData22May2026.mat")
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+# ── Section A: synthetic ──────────────────────────────────────────────────────
+
+def _toy_table() -> pd.DataFrame:
+    """8 ROIs (0-indexed ids 0-7) with deliberately overlapping markers.
+
+    NeuN+ : 0 1 2 3 4 5      GAD+ : 4 5      PV+ : 5 6      Mecp2+ : 0 6
+    So ROI 5 is NeuN+/GAD+/PV+ (triple), ROI 6 is PV+ but not NeuN+, and
+    ROI 7 belongs to nothing.
+    """
+    return pd.DataFrame({
+        "NeuN+": pd.Series([0, 1, 2, 3, 4, 5], dtype=float),
+        "GAD+": pd.Series([4, 5], dtype=float),
+        "PV+": pd.Series([5, 6], dtype=float),
+        "Mecp2+": pd.Series([0, 6], dtype=float),
+    })
+
+
+def _expression_checks() -> list[Check]:
+    channels = np.arange(1, 9)  # 1-indexed ROI numbers 1..8 ↔ ids 0..7
+    matrix, names = sn.build_marker_matrix(_toy_table(), channels)
+    checks: list[Check] = []
+
+    def ev(expr):
+        return sn.eval_group_expression(expr, matrix, names)
+
+    checks.append(("marker matrix shape (8, 4)", matrix.shape == (8, 4),
+                   str(matrix.shape)))
+    checks.append(("NeuN+ membership = ids 0-5",
+                   np.array_equal(np.nonzero(matrix[:, names.index("NeuN+")])[0],
+                                  np.arange(6)), ""))
+
+    cases = [
+        ("GAD+", [4, 5]),
+        ("GAD+ | PV+", [4, 5, 6]),
+        ("GAD+ & PV+", [5]),
+        ("~GAD+", [0, 1, 2, 3, 6, 7]),
+        ("NeuN+ & ~GAD+", [0, 1, 2, 3]),
+        # & binds tighter than |, so this is GAD+ OR (PV+ AND Mecp2+) = {4,5,6}
+        ("GAD+ | PV+ & Mecp2+", [4, 5, 6]),
+        # parentheses override that: (GAD+ OR PV+) AND Mecp2+ = {6}
+        ("(GAD+ | PV+) & Mecp2+", [6]),
+        ("NeuN+ & ~GAD+ & ~PV+", [0, 1, 2, 3]),
+        ("!GAD+ & !PV+ & !Mecp2+", [1, 2, 3, 7]),   # ! alias for ~
+        ("gad+", [4, 5]),                            # case-insensitive fallback
+    ]
+    for expr, expected in cases:
+        got = np.nonzero(ev(expr))[0].tolist()
+        checks.append((f"expr {expr!r} → {expected}", got == expected, f"got {got}"))
+
+    for bad in ["GAD+ &", "(GAD+", "GAD+ | Foo+", "", "GAD+ PV+ )"]:
+        try:
+            ev(bad)
+            ok, detail = False, "no error raised"
+        except sn.GroupExpressionError as e:
+            ok, detail = True, str(e)
+        checks.append((f"invalid expr {bad!r} rejected", ok, detail))
+
+    ei = sn.default_ei_groups(names)
+    checks.append(("default_ei_groups builds E/I from present markers",
+                   ei is not None and set(ei) == {"Excitatory", "Inhibitory"}, str(ei)))
+    checks.append(("default_ei_groups → None with no inhibitory marker",
+                   sn.default_ei_groups(["NeuN+", "Mecp2+"]) is None, ""))
+
+    groups = sn.resolve_groups(_toy_table(), channels, "E/I")
+    exc = np.nonzero(groups.masks[:, groups.names.index("Excitatory")])[0].tolist()
+    inh = np.nonzero(groups.masks[:, groups.names.index("Inhibitory")])[0].tolist()
+    checks.append(("E/I preset: excitatory = NeuN+ minus GAD+/PV+",
+                   exc == [0, 1, 2, 3], f"got {exc}"))
+    checks.append(("E/I preset: inhibitory = GAD+ ∪ PV+", inh == [4, 5, 6], f"got {inh}"))
+
+    default = sn.resolve_groups(_toy_table(), channels, None)
+    checks.append(("default grouping = one per spreadsheet column",
+                   default.names == names, str(default.names)))
+
+    empty = sn.resolve_groups(_toy_table(), channels, {"Nobody": "GAD+ & Mecp2+",
+                                                      "Some": "GAD+"})
+    checks.append(("empty groups dropped, others kept",
+                   empty.names == ["Some"], str(empty.names)))
+    return checks
+
+
+def _structure_checks() -> list[Check]:
+    """Induced subgraph / edge-mix / node-split invariants on a random graph."""
+    rng = np.random.default_rng(0)
+    channels = np.arange(1, 9)
+    groups = sn.resolve_groups(_toy_table(), channels, "E/I")
+
+    adj = rng.random((8, 8))
+    adj = (adj + adj.T) / 2
+    adj[adj < 0.45] = 0.0          # make it sparse
+    np.fill_diagonal(adj, 0.0)
+
+    checks: list[Check] = []
+
+    # Induced subgraph == adjM restricted to the group's nodes.
+    idx = groups.indices("Inhibitory")
+    expected = adj[np.ix_(idx, idx)]
+    params = Params(min_activity_level=0.0, exclude_edges_below_threshold=True)
+    results = sn.compute_subnetwork_metrics(
+        adj, np.full(8, 100.0), 10.0, groups, params, min_nodes=2, rng=rng,
+    )
+    inh = results["Inhibitory"]
+    got_nodes = inh["subnetworkNodeIndex"]
+    checks.append(("induced subgraph node set matches group mask",
+                   np.array_equal(got_nodes, idx), f"{got_nodes} vs {idx}"))
+    sub = inh.get("adjMsub")
+    active = inh["activeChannelIndex"]
+    checks.append(("induced subgraph weights == adjM[group, group]",
+                   sub is not None and np.allclose(sub, expected[np.ix_(active, active)]), ""))
+    checks.append(("fullNetworkIndex maps back into the whole network",
+                   np.array_equal(inh["fullNetworkIndex"], idx[active]), ""))
+    checks.append(("node degree computed on the subgraph, not the full net",
+                   "ND" in inh and len(inh["ND"]) == inh["aN"], ""))
+
+    # Edge mix: every above-zero upper-triangle edge lands in exactly one block
+    # when the groups are disjoint (E/I is, by construction).
+    disjoint = not (groups.masks[:, 0] & groups.masks[:, 1]).any()
+    mix = sn.compute_edge_mix(adj, groups)
+    iu = np.triu_indices(8, k=1)
+    assigned = groups.masks.any(axis=1)
+    counted = int(mix["nEdges"].sum())
+    # Only edges whose BOTH endpoints are in some group can appear in a block.
+    both = np.outer(assigned, assigned)
+    truth = int(((adj[iu] > 0) & both[iu]).sum())
+    checks.append(("E/I groups are disjoint", disjoint, ""))
+    checks.append(("edge-mix blocks partition the edges exactly once",
+                   counted == truth, f"{counted} vs {truth}"))
+    n_possible = int(mix["nPossible"].sum())
+    n_exp = int((both[iu]).sum())
+    checks.append(("edge-mix nPossible == possible pairs among grouped nodes",
+                   n_possible == n_exp, f"{n_possible} vs {n_exp}"))
+
+    # Within-group strength fraction is a proper fraction.
+    frac = sn.within_group_strength_fraction(adj, groups)
+    all_frac = np.concatenate([v[np.isfinite(v)] for v in frac.values()])
+    checks.append(("within-group strength fraction ∈ [0, 1]",
+                   bool(((all_frac >= 0) & (all_frac <= 1)).all()), ""))
+
+    # Node split: long format, every active node represented, overlaps duplicated.
+    full = results[sn.WHOLE_NETWORK] if sn.WHOLE_NETWORK in results else None
+    from meanap.pipeline.step4 import compute_network_metrics
+    full = compute_network_metrics(adj, np.full(8, 100.0), 10.0, 0.0, 2,
+                                   params=params, rng=rng)
+    node_df = sn.split_node_metrics(full, groups, channels, adj_m=adj)
+    active_full = np.asarray(full["activeChannelIndex"])
+    covered = set(node_df["NodeIndex"])
+    checks.append(("every active node appears in the node table",
+                   covered == set(active_full.tolist()),
+                   f"{sorted(covered)} vs {sorted(active_full.tolist())}"))
+    checks.append(("node table is long format (Group column present)",
+                   "Group" in node_df.columns, str(list(node_df.columns)[:4])))
+    unassigned = node_df.loc[node_df["Group"] == "Unassigned", "NodeIndex"].tolist()
+    checks.append(("ungrouped node 7 lands in 'Unassigned'",
+                   7 in unassigned or 7 not in active_full, str(unassigned)))
+
+    # Overlapping groups must duplicate the node, one row per membership.
+    overlap = sn.resolve_groups(_toy_table(), channels,
+                                {"GAD": "GAD+", "PV": "PV+"})
+    odf = sn.split_node_metrics(full, overlap, channels, adj_m=adj)
+    node5 = odf[odf["NodeIndex"] == 5]
+    checks.append(("node in two groups yields two rows",
+                   set(node5["Group"]) == {"GAD", "PV"}, str(list(node5["Group"]))))
+
+    summary = pd.DataFrame(sn.subnetwork_summary_rows(results))
+    checks.append(("summary has one row per group (+ whole network)",
+                   set(summary["Group"]) == {"Excitatory", "Inhibitory"},
+                   str(list(summary["Group"]))))
+    checks.append(("summary collapses node arrays to *_mean scalars",
+                   "ND_mean" in summary.columns
+                   and summary["ND_mean"].map(np.isscalar).all(), ""))
+    return checks
+
+
+# ── Section B: real dataset ───────────────────────────────────────────────────
+
+def _dataset_checks() -> list[Check]:
+    import scipy.io as sio
+
+    checks: list[Check] = []
+    table = sn.load_cell_type_table(CELLTYPE_CSV)
+    checks.append(("cell-type CSV loads with 5 marker columns",
+                   list(table.columns) == ["NeuN+", "Mecp2+", "PV+", "SST+", "GAD+"],
+                   str(list(table.columns))))
+
+    # The PositiveOnly *xlsx* has prose in the "NeuN-" style columns; the loader
+    # must drop them rather than emitting a marker with no ids.
+    xlsx = DATASET_DIR / f"PutativeCellType_{RECORDING}_PositiveOnly.xlsx"
+    if xlsx.exists():
+        x_table = sn.load_cell_type_table(xlsx)
+        checks.append(("xlsx prose-only columns dropped",
+                       list(x_table.columns) == ["NeuN+", "Mecp2+", "PV+", "SST+", "GAD+"],
+                       str(list(x_table.columns))))
+
+    mat = sio.loadmat(EXPDATA_MAT, struct_as_record=False, squeeze_me=True)
+    channels = np.asarray(mat["channels"]).ravel()
+    adj = np.asarray(mat["adjMs"].adjM1000mslag, dtype=float)
+
+    groups = sn.resolve_groups(table, channels, None)
+    counts = groups.counts()
+    checks.append(("per-column groups resolve on the real recording",
+                   set(groups.names) == set(table.columns), str(groups.names)))
+    # Cross-check one marker by hand: how many of its ROI ids survived the
+    # iscell + no-peaks filtering into `channels`.
+    gad_ids = table["GAD+"].dropna().to_numpy(dtype=int) + 1
+    expected_gad = int(np.isin(gad_ids, channels).sum())
+    checks.append((f"GAD+ count matches CSV∩channels ({expected_gad})",
+                   counts.get("GAD+") == expected_gad,
+                   f"{counts.get('GAD+')} vs {expected_gad}"))
+
+    ei = sn.resolve_groups(table, channels, "E/I")
+    exc = ei.masks[:, ei.names.index("Excitatory")]
+    inh = ei.masks[:, ei.names.index("Inhibitory")]
+    checks.append(("E/I split is non-empty on the real recording",
+                   exc.sum() > 0 and inh.sum() > 0,
+                   f"E={int(exc.sum())} I={int(inh.sum())}"))
+    checks.append(("E and I are disjoint", not (exc & inh).any(), ""))
+    print(f"      (E={int(exc.sum())} cells, I={int(inh.sum())} cells, "
+          f"ungrouped={int((~ei.masks.any(axis=1)).sum())} of {len(channels)})")
+
+    mix = sn.compute_edge_mix(adj, ei)
+    checks.append(("edge mix has 3 blocks for 2 groups (E-E, E-I, I-I)",
+                   len(mix) == 3, str(len(mix))))
+    within = mix[mix["Kind"] == "within"]["Density"].to_numpy()
+    between = mix[mix["Kind"] == "between"]["Density"].to_numpy()
+    checks.append(("all densities are finite fractions",
+                   bool(np.all((within >= 0) & (within <= 1))
+                        and np.all((between >= 0) & (between <= 1))), ""))
+    print("      edge-mix densities: "
+          + ", ".join(f"{r.GroupA}-{r.GroupB}={r.Density:.3f}" for r in mix.itertuples()))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("CAT-NAP cell-type subnetwork analysis")
+    print("=" * 70)
+
+    total_pass = total = 0
+    # Built lazily so each section's report prints before the next one runs.
+    for title, build in [
+        ("Section A1 — group expressions:", _expression_checks),
+        ("Section A2 — subgraph / edge-mix / node-split structure:", _structure_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+
+    if CELLTYPE_CSV.exists() and EXPDATA_MAT.exists():
+        p, n = _report("Section B — real example dataset:", _dataset_checks())
+        total_pass += p
+        total += n
+    else:
+        print(f"\nSection B — SKIPPED (dataset not found at {DATASET_DIR})")
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_gui_cell_type_groups.py
+++ b/python/test_gui_cell_type_groups.py
@@ -1,0 +1,354 @@
+"""Test the CAT-NAP cell-type subnetwork GUI controls.
+
+Run from the repo root::
+
+    uv run python python/test_gui_cell_type_groups.py
+
+Drives the real PyQt6 widgets offscreen (``QT_QPA_PLATFORM=offscreen``, set
+below) — no display needed, so this runs anywhere the GUI dependencies are
+installed and skips cleanly when they are not.
+
+What it checks:
+  - the group grid compiles marker include/exclude choices into the same
+    expressions :mod:`meanap.catnap.subnetwork` consumes, for any number of
+    groups (not just two);
+  - selections survive loading a different spreadsheet's marker set;
+  - ``Params`` round-trips through ``load()``/``save()`` in every grouping mode,
+    including the free-text fallback for expressions the grid cannot represent;
+  - the panel auto-detects the example dataset's spreadsheet and validates
+    against its markers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+DATASET_DIR = REPO_ROOT / "local" / "example2pdataWCellTypes"
+RECORDING = "OPME230825_1_20230915_P1_pup4A_Het_MOI50000_DIV21"
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        print(f"  {flag} {name}" + ("" if ok else f"  [{detail}]"))
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+def _editor_checks(app) -> list[Check]:
+    from meanap.gui.panels.cell_type_groups import (
+        CellTypeGroupEditor, EXCLUDE, IGNORE, INCLUDE, _CELL_STATES, _N_LEAD,
+    )
+
+    checks: list[Check] = []
+    ed = CellTypeGroupEditor()
+    markers = ["NeuN+", "Mecp2+", "PV+", "SST+", "GAD+"]
+    ed.set_markers(markers)
+
+    checks.append(("starts with 2 group rows", ed._table.rowCount() == 2,
+                   str(ed._table.rowCount())))
+    checks.append(("marker columns match the spreadsheet", ed.markers() == markers,
+                   str(ed.markers())))
+
+    def set_cell(row: int, marker: str, state: str) -> None:
+        col = _N_LEAD + markers.index(marker)
+        ed._table.cellWidget(row, col).setCurrentIndex(_CELL_STATES.index(state))
+
+    def set_name(row: int, name: str) -> None:
+        ed._table.item(row, 0).setText(name)
+
+    def set_match(row: int, match: str) -> None:
+        ed._table.cellWidget(row, 1).setCurrentIndex(1 if match == "all" else 0)
+
+    # Row 0: Excitatory = NeuN+ and none of the inhibitory markers.
+    set_name(0, "Excitatory")
+    set_match(0, "all")
+    set_cell(0, "NeuN+", INCLUDE)
+    for m in ("GAD+", "PV+", "SST+"):
+        set_cell(0, m, EXCLUDE)
+
+    # Row 1: Inhibitory = any inhibitory marker.
+    set_name(1, "Inhibitory")
+    set_match(1, "any")
+    for m in ("GAD+", "PV+", "SST+"):
+        set_cell(1, m, INCLUDE)
+
+    # Markers appear in *column* order, which is the spreadsheet's order — not
+    # the order they happen to be written in EXCITATORY_INHIBITORY_PRESET. The
+    # expressions are equivalent; assert the deterministic one the grid emits.
+    groups = ed.groups()
+    checks.append(("Excitatory compiles to the expected expression",
+                   groups.get("Excitatory") == "NeuN+ & ~PV+ & ~SST+ & ~GAD+",
+                   str(groups.get("Excitatory"))))
+    checks.append(("Inhibitory compiles to the expected expression",
+                   groups.get("Inhibitory") == "PV+ | SST+ | GAD+",
+                   str(groups.get("Inhibitory"))))
+
+    # …and it must select the same cells as the shipped preset does.
+    from meanap.catnap.subnetwork import (
+        EXCITATORY_INHIBITORY_PRESET, eval_group_expression,
+    )
+    import numpy as np
+    combos = np.array([[bool(i >> b & 1) for b in range(len(markers))]
+                       for i in range(2 ** len(markers))])
+    same = all(
+        np.array_equal(eval_group_expression(groups[name], combos, markers),
+                       eval_group_expression(EXCITATORY_INHIBITORY_PRESET[name],
+                                             combos, markers))
+        for name in ("Excitatory", "Inhibitory")
+    )
+    checks.append(("grid output is equivalent to the shipped E/I preset "
+                   "on every marker combination", same, ""))
+
+    # More than two groups — the point of the Add group button.
+    for i, (name, marker) in enumerate([("Mecp2 positive", "Mecp2+"),
+                                        ("PV interneurons", "PV+"),
+                                        ("SST interneurons", "SST+")]):
+        ed._add_btn.click()
+        row = ed._table.rowCount() - 1
+        set_name(row, name)
+        set_cell(row, marker, INCLUDE)
+    groups = ed.groups()
+    checks.append(("supports 5 groups, not just 2", len(groups) == 5, str(list(groups))))
+    checks.append(("extra groups compile correctly",
+                   groups.get("PV interneurons") == "PV+"
+                   and groups.get("SST interneurons") == "SST+", str(groups)))
+
+    # Combined include + exclude with 'any'.
+    ed._add_btn.click()
+    row = ed._table.rowCount() - 1
+    set_name(row, "Mixed")
+    set_match(row, "any")
+    set_cell(row, "PV+", INCLUDE)
+    set_cell(row, "SST+", INCLUDE)
+    set_cell(row, "NeuN+", EXCLUDE)
+    checks.append(("'any of' with exclusions parenthesises correctly",
+                   ed.groups().get("Mixed") == "(PV+ | SST+) & ~NeuN+",
+                   str(ed.groups().get("Mixed"))))
+
+    # Rows with nothing selected are dropped rather than emitting "".
+    ed._add_btn.click()
+    set_name(ed._table.rowCount() - 1, "Empty")
+    checks.append(("rows with no markers selected are skipped",
+                   "Empty" not in ed.groups(), str(list(ed.groups()))))
+
+    # Every expression the grid produces must be valid to the analysis code.
+    from meanap.catnap.subnetwork import GroupExpressionError, eval_group_expression
+    import numpy as np
+    identity = np.eye(len(markers), dtype=bool)
+    ok, detail = True, ""
+    for name, expr in ed.groups().items():
+        try:
+            eval_group_expression(expr, identity, markers)
+        except GroupExpressionError as e:
+            ok, detail = False, f"{name}: {e}"
+    checks.append(("every emitted expression parses in the analysis code", ok, detail))
+
+    # Reloading a narrower spreadsheet keeps what still applies.
+    before = ed.groups()
+    ed.set_markers(["NeuN+", "GAD+"])
+    after = ed.groups()
+    checks.append(("selections survive a marker-set change",
+                   after.get("Excitatory") == "NeuN+ & ~GAD+"
+                   and after.get("Inhibitory") == "GAD+", str(after)))
+    checks.append(("groups whose markers all vanished are dropped",
+                   "PV interneurons" not in after and "Excitatory" in before,
+                   str(list(after))))
+
+    # Round-trip through set_groups.
+    ed2 = CellTypeGroupEditor()
+    ed2.set_markers(markers)
+    ok = ed2.set_groups(before)
+    checks.append(("set_groups round-trips the grid's own output",
+                   ok and ed2.groups() == before, f"{ok} {ed2.groups()}"))
+    checks.append(("set_groups reports failure on an expression it cannot show",
+                   ed2.set_groups({"Weird": "(NeuN+ | GAD+) & (PV+ | SST+)"}) is False,
+                   ""))
+
+    # No markers loaded yet: columns are adopted from the expressions.
+    ed3 = CellTypeGroupEditor()
+    ok = ed3.set_groups({"Inhibitory": "GAD+ | PV+"})
+    checks.append(("set_groups works before any spreadsheet is loaded",
+                   ok and ed3.markers() == ["GAD+", "PV+"]
+                   and ed3.groups() == {"Inhibitory": "GAD+ | PV+"},
+                   f"{ok} {ed3.markers()} {ed3.groups()}"))
+
+    ed._remove_btn.click()
+    checks.append(("Remove drops a row", ed._table.rowCount() == 6,
+                   str(ed._table.rowCount())))
+    return checks
+
+
+def _panel_checks(app) -> list[Check]:
+    from meanap.gui.panels.catnap import (
+        CatNapPanel, MODE_CUSTOM, MODE_EI, MODE_EXPRESSIONS, MODE_PER_MARKER,
+    )
+    from meanap.params import Params
+
+    checks: list[Check] = []
+    panel = CatNapPanel()
+
+    # ── Mode round-trips through Params ───────────────────────────────────────
+    for mode, expected in [
+        (MODE_PER_MARKER, None),
+        (MODE_EI, "E/I"),
+    ]:
+        panel._subnetwork_enabled.setChecked(True)
+        panel._group_mode.setCurrentText(mode)
+        p = Params()
+        panel.save(p)
+        checks.append((f"{mode!r} saves as {expected!r}",
+                       p.twop_subnetwork_groups == expected
+                       and p.twop_subnetwork_analysis is True,
+                       str(p.twop_subnetwork_groups)))
+        panel.load(p)
+        checks.append((f"{mode!r} reloads into the same mode",
+                       panel._group_mode.currentText() == mode,
+                       panel._group_mode.currentText()))
+
+    # Custom grid mode.
+    panel._group_mode.setCurrentText(MODE_CUSTOM)
+    panel._group_editor.set_markers(["NeuN+", "GAD+", "PV+"])
+    panel._group_editor.set_groups({"Excitatory": "NeuN+ & ~GAD+",
+                                    "Inhibitory": "GAD+ | PV+",
+                                    "PV cells": "PV+"})
+    p = Params()
+    panel.save(p)
+    checks.append(("custom grid saves 3 groups as expressions",
+                   p.twop_subnetwork_groups == {"Excitatory": "NeuN+ & ~GAD+",
+                                                "Inhibitory": "GAD+ | PV+",
+                                                "PV cells": "PV+"},
+                   str(p.twop_subnetwork_groups)))
+    panel.load(p)
+    checks.append(("custom grid reloads into the grid, not free text",
+                   panel._group_mode.currentText() == MODE_CUSTOM,
+                   panel._group_mode.currentText()))
+
+    # An expression the grid cannot represent must land in free-text mode.
+    p2 = Params(twop_subnetwork_analysis=True,
+                twop_subnetwork_groups={"Weird": "(NeuN+ | GAD+) & (PV+ | SST+)"})
+    panel.load(p2)
+    checks.append(("grid-inexpressible group falls back to free text",
+                   panel._group_mode.currentText() == MODE_EXPRESSIONS,
+                   panel._group_mode.currentText()))
+    p3 = Params()
+    panel.save(p3)
+    checks.append(("free-text fallback preserves the expression verbatim",
+                   p3.twop_subnetwork_groups == p2.twop_subnetwork_groups,
+                   str(p3.twop_subnetwork_groups)))
+
+    # Free-text parsing tolerates blanks/comments.
+    panel._group_mode.setCurrentText(MODE_EXPRESSIONS)
+    panel._group_text.setPlainText(
+        "# a comment\n\nInhibitory = GAD+ | PV+\nExcitatory=NeuN+ & ~GAD+\nnonsense line\n"
+    )
+    p4 = Params()
+    panel.save(p4)
+    checks.append(("free text skips comments and malformed lines",
+                   p4.twop_subnetwork_groups == {"Inhibitory": "GAD+ | PV+",
+                                                 "Excitatory": "NeuN+ & ~GAD+"},
+                   str(p4.twop_subnetwork_groups)))
+
+    # Disabling the analysis must not lose the group definitions.
+    panel._subnetwork_enabled.setChecked(False)
+    p5 = Params()
+    panel.save(p5)
+    checks.append(("unticking the checkbox keeps the groups but disables the run",
+                   p5.twop_subnetwork_analysis is False and bool(p5.twop_subnetwork_groups),
+                   str(p5.twop_subnetwork_analysis)))
+    return checks
+
+
+def _dataset_checks(app) -> list[Check]:
+    from meanap.gui.panels.catnap import CatNapPanel, MODE_EI
+
+    checks: list[Check] = []
+    panel = CatNapPanel()
+    panel._subnetwork_enabled.setChecked(True)
+    panel._celltype_file.setText(
+        str(DATASET_DIR / RECORDING / f"PutativeCellType_{RECORDING}_PositiveOnly.csv")
+    )
+    panel._load_markers(verbose=True)
+    checks.append(("panel loads the example spreadsheet's markers",
+                   panel._group_editor.markers()
+                   == ["NeuN+", "Mecp2+", "PV+", "SST+", "GAD+"],
+                   str(panel._group_editor.markers())))
+
+    panel._group_mode.setCurrentText(MODE_EI)
+    panel._validate_groups()
+    status = panel._group_status.text()
+    checks.append(("E/I mode validates against the real markers",
+                   "Excitatory" in status and "Inhibitory" in status and "⚠" not in status,
+                   status))
+
+    # Auto-detection: no explicit path, discovered from the scanned recordings.
+    panel._celltype_file.setText("")
+    panel._group_editor.set_markers([])
+    from meanap.catnap.scanner import find_suite2p_recordings
+    panel._recordings = find_suite2p_recordings(str(DATASET_DIR))
+    panel._load_markers()
+    checks.append((f"auto-detects the spreadsheet from {len(panel._recordings)} scanned "
+                   "recording(s)",
+                   panel._group_editor.markers()
+                   == ["NeuN+", "Mecp2+", "PV+", "SST+", "GAD+"],
+                   str(panel._group_editor.markers())))
+
+    # A bad marker name must surface as a warning, not a silent skip.
+    from meanap.gui.panels.catnap import MODE_EXPRESSIONS
+    panel._group_mode.setCurrentText(MODE_EXPRESSIONS)
+    panel._group_text.setPlainText("Typo = GAB+ | PV+")
+    panel._validate_groups()
+    checks.append(("a mistyped marker is flagged while editing",
+                   "⚠" in panel._group_status.text(), panel._group_status.text()))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("CAT-NAP cell-type subnetwork GUI")
+    print("=" * 70)
+
+    try:
+        from PyQt6.QtWidgets import QApplication
+    except ImportError as e:
+        print(f"\nSKIPPED — PyQt6 not available ({e})")
+        return 0
+
+    app = QApplication.instance() or QApplication([])
+
+    total_pass = total = 0
+    for title, build in [
+        ("Group grid editor:", _editor_checks),
+        ("CAT-NAP panel ↔ Params:", _panel_checks),
+    ]:
+        p, n = _report(title, build(app))
+        total_pass += p
+        total += n
+
+    if (DATASET_DIR / RECORDING).is_dir():
+        p, n = _report("Real example dataset:", _dataset_checks(app))
+        total_pass += p
+        total += n
+    else:
+        print(f"\nReal example dataset — SKIPPED (not found at {DATASET_DIR})")
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -95,6 +95,7 @@ def run_catnap_pipeline(
     all_stats: dict[str, dict] = {}
     all_coords: dict[str, np.ndarray] = {}
     all_channels: dict[str, np.ndarray] = {}
+    subnetwork_tables: dict[str, list] = {"summary": [], "node": [], "mix": []}
 
     for rec in recordings:
         check_cancel(should_cancel)
@@ -151,7 +152,14 @@ def run_catnap_pipeline(
 
         _plot_recording(params, rec, data, res, rec_results, output_root, log)
 
+        if params.twop_subnetwork_analysis:
+            _run_subnetwork_analysis(
+                params, rec, res, rec_results, spike_counts, duration_s,
+                min_nodes, output_root, subnetwork_tables, log, rng,
+            )
+
     _save_catnap_results(recordings, all_results, all_stats, net_dir, log)
+    _save_subnetwork_results(subnetwork_tables, net_dir, log)
     log("  CAT-NAP pipeline complete.")
 
 
@@ -189,6 +197,122 @@ def _plot_recording(params, rec, data, res, rec_results, output_root, log) -> No
             )
         except Exception as e:
             log(f"  [{rec.filename}] warning: network plot (lag={lag_ms}) failed: {e}")
+
+
+# Node-level metrics compared across cell types (whole-network role of each
+# cell), and graph-level metrics compared across induced subgraphs. Both lists
+# are filtered against what a given run actually produced.
+_SUBNET_NODE_METRICS = ["ND", "NS", "MEW", "Eloc", "BC", "PC", "Z", "NE",
+                        "CC_raw", "WithinGroupStrengthFrac"]
+_SUBNET_GRAPH_METRICS = ["Dens", "NDmean", "NSmean", "MEW_mean", "Eglob",
+                         "ElocMean", "CC_rawMean", "SW", "SWw", "Q", "nMod"]
+
+
+def _run_subnetwork_analysis(
+    params, rec, res, rec_results, spike_counts, duration_s, min_nodes,
+    output_root, tables, log, rng,
+) -> None:
+    """Cell-type subnetwork analysis for one recording, across all lags.
+
+    Guarded end-to-end: a missing/unparseable cell-type spreadsheet or a
+    failing figure logs a warning and leaves the rest of the run intact — the
+    core CAT-NAP outputs never depend on this.
+    """
+    from meanap.catnap import subnetwork as sn
+    from meanap.catnap import subnetwork_plotting as snp
+
+    try:
+        path = (Path(params.twop_cell_type_file) if params.twop_cell_type_file
+                else sn.find_cell_type_file(params.raw_data, rec.filename))
+        if path is None or not Path(path).exists():
+            log(f"  [{rec.filename}] subnetworks: no cell-type file found — skipping")
+            return
+        table = sn.load_cell_type_table(path)
+        groups = sn.resolve_groups(table, res.channels, params.twop_subnetwork_groups)
+    except Exception as e:
+        log(f"  [{rec.filename}] warning: subnetwork setup failed: {e}")
+        return
+
+    if groups.n_groups == 0:
+        log(f"  [{rec.filename}] subnetworks: no non-empty groups in {Path(path).name}")
+        return
+    counts = ", ".join(f"{k}={v}" for k, v in groups.counts().items())
+    log(f"  [{rec.filename}] subnetworks from {Path(path).name}: {counts}")
+
+    for lag_key, full_metrics in rec_results.items():
+        if "adjMsub" not in full_metrics:
+            continue
+        lag_ms = int(lag_key.replace("mslag", ""))
+        adj_full = res.adjMs[f"adjM{lag_ms}mslag"]
+        base = {"FileName": rec.filename, "Grp": rec.group, "DIV": rec.div, "Lag": lag_key}
+        out_dir = (output_root / "4_NetworkActivity" / "4A_IndividualNetworkAnalysis"
+                   / rec.group / rec.filename / f"{lag_ms}mslag" / "cellTypeSubnetworks")
+
+        try:
+            log(f"  [{rec.filename}] subnetwork metrics (lag={lag_ms}ms)…")
+            results = sn.compute_subnetwork_metrics(
+                adj_full, spike_counts, duration_s, groups, params,
+                min_nodes=min_nodes, rng=rng, full_metrics=full_metrics,
+            )
+            summary = pd.DataFrame(sn.subnetwork_summary_rows(results))
+            node_df = sn.split_node_metrics(full_metrics, groups, res.channels,
+                                            adj_m=adj_full)
+
+            # Edge mixing is measured on the analysed (active) subgraph, so it
+            # describes the same network the whole-network metrics do.
+            active = np.asarray(full_metrics["activeChannelIndex"], dtype=int)
+            active_groups = groups.subset(active)
+            edge_mix = sn.compute_edge_mix(full_metrics["adjMsub"], active_groups)
+        except Exception as e:
+            log(f"  [{rec.filename}] warning: subnetwork metrics (lag={lag_ms}) failed: {e}")
+            continue
+
+        tables["summary"].extend(dict(base, **row) for row in summary.to_dict("records"))
+        tables["node"].extend(dict(base, **row) for row in node_df.to_dict("records"))
+        tables["mix"].extend(dict(base, **row) for row in edge_mix.to_dict("records"))
+
+        title = f"{rec.filename}  {lag_ms} ms lag"
+        coords_active = res.coords[active]
+        figures = [
+            ("1_CellTypeNetwork.png",
+             lambda p: snp.plot_subnetwork_spatial(
+                 full_metrics["adjMsub"], coords_active, active_groups, p, title)),
+            ("2_SubnetworkGraphs.png",
+             lambda p: snp.plot_subnetwork_panels(
+                 full_metrics["adjMsub"], coords_active, active_groups, p, title)),
+            ("3_NodeMetricsByCellType.png",
+             lambda p: snp.plot_node_metrics_by_group(
+                 node_df, _SUBNET_NODE_METRICS, p,
+                 f"{title} — whole-network node metrics by cell type", rng)),
+            ("4_SubnetworkMetrics.png",
+             lambda p: snp.plot_subnetwork_metric_bars(
+                 summary, _SUBNET_GRAPH_METRICS, p,
+                 f"{title} — metrics of each cell-type subnetwork")),
+            ("5_EdgeMixing.png",
+             lambda p: snp.plot_edge_mix_matrix(
+                 edge_mix, active_groups, p, f"{title} — connectivity within/between cell types")),
+        ]
+        for name, draw in figures:
+            try:
+                draw(out_dir / name)
+            except Exception as e:
+                log(f"  [{rec.filename}] warning: subnetwork figure {name} failed: {e}")
+
+
+def _save_subnetwork_results(tables: dict[str, list], net_dir: Path, log) -> None:
+    """Write the three batch-level cell-type subnetwork CSVs."""
+    outputs = {
+        "summary": "Subnetwork_RecordingLevel.csv",
+        "node": "Subnetwork_NodeLevel.csv",
+        "mix": "Subnetwork_EdgeMix.csv",
+    }
+    for key, filename in outputs.items():
+        if not tables[key]:
+            continue
+        try:
+            pd.DataFrame(tables[key]).to_csv(net_dir / filename, index=False)
+        except Exception as e:
+            log(f"  Warning: could not save {filename}: {e}")
 
 
 def _save_catnap_results(

--- a/src/meanap/catnap/subnetwork.py
+++ b/src/meanap/catnap/subnetwork.py
@@ -1,0 +1,706 @@
+"""Cell-type subnetwork analysis for CAT-NAP.
+
+A CAT-NAP recording comes with a *putative cell type* spreadsheet listing, for
+each immunohistochemistry marker (``NeuN+``, ``GAD+``, ``PV+``, …), the suite2p
+ROI ids that stained positive. MATLAB only uses that table cosmetically — as
+concentric rings drawn around nodes in the network plot
+(``StandardisedNetworkPlot.m``). This module turns it into an analysis:
+
+**Induced subgraphs.** For each named group of cells (a marker column, or a
+boolean combination of them such as ``Inhibitory = GAD+ | PV+ | SST+``), take
+the nodes belonging to that group and the edges *among* them, and re-run the
+shared step-4 metric suite on that subgraph. Answers "is the inhibitory network
+denser / more efficient / more small-world than the excitatory one?".
+
+**Split full-network metrics.** Tag every node of the *whole* network with its
+group(s) and compare the node-level distributions (node degree, node strength,
+participation coefficient, betweenness, local efficiency, …). Answers "are
+inhibitory cells more hub-like within the whole network?".
+
+**Edge mixing.** How connectivity distributes within versus between groups
+(a group × group density / mean-weight matrix, plus a per-node
+within-group-strength fraction).
+
+Group membership is deliberately allowed to overlap — a cell can be both
+``NeuN+`` and ``Mecp2+`` — so the node-level output is *long* format (one row
+per node × group), never a single hard assignment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from meanap.catnap.stats import get_cell_type_matrix
+
+# Markers conventionally taken to indicate a GABAergic (inhibitory) cell. Used
+# by :func:`default_ei_groups` to build an excitatory/inhibitory split from
+# whatever subset of them a given spreadsheet happens to contain.
+INHIBITORY_MARKERS = ("GAD+", "PV+", "SST+", "VIP+", "GABA+")
+
+# Marker taken to mean "is a neuron at all" — excitatory cells are defined as
+# neurons that are not positive for any inhibitory marker.
+NEURON_MARKER = "NeuN+"
+
+# Ready-made preset for the marker set shipped with the example dataset
+# (``local/example2pdataWCellTypes``). Assign to
+# ``Params.twop_subnetwork_groups`` to compare excitatory against inhibitory
+# cells; :func:`default_ei_groups` derives the same thing from whichever
+# markers are actually present.
+EXCITATORY_INHIBITORY_PRESET: dict[str, str] = {
+    "Excitatory": "NeuN+ & ~GAD+ & ~PV+ & ~SST+",
+    "Inhibitory": "GAD+ | PV+ | SST+",
+}
+
+
+# ── Locating and loading the cell-type spreadsheet ────────────────────────────
+
+def find_cell_type_file(raw_data: str | Path, filename: str) -> Path | None:
+    """Locate a recording's cell-type spreadsheet.
+
+    Mirrors ``MEApipeline.m``, which globs ``rawData/<FN>/*.csv`` and reads it
+    when exactly one match exists; extended here to accept ``.xlsx``/``.xls``
+    too, and to disambiguate several matches by preferring names starting with
+    ``PutativeCellType``. Returns ``None`` when nothing plausible is found.
+    """
+    folder = Path(raw_data) / filename
+    if not folder.is_dir():
+        return None
+
+    candidates = sorted(
+        p for ext in ("*.csv", "*.xlsx", "*.xls") for p in folder.glob(ext)
+    )
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    preferred = [p for p in candidates if p.name.lower().startswith("putativecelltype")]
+    return (preferred or candidates)[0]
+
+
+def load_cell_type_table(path: str | Path) -> pd.DataFrame:
+    """Read a cell-type spreadsheet (CSV or Excel) of ROI ids per marker.
+
+    One column per marker; each column lists the **0-indexed** suite2p ROI ids
+    positive for that marker, NaN-padded to the longest column (the format the
+    ``PutativeCellType_*`` files use).
+
+    Columns that hold no usable ids are dropped. This matters for the
+    ``…_PositiveOnly.xlsx`` variant, whose ``NeuN-``-style columns contain a
+    single sentence of prose ("Should be all those that are not in List NeuN+")
+    rather than ids — MATLAB reads the ``.csv`` sibling, which omits them
+    entirely.
+    """
+    path = Path(path)
+    df = pd.read_excel(path) if path.suffix.lower() in (".xlsx", ".xls") else pd.read_csv(path)
+
+    keep: dict[str, pd.Series] = {}
+    for col in df.columns:
+        ids = pd.to_numeric(df[col], errors="coerce").dropna()
+        if len(ids):
+            keep[str(col).strip()] = ids.reset_index(drop=True)
+    return pd.DataFrame(keep)
+
+
+def build_marker_matrix(
+    cell_type_df: pd.DataFrame, channels: np.ndarray,
+) -> tuple[np.ndarray, list[str]]:
+    """``(n_channels, n_markers)`` binary membership matrix for *channels*.
+
+    Thin wrapper over :func:`meanap.catnap.stats.get_cell_type_matrix` (the
+    ``getCellTypeMatrix.m`` port), which handles the 0-indexed-ROI → 1-indexed
+    ``channels`` conversion.
+    """
+    ids = {col: cell_type_df[col].to_numpy(dtype=float) for col in cell_type_df.columns}
+    matrix, names = get_cell_type_matrix(ids, channels)
+    return matrix.astype(bool), names
+
+
+# ── Group expressions ─────────────────────────────────────────────────────────
+
+class GroupExpressionError(ValueError):
+    """Raised when a subnetwork group expression cannot be parsed."""
+
+
+def _tokenize(expr: str, marker_names: list[str]) -> list[str]:
+    """Split *expr* into marker names and the operators ``& | ~ ( )``.
+
+    Marker names are matched greedily longest-first because they contain
+    characters (``+``, ``-``) that would otherwise be mistaken for operators or
+    split apart — ``NeuN+`` has to win over a hypothetical ``NeuN``.
+    """
+    by_length = sorted(marker_names, key=len, reverse=True)
+    lowered = {n.lower(): n for n in marker_names}
+    tokens: list[str] = []
+    i = 0
+    while i < len(expr):
+        ch = expr[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch in "&|~()":
+            tokens.append(ch)
+            i += 1
+            continue
+        if ch == "!":  # accept ! as an alias for ~
+            tokens.append("~")
+            i += 1
+            continue
+        for name in by_length:
+            if expr.startswith(name, i):
+                tokens.append(name)
+                i += len(name)
+                break
+        else:
+            # Case-insensitive fallback, so "gad+" still resolves.
+            match = next(
+                (lowered[n.lower()] for n in by_length
+                 if expr[i:i + len(n)].lower() == n.lower()), None,
+            )
+            if match is None:
+                raise GroupExpressionError(
+                    f"unrecognised token at position {i} in {expr!r}; "
+                    f"known markers: {', '.join(marker_names)}"
+                )
+            tokens.append(match)
+            i += len(match)
+    return tokens
+
+
+def eval_group_expression(
+    expr: str, marker_matrix: np.ndarray, marker_names: list[str],
+) -> np.ndarray:
+    """Evaluate a boolean marker expression into an ``(n_channels,)`` mask.
+
+    Supported syntax: marker names, ``&`` (and), ``|`` (or), ``~`` / ``!``
+    (not), and parentheses. ``&`` binds tighter than ``|``, as in Python.
+
+        >>> eval_group_expression("GAD+ | PV+ | SST+", m, names)   # inhibitory
+        >>> eval_group_expression("NeuN+ & ~GAD+", m, names)       # excitatory
+    """
+    tokens = _tokenize(expr, marker_names)
+    if not tokens:
+        raise GroupExpressionError(f"empty group expression: {expr!r}")
+    col_of = {name: i for i, name in enumerate(marker_names)}
+    pos = 0
+
+    def parse_or() -> np.ndarray:
+        nonlocal pos
+        value = parse_and()
+        while pos < len(tokens) and tokens[pos] == "|":
+            pos += 1
+            value = value | parse_and()
+        return value
+
+    def parse_and() -> np.ndarray:
+        nonlocal pos
+        value = parse_not()
+        while pos < len(tokens) and tokens[pos] == "&":
+            pos += 1
+            value = value & parse_not()
+        return value
+
+    def parse_not() -> np.ndarray:
+        nonlocal pos
+        if pos < len(tokens) and tokens[pos] == "~":
+            pos += 1
+            return ~parse_not()
+        return parse_atom()
+
+    def parse_atom() -> np.ndarray:
+        nonlocal pos
+        if pos >= len(tokens):
+            raise GroupExpressionError(f"unexpected end of expression: {expr!r}")
+        tok = tokens[pos]
+        if tok == "(":
+            pos += 1
+            value = parse_or()
+            if pos >= len(tokens) or tokens[pos] != ")":
+                raise GroupExpressionError(f"unbalanced parentheses in {expr!r}")
+            pos += 1
+            return value
+        if tok in (")", "&", "|"):
+            raise GroupExpressionError(f"unexpected {tok!r} in {expr!r}")
+        pos += 1
+        return marker_matrix[:, col_of[tok]].astype(bool)
+
+    mask = parse_or()
+    if pos != len(tokens):
+        raise GroupExpressionError(f"trailing tokens after position {pos} in {expr!r}")
+    return mask
+
+
+def _tokenize_lenient(expr: str) -> list[str]:
+    """Tokenize without knowing the marker names.
+
+    Used when reconstructing a saved expression before any spreadsheet has been
+    read (the GUI can be opened on a saved parameter file with no data loaded).
+    Any maximal run of characters that are not operators or whitespace is taken
+    to be a marker name — correct for the ``NeuN+`` / ``GAD+`` style names these
+    spreadsheets use, though it would split a name containing a space.
+    """
+    tokens: list[str] = []
+    current = ""
+    for ch in expr:
+        if ch in "&|~()" or ch.isspace() or ch == "!":
+            if current:
+                tokens.append(current)
+                current = ""
+            if ch == "!":
+                tokens.append("~")
+            elif not ch.isspace():
+                tokens.append(ch)
+        else:
+            current += ch
+    if current:
+        tokens.append(current)
+    return tokens
+
+
+def build_group_expression(
+    include: list[str], exclude: list[str], match: str = "any",
+) -> str:
+    """Compose a group expression from included/excluded markers.
+
+    ``match`` applies to *include* only: ``"any"`` joins them with ``|``,
+    ``"all"`` with ``&``. Excluded markers are always AND-ed as ``~marker``, so
+    "any of these, but none of those" and "all of these, but none of those" are
+    both expressible — which is what the GUI's include/exclude grid offers.
+
+    Round-trips with :func:`parse_group_expression_terms`.
+    """
+    parts: list[str] = []
+    if include:
+        if len(include) == 1:
+            parts.append(include[0])
+        elif match == "all":
+            parts.append(" & ".join(include))
+        else:
+            parts.append(" | ".join(include) if not exclude
+                         else "(" + " | ".join(include) + ")")
+    parts += [f"~{name}" for name in exclude]
+    return " & ".join(parts)
+
+
+def parse_group_expression_terms(
+    expr: str, marker_names: list[str] | None = None,
+) -> tuple[str, list[str], list[str]] | None:
+    """Inverse of :func:`build_group_expression`.
+
+    Returns ``(match, include, exclude)``, or ``None`` when *expr* is richer
+    than the include/exclude form — nested parentheses, mixed ``&``/``|`` at the
+    same level, and so on. Callers offering a grid UI should fall back to a
+    free-text editor on ``None`` rather than silently dropping the expression.
+
+    ``marker_names`` makes tokenization exact; without it names are guessed
+    (see :func:`_tokenize_lenient`).
+    """
+    tokens = (_tokenize(expr, marker_names) if marker_names
+              else _tokenize_lenient(expr))
+    if not tokens:
+        return None
+
+    # Split on top-level '&'.
+    conjuncts: list[list[str]] = [[]]
+    depth = 0
+    for tok in tokens:
+        if tok == "(":
+            depth += 1
+        elif tok == ")":
+            depth -= 1
+        if tok == "&" and depth == 0:
+            conjuncts.append([])
+        else:
+            conjuncts[-1].append(tok)
+    if any(not c for c in conjuncts):
+        return None
+
+    def as_or_chain(part: list[str]) -> list[str] | None:
+        """``A | B | C`` → ``[A, B, C]``; anything else → None."""
+        if not part or len(part) % 2 == 0:
+            return None
+        names, ops = part[0::2], part[1::2]
+        if any(n in ("&", "|", "~", "(", ")") for n in names):
+            return None
+        return names if all(op == "|" for op in ops) else None
+
+    include_any: list[str] | None = None
+    include_all: list[str] = []
+    exclude: list[str] = []
+
+    for part in conjuncts:
+        if part[0] == "(" and part[-1] == ")":
+            part = part[1:-1]
+            names = as_or_chain(part)
+            if names is None or include_any is not None:
+                return None
+            include_any = names
+        elif len(part) == 2 and part[0] == "~":
+            exclude.append(part[1])
+        elif len(part) == 1:
+            include_all.append(part[0])
+        elif len(conjuncts) == 1:
+            names = as_or_chain(part)
+            if names is None:
+                return None
+            include_any = names
+        else:
+            return None
+
+    if include_any is not None:
+        return None if include_all else ("any", include_any, exclude)
+    if not include_all and not exclude:
+        return None
+    return ("all", include_all, exclude)
+
+
+def default_ei_groups(marker_names: list[str]) -> dict[str, str] | None:
+    """Build an excitatory/inhibitory group spec from the markers available.
+
+    Returns ``None`` when the spreadsheet has no inhibitory marker (in which
+    case an E/I split is not derivable and the caller should fall back to
+    one group per column).
+    """
+    inhibitory = [n for n in INHIBITORY_MARKERS if n in marker_names]
+    if not inhibitory:
+        return None
+    inh_expr = " | ".join(inhibitory)
+    not_inh = " & ".join(f"~{n}" for n in inhibitory)
+    exc_expr = f"{NEURON_MARKER} & {not_inh}" if NEURON_MARKER in marker_names else not_inh
+    return {"Excitatory": exc_expr, "Inhibitory": inh_expr}
+
+
+@dataclass
+class CellTypeGroups:
+    """Resolved subnetwork groups for one recording.
+
+    Attributes
+    ----------
+    names : group names, in output order.
+    masks : ``(n_channels, n_groups)`` boolean membership; columns may overlap.
+    marker_names, marker_matrix : the underlying spreadsheet columns.
+    definitions : group name → the expression it was built from.
+    """
+
+    names: list[str]
+    masks: np.ndarray
+    marker_names: list[str]
+    marker_matrix: np.ndarray
+    definitions: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def n_groups(self) -> int:
+        return len(self.names)
+
+    def indices(self, group: str, within: np.ndarray | None = None) -> np.ndarray:
+        """0-based node indices belonging to *group*.
+
+        ``within`` restricts to (and re-indexes against) a subset of channels —
+        pass ``metrics["activeChannelIndex"]`` to get positions into the active
+        subgraph rather than into the full channel list.
+        """
+        mask = self.masks[:, self.names.index(group)]
+        if within is None:
+            return np.nonzero(mask)[0]
+        return np.nonzero(mask[np.asarray(within, dtype=int)])[0]
+
+    def counts(self) -> dict[str, int]:
+        return {name: int(self.masks[:, i].sum()) for i, name in enumerate(self.names)}
+
+    def subset(self, indices: np.ndarray) -> "CellTypeGroups":
+        """Same groups, restricted to a subset of nodes (e.g. the active ones).
+
+        Group names are kept even if a group ends up empty, so a subsetted
+        object still lines up column-for-column with the original.
+        """
+        idx = np.asarray(indices, dtype=int)
+        return CellTypeGroups(list(self.names), self.masks[idx], list(self.marker_names),
+                              self.marker_matrix[idx], dict(self.definitions))
+
+
+def resolve_groups(
+    cell_type_df: pd.DataFrame,
+    channels: np.ndarray,
+    group_spec: dict[str, str] | str | None = None,
+) -> CellTypeGroups:
+    """Turn a cell-type table into named node groups.
+
+    ``group_spec`` may be:
+
+    - ``None`` (default) — one group per spreadsheet column;
+    - ``"E/I"`` — the excitatory/inhibitory split derived from the markers
+      present (:func:`default_ei_groups`), falling back to per-column when no
+      inhibitory marker exists;
+    - a dict of ``{group name: boolean marker expression}``.
+
+    Groups that end up empty are dropped (with the rest kept), so a spec
+    written for a richer marker panel still works on a sparser recording.
+    """
+    marker_matrix, marker_names = build_marker_matrix(cell_type_df, channels)
+
+    if isinstance(group_spec, str):
+        if group_spec.strip().upper() not in ("E/I", "EI", "E_I"):
+            raise GroupExpressionError(
+                f"unknown group preset {group_spec!r}; use 'E/I', None, or a dict"
+            )
+        group_spec = default_ei_groups(marker_names)
+
+    if not group_spec:
+        definitions = {name: name for name in marker_names}
+    else:
+        definitions = dict(group_spec)
+
+    names: list[str] = []
+    columns: list[np.ndarray] = []
+    kept: dict[str, str] = {}
+    for name, expr in definitions.items():
+        mask = eval_group_expression(expr, marker_matrix, marker_names)
+        if not mask.any():
+            continue
+        names.append(name)
+        columns.append(mask)
+        kept[name] = expr
+
+    masks = (np.column_stack(columns) if columns
+             else np.zeros((len(np.asarray(channels).ravel()), 0), dtype=bool))
+    return CellTypeGroups(names, masks, marker_names, marker_matrix, kept)
+
+
+# ── Induced-subgraph metrics ──────────────────────────────────────────────────
+
+# Label used for the reference row/panel covering every node, regardless of type.
+WHOLE_NETWORK = "Whole network"
+
+
+def compute_subnetwork_metrics(
+    adj_m: np.ndarray,
+    spike_counts: np.ndarray,
+    duration_s: float,
+    groups: CellTypeGroups,
+    params,
+    *,
+    min_nodes: int = 25,
+    rng: np.random.Generator | None = None,
+    full_metrics: dict | None = None,
+) -> dict[str, dict]:
+    """Re-run the shared step-4 metric suite on each group's induced subgraph.
+
+    The subgraph keeps only the group's nodes and the edges *among* them;
+    ``compute_network_metrics`` then applies its usual active-node filter
+    (nonzero strength + minimum activity) inside that subgraph, so a cell with
+    no within-group partners drops out — which is the intended semantics.
+
+    ``full_metrics`` (the already-computed whole-network result) is echoed back
+    under :data:`WHOLE_NETWORK` as a reference row rather than recomputed, since
+    the small-worldness null models are the expensive part.
+
+    Returns ``{group name: metrics dict}``; groups smaller than *min_nodes*
+    still appear but carry only ``aN`` / ``activeChannelIndex``, exactly as
+    ``compute_network_metrics`` does for a too-small network.
+    """
+    from meanap.pipeline.step4 import compute_network_metrics
+
+    results: dict[str, dict] = {}
+    if full_metrics is not None:
+        results[WHOLE_NETWORK] = full_metrics
+
+    for name in groups.names:
+        idx = groups.indices(name)
+        if idx.size == 0:
+            continue
+        sub = adj_m[np.ix_(idx, idx)]
+        metrics = compute_network_metrics(
+            sub, np.asarray(spike_counts, dtype=float)[idx], duration_s,
+            params.min_activity_level, min_nodes,
+            exclude_edges_below_threshold=params.exclude_edges_below_threshold,
+            params=params, rng=rng,
+        )
+        # activeChannelIndex is relative to the subgraph; also record where
+        # those nodes sit in the full network so callers can map back.
+        metrics["subnetworkNodeIndex"] = idx
+        metrics["fullNetworkIndex"] = idx[metrics["activeChannelIndex"]]
+        results[name] = metrics
+
+    return results
+
+
+# ── Edge mixing ───────────────────────────────────────────────────────────────
+
+def compute_edge_mix(
+    adj_m: np.ndarray, groups: CellTypeGroups, edge_thresh: float = 0.0,
+) -> pd.DataFrame:
+    """Group × group connectivity summary.
+
+    One row per ordered-but-unique group pair (``A–A``, ``A–B``, ``B–B``) with:
+
+    - ``nPossible`` / ``nEdges`` / ``Density`` — how many of the possible node
+      pairs in that block carry an edge above *edge_thresh*;
+    - ``MeanWeightNonzero`` — mean weight over the edges that exist;
+    - ``MeanWeightAll`` — mean over every possible pair (zeros included), the
+      quantity that scales with both density and strength.
+
+    Self-connections are excluded throughout; within-group blocks count each
+    undirected pair once. Between-group blocks count each pair once when the
+    groups are disjoint; where two groups overlap, a pair of shared nodes is
+    counted in both directions (it belongs to the block twice over), which
+    leaves the density and mean-weight ratios unchanged.
+    """
+    adj = np.asarray(adj_m, dtype=float).copy()
+    np.fill_diagonal(adj, 0.0)
+
+    rows = []
+    for i, gi in enumerate(groups.names):
+        for j, gj in enumerate(groups.names[i:], start=i):
+            idx_i = np.nonzero(groups.masks[:, i])[0]
+            idx_j = np.nonzero(groups.masks[:, j])[0]
+            block = adj[np.ix_(idx_i, idx_j)]
+            if i == j:
+                # Upper triangle only — each undirected pair once, no diagonal.
+                weights = block[np.triu_indices(block.shape[0], k=1)]
+            else:
+                # Groups may overlap; drop the self-pairs a shared node creates.
+                weights = block[idx_i[:, None] != idx_j[None, :]]
+            n_possible = weights.size
+            present = weights > edge_thresh
+            rows.append({
+                "GroupA": gi,
+                "GroupB": gj,
+                "Kind": "within" if i == j else "between",
+                "nNodesA": int(idx_i.size),
+                "nNodesB": int(idx_j.size),
+                "nPossible": int(n_possible),
+                "nEdges": int(present.sum()),
+                "Density": float(present.sum() / n_possible) if n_possible else np.nan,
+                "MeanWeightNonzero": float(weights[present].mean()) if present.any() else np.nan,
+                "MeanWeightAll": float(weights.mean()) if n_possible else np.nan,
+            })
+    return pd.DataFrame(rows)
+
+
+def within_group_strength_fraction(
+    adj_m: np.ndarray, groups: CellTypeGroups,
+) -> dict[str, np.ndarray]:
+    """Per-node fraction of connection strength going to same-group partners.
+
+    ``{group name: (n_nodes_in_group,) array}``. A value near 1 means the cell
+    wires almost exclusively within its own type; near 0 means it is dominated
+    by cross-type connections. NaN for nodes with zero total strength.
+    """
+    adj = np.asarray(adj_m, dtype=float).copy()
+    np.fill_diagonal(adj, 0.0)
+    total = adj.sum(axis=1)
+
+    out: dict[str, np.ndarray] = {}
+    for i, name in enumerate(groups.names):
+        mask = groups.masks[:, i]
+        idx = np.nonzero(mask)[0]
+        within = adj[np.ix_(idx, idx)].sum(axis=1)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            frac = np.where(total[idx] > 0, within / total[idx], np.nan)
+        out[name] = frac
+    return out
+
+
+# ── Splitting whole-network node metrics by group ─────────────────────────────
+
+# Keys of a metrics dict that are bookkeeping rather than per-node measurements.
+_NON_METRIC_KEYS = {
+    "aN", "activeChannelIndex", "adjMsub", "subnetworkNodeIndex", "fullNetworkIndex",
+}
+
+
+def node_metric_names(metrics: dict) -> list[str]:
+    """Node-level (length-``aN``) numeric metric names present in *metrics*."""
+    a_n = int(metrics.get("aN", 0))
+    names = []
+    for key, value in metrics.items():
+        if key in _NON_METRIC_KEYS or not isinstance(value, (list, np.ndarray)):
+            continue
+        arr = np.asarray(value)
+        if arr.ndim == 1 and arr.size == a_n and np.issubdtype(arr.dtype, np.number):
+            names.append(key)
+    return sorted(names)
+
+
+def split_node_metrics(
+    metrics: dict,
+    groups: CellTypeGroups,
+    channels: np.ndarray,
+    *,
+    adj_m: np.ndarray | None = None,
+    include_unassigned: bool = True,
+) -> pd.DataFrame:
+    """Long-format table of whole-network node metrics tagged by cell type.
+
+    One row per (active node × group it belongs to). Because groups overlap, a
+    node positive for two markers contributes two rows — deliberate, so that
+    per-group distributions are each complete. Nodes in no group are emitted
+    once under ``"Unassigned"`` when *include_unassigned*.
+
+    ``adj_m`` (the **full**, unsubsetted adjacency matrix) adds a
+    ``WithinGroupStrengthFrac`` column.
+    """
+    active = np.asarray(metrics.get("activeChannelIndex", []), dtype=int)
+    if active.size == 0:
+        return pd.DataFrame()
+
+    channels = np.asarray(channels).ravel()
+    metric_names = node_metric_names(metrics)
+
+    frac_by_group = (within_group_strength_fraction(adj_m, groups)
+                     if adj_m is not None else {})
+    # Map full-network node index → its within-group fraction, per group.
+    frac_lookup: dict[str, dict[int, float]] = {}
+    for name, values in frac_by_group.items():
+        idx = groups.indices(name)
+        frac_lookup[name] = dict(zip(idx.tolist(), values.tolist()))
+
+    rows = []
+    for pos, node in enumerate(active):
+        base = {"Channel": int(channels[node]), "NodeIndex": int(node)}
+        base.update({m: float(np.asarray(metrics[m])[pos]) for m in metric_names})
+        memberships = [n for i, n in enumerate(groups.names) if groups.masks[node, i]]
+        if not memberships and include_unassigned:
+            memberships = ["Unassigned"]
+        for name in memberships:
+            row = dict(base, Group=name)
+            row["WithinGroupStrengthFrac"] = frac_lookup.get(name, {}).get(int(node), np.nan)
+            rows.append(row)
+
+    if not rows:
+        return pd.DataFrame()
+    df = pd.DataFrame(rows)
+    lead = ["Group", "Channel", "NodeIndex"]
+    return df[lead + [c for c in df.columns if c not in lead]]
+
+
+def subnetwork_summary_rows(results: dict[str, dict]) -> list[dict]:
+    """Flatten :func:`compute_subnetwork_metrics` output to scalar rows.
+
+    Node-level arrays are collapsed to their mean (suffixed ``_mean``) so a
+    single row fully summarises each group's subgraph.
+    """
+    rows = []
+    for name, metrics in results.items():
+        row: dict = {"Group": name, "aN": int(metrics.get("aN", 0))}
+        node_metrics = set(node_metric_names(metrics))
+        for key, value in metrics.items():
+            if key in _NON_METRIC_KEYS:
+                continue
+            if key in node_metrics:
+                arr = np.asarray(value, dtype=float)
+                if arr.size:
+                    row[f"{key}_mean"] = float(np.nanmean(arr))
+                continue
+            if isinstance(value, (list, np.ndarray)):
+                arr = np.asarray(value)
+                if arr.size == 1:
+                    row[key] = arr.ravel()[0]
+                continue
+            row[key] = value
+        rows.append(row)
+    return rows

--- a/src/meanap/catnap/subnetwork_plotting.py
+++ b/src/meanap/catnap/subnetwork_plotting.py
@@ -1,0 +1,472 @@
+"""Figures for the CAT-NAP cell-type subnetwork analysis.
+
+Two families, matching the two questions the analysis answers:
+
+*Graphs* — where the subnetworks sit in the field of view.
+  - :func:`plot_subnetwork_spatial` — the whole network, nodes coloured by cell
+    type and edges coloured by whether they stay within a type or cross between
+    types.
+  - :func:`plot_subnetwork_panels` — the same coordinates repeated per group,
+    each panel showing only that group's induced subgraph.
+
+*Comparisons* — how the subnetworks differ.
+  - :func:`plot_node_metrics_by_group` — half-violin distributions of
+    whole-network node metrics, split by cell type.
+  - :func:`plot_subnetwork_metric_bars` — recording-level metrics recomputed on
+    each induced subgraph.
+  - :func:`plot_edge_mix_matrix` — group × group density / mean-weight heatmaps.
+
+Node coordinates are suite2p cell centroids (``res.coords``), so these render
+in imaging space; the ``y`` axis is inverted to match the image convention used
+by the other CAT-NAP figures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from meanap.catnap.subnetwork import CellTypeGroups, WHOLE_NETWORK
+from meanap.pipeline.plotting_step4 import _half_violin
+
+# Qualitative palette for cell-type groups — distinguishable in print and for
+# the common forms of colour-vision deficiency (Okabe–Ito, reordered so the
+# first two entries read as a clear pair for an excitatory/inhibitory split).
+# Okabe–Ito's yellow is meant for filled areas; as the hairline strokes these
+# graphs are made of it washes out on white, so it sits last and is darkened.
+_TYPE_COLORS = [
+    (0.000, 0.447, 0.698),   # blue
+    (0.835, 0.369, 0.000),   # vermillion
+    (0.000, 0.620, 0.451),   # bluish green
+    (0.800, 0.475, 0.655),   # reddish purple
+    (0.337, 0.706, 0.913),   # sky blue
+    (0.902, 0.624, 0.000),   # orange
+    (0.690, 0.640, 0.090),   # darkened yellow
+]
+_UNASSIGNED_COLOR = (0.65, 0.65, 0.65)
+_WHOLE_COLOR = (0.35, 0.35, 0.35)
+
+
+def group_colors(names: list[str]) -> dict[str, tuple]:
+    """Stable colour per group name, with fixed colours for the two
+    pseudo-groups (:data:`WHOLE_NETWORK`, ``"Unassigned"``)."""
+    colors: dict[str, tuple] = {}
+    i = 0
+    for name in names:
+        if name == WHOLE_NETWORK:
+            colors[name] = _WHOLE_COLOR
+        elif name == "Unassigned":
+            colors[name] = _UNASSIGNED_COLOR
+        else:
+            colors[name] = _TYPE_COLORS[i % len(_TYPE_COLORS)]
+            i += 1
+    return colors
+
+
+# Above this many drawn edges a spatial plot is an unreadable hairball, so only
+# the strongest EDGE_DISPLAY_LIMIT are rendered — always annotated on the
+# figure, never silently. Metrics are computed on the full graph regardless.
+# 2P peak/STTC networks routinely exceed 80% density, so this bites often.
+EDGE_DISPLAY_LIMIT = 3000
+
+
+def _edge_segments(
+    adj: np.ndarray,
+    coords: np.ndarray,
+    keep: np.ndarray | None = None,
+    limit: int | None = EDGE_DISPLAY_LIMIT,
+) -> tuple[list, np.ndarray, int]:
+    """Line segments + weights for above-zero upper-triangle edges.
+
+    ``keep`` is an optional ``(n, n)`` boolean mask selecting which edges to
+    include (e.g. only within-group ones). ``limit`` keeps only the strongest
+    that many edges.
+
+    Returns ``(segments, weights, n_total)`` — ``n_total`` being the edge count
+    *before* the limit, so callers can report what was dropped.
+    """
+    iu = np.triu_indices(adj.shape[0], k=1)
+    weights = adj[iu]
+    sel = weights > 0
+    if keep is not None:
+        sel &= keep[iu]
+    rows, cols, weights = iu[0][sel], iu[1][sel], weights[sel]
+    n_total = int(weights.size)
+
+    if limit is not None and n_total > limit:
+        strongest = np.argpartition(weights, n_total - limit)[n_total - limit:]
+        rows, cols, weights = rows[strongest], cols[strongest], weights[strongest]
+
+    segments = [
+        [(coords[r, 0], coords[r, 1]), (coords[c, 0], coords[c, 1])]
+        for r, c in zip(rows, cols)
+    ]
+    return segments, weights, n_total
+
+
+def _draw_edges(ax, segments, weights, color, w_max: float, alpha=1.0, zorder=1,
+                crowding_n: int | None = None):
+    """Draw edges as a single LineCollection, width scaled by weight.
+
+    One collection rather than per-edge ``plot`` calls: a dense 2P network has
+    tens of thousands of edges, and the per-artist overhead dominates otherwise.
+    Line width and opacity both taper as the collection grows, so a dense graph
+    reads as a texture instead of a solid block.
+
+    ``crowding_n`` overrides the edge count that tapering is derived from. Pass
+    the figure's *total* edge count when several groups share one axes,
+    otherwise a small group is drawn bold against a faded large one and reads
+    as the dominant structure when it is the opposite.
+    """
+    from matplotlib.collections import LineCollection
+
+    if not segments:
+        return
+    n = crowding_n if crowding_n is not None else len(segments)
+    max_width = 2.5 if n < 500 else (1.2 if n < 2000 else 0.6)
+    crowding = min(1.0, 400 / max(n, 1)) ** 0.35
+    widths = 0.15 + max_width * (np.asarray(weights) / max(w_max, 1e-12))
+    ax.add_collection(LineCollection(
+        segments, linewidths=widths, colors=[color],
+        alpha=alpha * max(crowding, 0.12), zorder=zorder,
+    ))
+
+
+def _edge_caption(n_drawn: int, n_total: int) -> str:
+    """Edge-count text, stating the display cap whenever it applied."""
+    if n_drawn < n_total:
+        return f"{n_total} edges (strongest {n_drawn} drawn)"
+    return f"{n_total} edges"
+
+
+def _style_spatial_axes(ax, coords: np.ndarray) -> None:
+    pad = 0.05 * max(np.ptp(coords[:, 0]), np.ptp(coords[:, 1]), 1e-9)
+    ax.set_xlim(coords[:, 0].min() - pad, coords[:, 0].max() + pad)
+    ax.set_ylim(coords[:, 1].max() + pad, coords[:, 1].min() - pad)  # image convention
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+
+def plot_subnetwork_spatial(
+    adj_m: np.ndarray,
+    coords: np.ndarray,
+    groups: CellTypeGroups,
+    out_path: Path,
+    title: str = "",
+    node_size: float = 22.0,
+) -> None:
+    """Whole network with nodes coloured by cell type and edges by mixing.
+
+    Between-group edges are drawn first in pale grey so the within-group
+    structure — the thing the subnetwork analysis is about — sits on top.
+    Nodes belonging to more than one group get a second, smaller ring in the
+    other group's colour (the same convention MATLAB's
+    ``StandardisedNetworkPlot.m`` uses for cell types).
+    """
+    adj = np.asarray(adj_m, dtype=float).copy()
+    np.fill_diagonal(adj, 0.0)
+    coords = np.asarray(coords, dtype=float)
+    colors = group_colors(groups.names)
+    w_max = float(adj.max()) if adj.size else 1.0
+
+    fig, ax = plt.subplots(figsize=(9, 9))
+    fig.patch.set_facecolor("white")
+
+    within_any = np.zeros(adj.shape, dtype=bool)
+    for i in range(groups.n_groups):
+        m = groups.masks[:, i]
+        within_any |= np.outer(m, m)
+
+    # Collect every group's edges before drawing any, so all collections can
+    # share one crowding scale (see _draw_edges).
+    layers = [((0.75, 0.75, 0.75), 0.45, 1,
+               "between-type", _edge_segments(adj, coords, keep=~within_any))]
+    for i, name in enumerate(groups.names):
+        m = groups.masks[:, i]
+        layers.append((colors[name], 0.85, 2, name,
+                       _edge_segments(adj, coords, keep=np.outer(m, m))))
+    total_drawn = sum(len(segs) for *_, (segs, _, _) in layers)
+
+    captions = []
+    for color, alpha, zorder, label, (segs, wts, n_edges) in layers:
+        _draw_edges(ax, segs, wts, color, w_max, alpha=alpha, zorder=zorder,
+                    crowding_n=total_drawn)
+        captions.append(f"{label}: {_edge_caption(len(segs), n_edges)}")
+
+    assigned = groups.masks.any(axis=1) if groups.n_groups else np.zeros(len(coords), bool)
+    ax.scatter(coords[~assigned, 0], coords[~assigned, 1], s=node_size * 0.5,
+               c=[_UNASSIGNED_COLOR], edgecolors="none", zorder=3)
+
+    # Concentric rings (large first) let a node in several groups show all of
+    # them — MATLAB's StandardisedNetworkPlot.m convention. When memberships
+    # are disjoint no rings are needed, and shrinking later groups would just
+    # make them read as less important, so keep every node the same size.
+    overlapping = groups.n_groups > 1 and bool((groups.masks.sum(axis=1) > 1).any())
+    sizes = (np.linspace(1.0, 0.45, groups.n_groups) * node_size if overlapping
+             else np.full(max(groups.n_groups, 1), node_size))
+    for i, name in enumerate(groups.names):
+        m = groups.masks[:, i]
+        ax.scatter(coords[m, 0], coords[m, 1], s=sizes[i], c=[colors[name]],
+                   edgecolors="white", linewidths=0.3, zorder=4 + i)
+
+    handles = [plt.Line2D([], [], marker="o", linestyle="", color=colors[n],
+                          markersize=7, label=f"{n} (n={int(groups.masks[:, i].sum())})")
+               for i, n in enumerate(groups.names)]
+    if (~assigned).any():
+        handles.append(plt.Line2D([], [], marker="o", linestyle="", color=_UNASSIGNED_COLOR,
+                                  markersize=5, label=f"Unassigned (n={int((~assigned).sum())})"))
+    handles.append(plt.Line2D([], [], color=(0.75, 0.75, 0.75), lw=1.5, label="between-type edge"))
+    ax.legend(handles=handles, loc="upper right", fontsize=8, frameon=False)
+
+    _style_spatial_axes(ax, coords)
+    ax.set_title("\n".join([title] + ["  ·  ".join(captions)]) if title
+                 else "  ·  ".join(captions), fontsize=10)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_subnetwork_panels(
+    adj_m: np.ndarray,
+    coords: np.ndarray,
+    groups: CellTypeGroups,
+    out_path: Path,
+    title: str = "",
+    node_size: float = 20.0,
+) -> None:
+    """One panel per group showing only that group's induced subgraph.
+
+    Every panel shares the whole recording's axis limits and edge-width scale,
+    so the panels are directly comparable to each other and to the leading
+    whole-network reference panel. Non-member cells stay visible as faint grey
+    dots to keep the spatial context.
+    """
+    adj = np.asarray(adj_m, dtype=float).copy()
+    np.fill_diagonal(adj, 0.0)
+    coords = np.asarray(coords, dtype=float)
+    colors = group_colors(groups.names)
+    w_max = float(adj.max()) if adj.size else 1.0
+
+    panels = [WHOLE_NETWORK] + list(groups.names)
+    n_cols = min(3, len(panels))
+    n_rows = int(np.ceil(len(panels) / n_cols))
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5.2 * n_cols, 5.2 * n_rows),
+                             squeeze=False)
+    fig.patch.set_facecolor("white")
+
+    for ax, name in zip(axes.ravel(), panels):
+        if name == WHOLE_NETWORK:
+            mask = np.ones(adj.shape[0], dtype=bool)
+            color = _WHOLE_COLOR
+        else:
+            mask = groups.masks[:, groups.names.index(name)]
+            color = colors[name]
+
+        ax.scatter(coords[:, 0], coords[:, 1], s=node_size * 0.35,
+                   c=[(0.87, 0.87, 0.87)], edgecolors="none", zorder=1)
+        segs, wts, n_edges = _edge_segments(adj, coords, keep=np.outer(mask, mask))
+        _draw_edges(ax, segs, wts, color, w_max, alpha=0.8, zorder=2)
+        ax.scatter(coords[mask, 0], coords[mask, 1], s=node_size, c=[color],
+                   edgecolors="white", linewidths=0.3, zorder=3)
+
+        n_nodes = int(mask.sum())
+        possible = n_nodes * (n_nodes - 1) / 2
+        dens = n_edges / possible if possible else np.nan
+        ax.set_title(f"{name}\n{n_nodes} cells · {_edge_caption(len(segs), n_edges)}"
+                     f" · density {dens:.3f}", fontsize=10)
+        _style_spatial_axes(ax, coords)
+
+    for ax in axes.ravel()[len(panels):]:
+        ax.axis("off")
+
+    if title:
+        fig.suptitle(title, fontsize=12)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_node_metrics_by_group(
+    node_df: pd.DataFrame,
+    metrics: list[str],
+    out_path: Path,
+    title: str = "",
+    rng: np.random.Generator | None = None,
+) -> None:
+    """Half-violin distributions of whole-network node metrics, split by group.
+
+    These are metrics of each cell's role in the **whole** network — the
+    subnetworks are used only to label the cells, not to rebuild the graph. So
+    a higher participation coefficient for inhibitory cells here means they
+    connect across more modules of the full network, which is a different (and
+    usually more interesting) claim than the induced-subgraph comparison in
+    :func:`plot_subnetwork_metric_bars`.
+
+    Uses the same ``HalfViolinPlot.m`` renderer as the rest of the pipeline:
+    KDE on the right, jittered points on the left, mean ± SEM in black.
+    """
+    if node_df.empty:
+        return
+    metrics = [m for m in metrics if m in node_df.columns]
+    if not metrics:
+        return
+
+    order = [g for g in node_df["Group"].unique() if g != "Unassigned"]
+    order += [g for g in node_df["Group"].unique() if g == "Unassigned"]
+    colors = group_colors(order)
+
+    n_cols = min(3, len(metrics))
+    n_rows = int(np.ceil(len(metrics) / n_cols))
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(4.0 * n_cols, 3.4 * n_rows),
+                             squeeze=False)
+    fig.patch.set_facecolor("white")
+
+    for ax, metric in zip(axes.ravel(), metrics):
+        for pos, grp in enumerate(order, start=1):
+            values = node_df.loc[node_df["Group"] == grp, metric].to_numpy(dtype=float)
+            _half_violin(ax, values, pos=pos, colour=colors[grp], width=0.3, rng=rng)
+        ax.set_xticks(range(1, len(order) + 1))
+        ax.set_xticklabels([f"{g}\n(n={int((node_df['Group'] == g).sum())})" for g in order],
+                           fontsize=8)
+        ax.set_xlim(0.4, len(order) + 0.8)
+        ax.set_ylabel(metric, fontsize=9)
+        ax.spines[["top", "right"]].set_visible(False)
+
+    for ax in axes.ravel()[len(metrics):]:
+        ax.axis("off")
+
+    if title:
+        fig.suptitle(title, fontsize=12)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_subnetwork_metric_bars(
+    summary: pd.DataFrame,
+    metrics: list[str],
+    out_path: Path,
+    title: str = "",
+) -> None:
+    """Recording-level metrics recomputed on each group's induced subgraph.
+
+    Unlike :func:`plot_node_metrics_by_group`, these describe the subnetwork as
+    a graph in its own right (its density, global efficiency, small-worldness,
+    …). The :data:`WHOLE_NETWORK` bar is the whole-network reference.
+
+    Density-like metrics are strongly size-dependent, so each bar is annotated
+    with the number of active nodes the metric was computed over — a
+    difference between two groups of very different size should be read with
+    that in mind.
+    """
+    if summary.empty:
+        return
+    metrics = [m for m in metrics if m in summary.columns
+               and summary[m].notna().any()]
+    if not metrics:
+        return
+
+    order = list(summary["Group"])
+    colors = group_colors(order)
+    n_cols = min(3, len(metrics))
+    n_rows = int(np.ceil(len(metrics) / n_cols))
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(4.0 * n_cols, 3.4 * n_rows),
+                             squeeze=False)
+    fig.patch.set_facecolor("white")
+
+    for ax, metric in zip(axes.ravel(), metrics):
+        values = summary[metric].to_numpy(dtype=float)
+        bars = ax.bar(range(len(order)), values,
+                      color=[colors[g] for g in order], width=0.65)
+        finite = values[np.isfinite(values)]
+        span = (max(finite.max(), 0.0) - min(finite.min(), 0.0)) if finite.size else 1.0
+        offset = 0.02 * max(span, 1e-9)
+        for bar, value, a_n in zip(bars, values, summary["aN"]):
+            if not np.isfinite(value):
+                continue
+            # Sit outside the bar on whichever side it grows — an all-negative
+            # metric (SWw is routinely negative) would otherwise print the
+            # label inside the bar, in low-contrast grey on the bar colour.
+            above = value >= 0
+            ax.text(bar.get_x() + bar.get_width() / 2,
+                    value + (offset if above else -offset), f"n={int(a_n)}",
+                    ha="center", va="bottom" if above else "top",
+                    fontsize=7, color="0.3")
+        ax.margins(y=0.12)
+        ax.set_xticks(range(len(order)))
+        ax.set_xticklabels(order, fontsize=8, rotation=20, ha="right")
+        ax.set_ylabel(metric, fontsize=9)
+        ax.spines[["top", "right"]].set_visible(False)
+
+    for ax in axes.ravel()[len(metrics):]:
+        ax.axis("off")
+
+    if title:
+        fig.suptitle(title, fontsize=12)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_edge_mix_matrix(
+    edge_mix: pd.DataFrame,
+    groups: CellTypeGroups,
+    out_path: Path,
+    title: str = "",
+) -> None:
+    """Group × group heatmaps of edge density and mean edge weight.
+
+    The diagonal is within-type connectivity, the off-diagonal between-type.
+    A diagonal that dominates means cell types wire preferentially among
+    themselves — assortative mixing by type.
+    """
+    if edge_mix.empty or groups.n_groups == 0:
+        return
+
+    names = groups.names
+    n = len(names)
+    fields = [("Density", "edge density"), ("MeanWeightNonzero", "mean weight (edges present)")]
+
+    fig, axes = plt.subplots(1, len(fields), figsize=(5.6 * len(fields), 5.0), squeeze=False)
+    fig.patch.set_facecolor("white")
+
+    for ax, (field, label) in zip(axes.ravel(), fields):
+        mat = np.full((n, n), np.nan)
+        for _, row in edge_mix.iterrows():
+            if row["GroupA"] not in names or row["GroupB"] not in names:
+                continue
+            i, j = names.index(row["GroupA"]), names.index(row["GroupB"])
+            mat[i, j] = mat[j, i] = row[field]
+
+        im = ax.imshow(mat, cmap="viridis")
+        ax.set_xticks(range(n), names, fontsize=9, rotation=25, ha="right")
+        ax.set_yticks(range(n), names, fontsize=9)
+        for i in range(n):
+            for j in range(n):
+                if not np.isfinite(mat[i, j]):
+                    continue
+                # Contrast against the cell's actual colour, not against the
+                # data mean — viridis is dark at the low end and bright at the
+                # high end regardless of what the numbers happen to be.
+                dark_cell = float(im.norm(mat[i, j])) < 0.6
+                ax.text(j, i, f"{mat[i, j]:.3g}", ha="center", va="center", fontsize=9,
+                        color="white" if dark_cell else "black")
+        ax.set_title(label, fontsize=10)
+        fig.colorbar(im, ax=ax, fraction=0.046)
+
+    if title:
+        fig.suptitle(title, fontsize=12)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)

--- a/src/meanap/gui/panels/catnap.py
+++ b/src/meanap/gui/panels/catnap.py
@@ -9,7 +9,7 @@ from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtWidgets import (
     QCheckBox, QComboBox, QDoubleSpinBox, QFormLayout, QGroupBox,
     QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem,
-    QPushButton, QScrollArea, QSizePolicy, QSpinBox, QSplitter,
+    QPlainTextEdit, QPushButton, QScrollArea, QSizePolicy, QSpinBox, QSplitter,
     QTextEdit, QVBoxLayout, QWidget,
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
@@ -18,9 +18,19 @@ from matplotlib.figure import Figure
 from meanap.catnap.scanner import Suite2pRecording, find_suite2p_recordings
 from meanap.catnap.loader import Suite2pData, load_suite2p
 from meanap.catnap.denoising import oasis_available
+from meanap.gui.panels.cell_type_groups import CellTypeGroupEditor
 from meanap.params import Params
 
 ACTIVITY_TYPES = ["peaks", "denoised F", "F", "spks"]
+
+# Subnetwork grouping modes, in combo-box order. The stored value of
+# ``Params.twop_subnetwork_groups`` is None / "E/I" / a dict of expressions;
+# CUSTOM and EXPRESSIONS both produce a dict, differing only in how it is edited.
+MODE_PER_MARKER = "One subnetwork per marker"
+MODE_EI = "Excitatory vs inhibitory"
+MODE_CUSTOM = "Custom groups"
+MODE_EXPRESSIONS = "Custom groups (expressions)"
+GROUP_MODES = [MODE_PER_MARKER, MODE_EI, MODE_CUSTOM, MODE_EXPRESSIONS]
 
 
 # ── Background worker threads ─────────────────────────────────────────────────
@@ -160,6 +170,9 @@ class CatNapPanel(QWidget):
         self._recordings: list[Suite2pRecording] = []
         self._current_data: Suite2pData | None = None
         self._current_plane0: str = ""
+        # (n_roi_ids, n_markers) membership from the cell-type spreadsheet,
+        # used to show live group sizes while editing. None until one is read.
+        self._celltype_matrix: np.ndarray | None = None
 
         # background worker refs (kept alive)
         self._scan_worker: _ScanWorker | None = None
@@ -302,6 +315,19 @@ class CatNapPanel(QWidget):
         # Embedded trace canvas
         self._canvas = _TraceCanvas()
 
+        preview = QWidget()
+        preview_layout = QVBoxLayout(preview)
+        preview_layout.setContentsMargins(0, 0, 0, 0)
+        preview_layout.addWidget(ctrl_box)
+        preview_layout.addWidget(self._canvas, stretch=1)
+
+        # Trace preview and the group editor both want vertical room, and which
+        # one matters depends on what the user is doing — let them decide.
+        splitter = QSplitter(Qt.Orientation.Vertical)
+        splitter.addWidget(preview)
+        splitter.addWidget(self._build_subnetwork_box())
+        splitter.setSizes([360, 360])
+
         # Status log
         log_box = QGroupBox("Log")
         log_layout = QVBoxLayout(log_box)
@@ -310,10 +336,65 @@ class CatNapPanel(QWidget):
         self._log.setMaximumHeight(100)
         log_layout.addWidget(self._log)
 
-        layout.addWidget(ctrl_box)
-        layout.addWidget(self._canvas, stretch=1)
+        layout.addWidget(splitter, stretch=1)
         layout.addWidget(log_box)
         return w
+
+    def _build_subnetwork_box(self) -> QWidget:
+        """Cell-type subnetwork settings (see catnap/subnetwork.py)."""
+        box = QGroupBox("Cell-type subnetworks")
+        layout = QVBoxLayout(box)
+
+        form = QFormLayout()
+        self._subnetwork_enabled = QCheckBox()
+        self._subnetwork_enabled.toggled.connect(self._update_subnetwork_enabled)
+        form.addRow("Analyse cell-type subnetworks", self._subnetwork_enabled)
+
+        file_row = QHBoxLayout()
+        self._celltype_file = QLineEdit()
+        self._celltype_file.setPlaceholderText(
+            "Auto-detect a spreadsheet in each recording's folder"
+        )
+        browse = QPushButton("Browse…")
+        browse.setFixedWidth(72)
+        browse.clicked.connect(self._on_browse_celltype)
+        self._load_markers_btn = QPushButton("Load markers")
+        self._load_markers_btn.setFixedWidth(96)
+        self._load_markers_btn.clicked.connect(lambda: self._load_markers(verbose=True))
+        file_row.addWidget(self._celltype_file)
+        file_row.addWidget(browse)
+        file_row.addWidget(self._load_markers_btn)
+        form.addRow("Cell-type file", file_row)
+
+        self._group_mode = QComboBox()
+        self._group_mode.addItems(GROUP_MODES)
+        self._group_mode.currentTextChanged.connect(self._update_subnetwork_enabled)
+        form.addRow("Grouping", self._group_mode)
+        layout.addLayout(form)
+
+        self._group_editor = CellTypeGroupEditor()
+        self._group_editor.changed.connect(self._validate_groups)
+
+        self._group_text = QPlainTextEdit()
+        self._group_text.setPlaceholderText(
+            "One group per line, as  Name = expression\n"
+            "e.g.  Inhibitory = GAD+ | PV+ | SST+\n"
+            "      Excitatory = NeuN+ & ~GAD+ & ~PV+ & ~SST+\n"
+            "Operators: & (and)  | (or)  ~ (not)  ( )"
+        )
+        self._group_text.setMaximumHeight(110)
+        self._group_text.textChanged.connect(self._validate_groups)
+
+        self._group_status = QLabel("")
+        self._group_status.setWordWrap(True)
+        self._group_status.setStyleSheet("font-size: 10px;")
+
+        layout.addWidget(self._group_editor)
+        layout.addWidget(self._group_text)
+        layout.addWidget(self._group_status)
+
+        self._update_subnetwork_enabled()
+        return box
 
     # ── Slots ─────────────────────────────────────────────────────────────────
 
@@ -347,6 +428,9 @@ class CatNapPanel(QWidget):
 
         self._log_msg(f"Found {len(recordings)} suite2p recording(s).")
         self._scan_btn.setEnabled(True)
+        # Pick up cell-type markers as soon as we know where the recordings are,
+        # so the group editor is usable without a separate click.
+        self._load_markers()
 
     def _on_recording_selected(self, row: int) -> None:
         if row < 0 or row >= len(self._recordings):
@@ -356,6 +440,7 @@ class CatNapPanel(QWidget):
         self._current_plane0 = str(rec.suite2p_dir)
         self._log_msg(f"Loading {rec.name}…")
         self._denoise_btn.setEnabled(False)
+        self._load_markers()
 
         self._load_worker = _LoadWorker(self._current_plane0)
         self._load_worker.finished.connect(self._on_load_done)
@@ -424,6 +509,174 @@ class CatNapPanel(QWidget):
         preview_indices = cell_indices[:n]
         self._canvas.plot_traces(data, preview_indices, activity)
 
+    # ── Cell-type subnetwork slots ────────────────────────────────────────────
+
+    def _update_subnetwork_enabled(self) -> None:
+        """Show only the editor the current grouping mode uses."""
+        on = self._subnetwork_enabled.isChecked()
+        mode = self._group_mode.currentText()
+        for widget in (self._celltype_file, self._load_markers_btn, self._group_mode):
+            widget.setEnabled(on)
+        self._group_editor.setVisible(on and mode == MODE_CUSTOM)
+        self._group_text.setVisible(on and mode == MODE_EXPRESSIONS)
+        self._group_status.setVisible(on)
+        self._validate_groups()
+
+    def _on_browse_celltype(self) -> None:
+        from PyQt6.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select cell-type spreadsheet", self._celltype_file.text(),
+            "Spreadsheets (*.csv *.xlsx *.xls)",
+        )
+        if path:
+            self._celltype_file.setText(path)
+            self._load_markers(verbose=True)
+
+    def _resolve_celltype_file(self) -> Path | None:
+        """Explicit path if set, else auto-detect beside the selected recording."""
+        from meanap.catnap.subnetwork import find_cell_type_file
+
+        explicit = self._celltype_file.text().strip()
+        if explicit:
+            path = Path(explicit)
+            return path if path.exists() else None
+
+        row = self._recording_list.currentRow()
+        folders = []
+        if 0 <= row < len(self._recordings):
+            folders.append(Path(self._recordings[row].suite2p_dir).parent.parent)
+        folders += [Path(r.suite2p_dir).parent.parent for r in self._recordings]
+        for folder in folders:
+            found = find_cell_type_file(folder.parent, folder.name)
+            if found is not None:
+                return found
+        return None
+
+    def _load_markers(self, verbose: bool = False) -> None:
+        """Read the spreadsheet's marker columns into the group editor."""
+        from meanap.catnap.subnetwork import build_marker_matrix, load_cell_type_table
+
+        path = self._resolve_celltype_file()
+        if path is None:
+            if verbose:
+                self._log_msg("No cell-type spreadsheet found. Browse to one, or "
+                              "put a single .csv/.xlsx in each recording's folder.")
+            return
+        try:
+            table = load_cell_type_table(path)
+            markers = list(table.columns)
+            # Membership over every ROI id the spreadsheet mentions — the run's
+            # `channels` are not known here, so use the full id range to give
+            # the validator something concrete to count against.
+            max_id = int(table.max(numeric_only=True).max()) if markers else 0
+            self._celltype_matrix, markers = build_marker_matrix(
+                table, np.arange(1, max_id + 2)
+            )
+        except Exception as e:
+            self._celltype_matrix = None
+            self._log_msg(f"Could not read {Path(path).name}: {e}")
+            return
+        if not markers:
+            self._celltype_matrix = None
+            self._log_msg(f"{Path(path).name} has no columns with cell ids in them.")
+            return
+
+        self._group_editor.set_markers(markers)
+        if verbose:
+            self._log_msg(f"Loaded {len(markers)} marker(s) from {Path(path).name}: "
+                          + ", ".join(markers))
+        self._validate_groups()
+
+    def _current_groups(self) -> dict[str, str] | str | None:
+        """The value ``Params.twop_subnetwork_groups`` should take right now."""
+        mode = self._group_mode.currentText()
+        if mode == MODE_PER_MARKER:
+            return None
+        if mode == MODE_EI:
+            return "E/I"
+        if mode == MODE_CUSTOM:
+            return self._group_editor.groups()
+        groups: dict[str, str] = {}
+        for line in self._group_text.toPlainText().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            name, expr = line.split("=", 1)
+            if name.strip() and expr.strip():
+                groups[name.strip()] = expr.strip()
+        return groups
+
+    def _validate_groups(self) -> None:
+        """Report group sizes (or the first error) beneath the editor.
+
+        Checking against the loaded markers here means a typo surfaces while
+        editing rather than as a skipped analysis mid-run.
+        """
+        from meanap.catnap.subnetwork import (
+            GroupExpressionError, default_ei_groups, eval_group_expression,
+        )
+        import numpy as np
+
+        if not self._subnetwork_enabled.isChecked():
+            self._group_status.setText("")
+            return
+
+        markers = self._group_editor.markers()
+        mode = self._group_mode.currentText()
+        if mode == MODE_PER_MARKER:
+            self._group_status.setText(
+                f"One subnetwork per marker: {', '.join(markers)}" if markers
+                else "One subnetwork per marker column found in each spreadsheet."
+            )
+            self._group_status.setStyleSheet("font-size: 10px; color: gray;")
+            return
+
+        groups = self._current_groups()
+        if mode == MODE_EI:
+            groups = default_ei_groups(markers) if markers else None
+            if markers and groups is None:
+                self._set_group_status(
+                    "No inhibitory marker (GAD+/PV+/SST+/VIP+/GABA+) in this file — "
+                    "an E/I split cannot be derived; the run falls back to one "
+                    "subnetwork per marker.", warn=True)
+                return
+        if not groups:
+            self._set_group_status("No groups defined yet.", warn=True)
+            return
+
+        if not markers or self._celltype_matrix is None:
+            self._set_group_status(
+                f"{len(groups)} group(s) defined. Load a cell-type file to check "
+                "them against its markers.")
+            return
+
+        # Counts are over every ROI the spreadsheet labels — an upper bound on
+        # what a run sees, since iscell / no-peaks / inactive-node filtering all
+        # happen later. Still the quickest way to catch a group that is empty or
+        # accidentally swallows everything.
+        summary = []
+        for name, expr in groups.items():
+            try:
+                mask = eval_group_expression(expr, self._celltype_matrix, markers)
+            except GroupExpressionError as e:
+                self._set_group_status(f"{name}: {e}", warn=True)
+                return
+            if not mask.any():
+                self._set_group_status(
+                    f"{name!r} matches no labelled cell — it will be dropped.",
+                    warn=True)
+                return
+            summary.append(f"{name} ({int(mask.sum())})")
+        self._set_group_status(
+            f"{len(groups)} group(s), cells labelled in the spreadsheet: "
+            + ", ".join(summary))
+
+    def _set_group_status(self, text: str, warn: bool = False) -> None:
+        self._group_status.setText(("⚠ " if warn else "") + text)
+        self._group_status.setStyleSheet(
+            "font-size: 10px; color: " + ("#aa6600;" if warn else "gray;")
+        )
+
     # ── Params sync ───────────────────────────────────────────────────────────
 
     def load(self, params: Params) -> None:
@@ -438,6 +691,27 @@ class CatNapPanel(QWidget):
         self._time_before.setValue(params.twop_denoising_time_before_peak)
         self._time_after.setValue(params.twop_denoising_time_after_peak)
 
+        self._subnetwork_enabled.setChecked(params.twop_subnetwork_analysis)
+        self._celltype_file.setText(params.twop_cell_type_file)
+        self._load_markers()
+
+        groups = params.twop_subnetwork_groups
+        if groups is None:
+            self._group_mode.setCurrentText(MODE_PER_MARKER)
+        elif isinstance(groups, str):
+            self._group_mode.setCurrentText(MODE_EI)
+        else:
+            # Prefer the grid; fall back to free text for anything it cannot
+            # represent, so a hand-written expression is never silently lost.
+            if self._group_editor.set_groups(groups):
+                self._group_mode.setCurrentText(MODE_CUSTOM)
+            else:
+                self._group_text.setPlainText(
+                    "\n".join(f"{name} = {expr}" for name, expr in groups.items())
+                )
+                self._group_mode.setCurrentText(MODE_EXPRESSIONS)
+        self._update_subnetwork_enabled()
+
     def save(self, params: Params) -> None:
         params.raw_data = self._folder_edit.text()
         params.suite2p_mode = self._suite2p_mode.isChecked()
@@ -447,6 +721,10 @@ class CatNapPanel(QWidget):
         params.twop_denoising_threshold = self._denoise_threshold.value()
         params.twop_denoising_time_before_peak = self._time_before.value()
         params.twop_denoising_time_after_peak = self._time_after.value()
+
+        params.twop_subnetwork_analysis = self._subnetwork_enabled.isChecked()
+        params.twop_cell_type_file = self._celltype_file.text().strip()
+        params.twop_subnetwork_groups = self._current_groups()
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/src/meanap/gui/panels/cell_type_groups.py
+++ b/src/meanap/gui/panels/cell_type_groups.py
@@ -1,0 +1,302 @@
+"""Editor for CAT-NAP cell-type subnetwork groups.
+
+Lets the user say which immunohistochemistry markers make up which subnetwork —
+"Excitatory = NeuN+ but not GAD+/PV+/SST+", "Inhibitory = any of GAD+/PV+/SST+"
+— without writing the boolean expressions that
+:mod:`meanap.catnap.subnetwork` actually consumes.
+
+The editor is a grid: one row per group, one column per marker found in the
+recording's cell-type spreadsheet, and each cell set to *ignore* / *include* /
+*exclude*. A per-row **Match** control decides whether the included markers are
+OR-ed ("any") or AND-ed ("all"); excluded markers are always AND-NOT-ed. That
+covers every group shape the marker panels in practice call for, and each row
+shows the expression it compiles to so nothing is hidden.
+
+Groups are unlimited: two rows are created by default and **Add group** appends
+more. Anything the grid cannot express (nested parentheses, mixed operators) is
+still supported through the free-text expression mode in the parent panel — see
+:meth:`CellTypeGroupEditor.set_groups`, which reports when it cannot round-trip
+a stored expression.
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QComboBox, QHBoxLayout, QHeaderView, QLabel, QLineEdit, QPushButton,
+    QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget,
+)
+
+from meanap.catnap.subnetwork import (
+    GroupExpressionError, build_group_expression, parse_group_expression_terms,
+)
+
+# Cell states, in the order they appear in each marker combo box.
+IGNORE, INCLUDE, EXCLUDE = "—", "include", "exclude"
+_CELL_STATES = [IGNORE, INCLUDE, EXCLUDE]
+
+_MATCH_LABELS = {"any": "any of", "all": "all of"}
+
+# Fixed leading columns; marker columns follow, then the expression preview.
+_COL_NAME, _COL_MATCH = 0, 1
+_N_LEAD = 2
+
+
+class CellTypeGroupEditor(QWidget):
+    """Grid of groups × markers. Emits :attr:`changed` on every edit."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._markers: list[str] = []
+        self._updating = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._hint = QLabel(
+            "Load a cell-type spreadsheet to list its markers, then assign each "
+            "marker to a group."
+        )
+        self._hint.setWordWrap(True)
+        self._hint.setStyleSheet("color: gray; font-size: 10px;")
+
+        self._table = QTableWidget(0, _N_LEAD + 1)
+        self._table.setAlternatingRowColors(True)
+        self._table.verticalHeader().setVisible(False)
+        self._table.itemChanged.connect(self._on_item_changed)
+        self._apply_headers()
+
+        buttons = QHBoxLayout()
+        self._add_btn = QPushButton("Add group")
+        self._add_btn.clicked.connect(lambda: self._append_row(f"Group {self._table.rowCount() + 1}"))
+        self._remove_btn = QPushButton("Remove selected")
+        self._remove_btn.clicked.connect(self._on_remove)
+        buttons.addWidget(self._add_btn)
+        buttons.addWidget(self._remove_btn)
+        buttons.addStretch()
+
+        layout.addWidget(self._hint)
+        layout.addWidget(self._table)
+        layout.addLayout(buttons)
+
+        # Two rows to start with — the excitatory/inhibitory case — but the
+        # editor is not limited to two; Add group appends as many as needed.
+        self._append_row("Excitatory")
+        self._append_row("Inhibitory")
+
+    # ── Markers ───────────────────────────────────────────────────────────────
+
+    def markers(self) -> list[str]:
+        return list(self._markers)
+
+    def set_markers(self, markers: list[str]) -> None:
+        """Rebuild the marker columns, preserving selections *by marker name*.
+
+        Loading a different recording's spreadsheet therefore keeps whatever
+        assignments still apply and quietly drops the ones whose marker is gone.
+        """
+        previous = self._row_states()
+        self._markers = list(markers)
+        self._updating = True
+        try:
+            # Rebuild rows wholesale: the marker columns *and* the trailing
+            # expression column all move, so patching cells in place would
+            # leave stale widgets behind.
+            self._table.setRowCount(0)
+            self._apply_headers()
+            for name, match, include, exclude in previous:
+                self._append_row(name, emit=False)
+                self._apply_row_state(self._table.rowCount() - 1, match, include, exclude)
+        finally:
+            self._updating = False
+        self._hint.setVisible(not self._markers)
+        self._refresh_expressions()
+        self.changed.emit()
+
+    # ── Group values ──────────────────────────────────────────────────────────
+
+    def groups(self) -> dict[str, str]:
+        """``{group name: expression}``, skipping unnamed or empty rows."""
+        out: dict[str, str] = {}
+        for name, match, include, exclude in self._row_states():
+            if not name or (not include and not exclude):
+                continue
+            out[name] = build_group_expression(include, exclude, match)
+        return out
+
+    def set_groups(self, groups: dict[str, str]) -> bool:
+        """Populate from stored expressions.
+
+        Returns ``False`` (leaving the grid untouched) when any expression is
+        richer than the include/exclude form — the caller should then switch to
+        the free-text mode rather than show a grid that silently misrepresents
+        what will run.
+        """
+        markers = self._markers or None
+        parsed = []
+        for name, expr in groups.items():
+            try:
+                terms = parse_group_expression_terms(expr, markers)
+            except GroupExpressionError:
+                # Names a marker this spreadsheet does not have — the grid has
+                # no column to show it in, so treat it like any other shape the
+                # grid cannot represent.
+                return False
+            if terms is None:
+                return False
+            parsed.append((name, *terms))
+
+        # Expressions may name markers no spreadsheet has been loaded for yet;
+        # adopt them as columns so the grid can show the stored configuration.
+        if not self._markers:
+            seen: list[str] = []
+            for _n, _m, inc, exc in parsed:
+                for marker in inc + exc:
+                    if marker not in seen:
+                        seen.append(marker)
+            if seen:
+                self.set_markers(seen)
+
+        self._updating = True
+        try:
+            self._table.setRowCount(0)
+            for name, match, include, exclude in parsed:
+                self._append_row(name, emit=False)
+                self._apply_row_state(self._table.rowCount() - 1, match, include, exclude)
+            if self._table.rowCount() == 0:
+                self._append_row("Excitatory", emit=False)
+                self._append_row("Inhibitory", emit=False)
+        finally:
+            self._updating = False
+        self._refresh_expressions()
+        return True
+
+    # ── Row plumbing ──────────────────────────────────────────────────────────
+
+    def _apply_headers(self) -> None:
+        headers = ["Group", "Match"] + self._markers + ["Expression"]
+        self._table.setColumnCount(len(headers))
+        self._table.setHorizontalHeaderLabels(headers)
+        header = self._table.horizontalHeader()
+        # Group names are user-typed and often long; marker columns only need to
+        # fit a combo box. Give the leftover width to the expression preview.
+        header.setSectionResizeMode(_COL_NAME, QHeaderView.ResizeMode.Interactive)
+        self._table.setColumnWidth(_COL_NAME, 150)
+        for col in range(_N_LEAD, len(headers) - 1):
+            header.setSectionResizeMode(col, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(len(headers) - 1, QHeaderView.ResizeMode.Stretch)
+
+    def _append_row(self, name: str, emit: bool = True) -> None:
+        row = self._table.rowCount()
+        was_updating = self._updating
+        self._updating = True
+        try:
+            self._table.insertRow(row)
+            self._table.setItem(row, _COL_NAME, QTableWidgetItem(name))
+
+            match_combo = QComboBox()
+            match_combo.addItems([_MATCH_LABELS["any"], _MATCH_LABELS["all"]])
+            match_combo.setToolTip(
+                "How the markers set to 'include' combine:\n"
+                "  any of — a cell needs at least one of them\n"
+                "  all of — a cell needs every one of them\n"
+                "Markers set to 'exclude' must always be absent."
+            )
+            match_combo.currentIndexChanged.connect(self._on_cell_changed)
+            self._table.setCellWidget(row, _COL_MATCH, match_combo)
+
+            self._build_marker_cells(row)
+
+            expr_item = QTableWidgetItem("")
+            expr_item.setFlags(expr_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self._table.setItem(row, self._expr_col(), expr_item)
+        finally:
+            self._updating = was_updating
+        self._refresh_expressions()
+        if emit and not self._updating:
+            self.changed.emit()
+
+    def _build_marker_cells(self, row: int) -> None:
+        for col, marker in enumerate(self._markers, start=_N_LEAD):
+            combo = QComboBox()
+            combo.addItems(_CELL_STATES)
+            combo.setToolTip(
+                f"Whether a cell must be {marker} to belong to this group:\n"
+                f"  —        {marker} is irrelevant\n"
+                f"  include  the cell must be {marker}\n"
+                f"  exclude  the cell must NOT be {marker}"
+            )
+            combo.currentIndexChanged.connect(self._on_cell_changed)
+            self._table.setCellWidget(row, col, combo)
+
+    def _expr_col(self) -> int:
+        return self._table.columnCount() - 1
+
+    def _name_of(self, row: int) -> str:
+        item = self._table.item(row, _COL_NAME)
+        return item.text().strip() if item else ""
+
+    def _row_states(self) -> list[tuple[str, str, list[str], list[str]]]:
+        states = []
+        for row in range(self._table.rowCount()):
+            match_combo = self._table.cellWidget(row, _COL_MATCH)
+            match = "all" if match_combo and match_combo.currentIndex() == 1 else "any"
+            include, exclude = [], []
+            for col, marker in enumerate(self._markers, start=_N_LEAD):
+                combo = self._table.cellWidget(row, col)
+                if combo is None:
+                    continue
+                if combo.currentText() == INCLUDE:
+                    include.append(marker)
+                elif combo.currentText() == EXCLUDE:
+                    exclude.append(marker)
+            states.append((self._name_of(row), match, include, exclude))
+        return states
+
+    def _apply_row_state(self, row: int, match: str, include: list[str],
+                         exclude: list[str]) -> None:
+        match_combo = self._table.cellWidget(row, _COL_MATCH)
+        if match_combo:
+            match_combo.setCurrentIndex(1 if match == "all" else 0)
+        for col, marker in enumerate(self._markers, start=_N_LEAD):
+            combo = self._table.cellWidget(row, col)
+            if combo is None:
+                continue
+            state = (INCLUDE if marker in include
+                     else EXCLUDE if marker in exclude else IGNORE)
+            combo.setCurrentIndex(_CELL_STATES.index(state))
+
+    def _refresh_expressions(self) -> None:
+        col = self._expr_col()
+        for row, (_name, match, include, exclude) in enumerate(self._row_states()):
+            item = self._table.item(row, col)
+            if item is None:
+                continue
+            expr = build_group_expression(include, exclude, match)
+            item.setText(expr or "(no markers selected — group ignored)")
+            # The column is often too narrow for the whole expression, and this
+            # is the one place the user can confirm what will actually run.
+            item.setToolTip(expr)
+
+    # ── Slots ─────────────────────────────────────────────────────────────────
+
+    def _on_remove(self) -> None:
+        rows = sorted({i.row() for i in self._table.selectedIndexes()}, reverse=True)
+        if not rows:
+            rows = [self._table.rowCount() - 1] if self._table.rowCount() else []
+        for row in rows:
+            self._table.removeRow(row)
+        self.changed.emit()
+
+    def _on_cell_changed(self, _index: int) -> None:
+        if self._updating:
+            return
+        self._refresh_expressions()
+        self.changed.emit()
+
+    def _on_item_changed(self, item: QTableWidgetItem) -> None:
+        if self._updating or item.column() != _COL_NAME:
+            return
+        self.changed.emit()

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -158,6 +158,21 @@ class Params:
     twop_denoising_time_after_peak: float = 2.05
     python_path: str = ""
 
+    # Cell-type subnetwork analysis (see catnap/subnetwork.py). When enabled,
+    # each recording's putative-cell-type spreadsheet splits the network into
+    # named groups; the pipeline then re-runs the step-4 metrics on each
+    # group's induced subgraph, splits the whole-network node metrics by group,
+    # and summarises within- vs between-type edge mixing.
+    twop_subnetwork_analysis: bool = False
+    # Explicit path to the cell-type spreadsheet; "" auto-discovers one inside
+    # each recording's folder (same rule as MEApipeline.m, extended to xlsx).
+    twop_cell_type_file: str = ""
+    # None      → one subnetwork per spreadsheet column;
+    # "E/I"     → excitatory vs inhibitory, derived from the markers present;
+    # dict      → {group name: boolean marker expression}, e.g.
+    #             {"Inhibitory": "GAD+ | PV+ | SST+"}.
+    twop_subnetwork_groups: dict[str, str] | str | None = None
+
     # ── Stimulation (MEA-Stim) ───────────────────────────────────────────────
     # See src/meanap/stim/ and python/MEASTIM_PORT_PLAN.md. When
     # ``stimulation_mode`` is set, the pipeline runs the stim analysis right

--- a/src/meanap/pipeline/null_models.py
+++ b/src/meanap/pipeline/null_models.py
@@ -92,6 +92,12 @@ def randmio_und_signed(
 
     r = w.astype(float).copy()
     n = r.shape[0]
+    if n < 4:
+        # A double-edge swap needs four distinct nodes. MATLAB's
+        # randmio_und_signed.m draws them in a bare `while 1`, which spins
+        # forever below n=4; MEA arrays are never that small, but a cell-type
+        # subnetwork can be. Nothing is rewirable, so return the input.
+        return r
     total_iter = int(iterations * n * (n - 1) / 2)
     max_attempts = round(n / 2)
 
@@ -250,26 +256,53 @@ def null_model_und_sign(
 # already-nonnegative adjacency matrices). Both batch their random draws for
 # speed, same trick as ``randmio_und_signed``'s ``next_quad``.
 
+# Consecutive rejected draws after which _valid_quad_stream concludes the graph
+# has no valid quad at all. See the deviation note in its docstring.
+_QUAD_SEARCH_BUDGET = 2_000_000
+
+
 def _valid_quad_stream(
     rng: np.random.Generator, k: int, i_arr: list[int], j_arr: list[int], batch_size: int = 8192,
-) -> Iterator[tuple[int, int, int, int, int, int]]:
+) -> Iterator[tuple[int, int, int, int, int, int] | None]:
     """Yields ``(e1, e2, a, b, c, d)``: two distinct edge indices into
     ``i_arr``/``j_arr`` whose four endpoint nodes are all distinct.
 
     ``i_arr``/``j_arr`` are read fresh on each yield (not snapshotted), so
     callers may mutate them between ``next()`` calls — required, since the
     edge-flip step below does exactly that.
+
+    **Deviation from MATLAB.** ``latmio_und_v2.m`` / ``randmio_und_v2.m`` wrap
+    this search in a bare ``while 1``, which never terminates on a graph where
+    no two edges have four distinct endpoints — a triangle, a star, any small
+    or degenerate component. MEA-NAP's ephys networks are large enough that
+    MATLAB never hit it, but a cell-type subnetwork can easily be three or four
+    cells, so the search is bounded here: after
+    ``_QUAD_SEARCH_BUDGET`` consecutive rejected draws this yields ``None``,
+    telling the caller to stop rewiring rather than spin forever. The budget is
+    far beyond what any graph that *does* admit a swap would need, so this only
+    changes behaviour in cases where MATLAB would hang.
     """
+    # A graph with any valid quad at all has at least ~2/k² of its draws
+    # succeed, so scaling the budget with k² keeps the false-give-up
+    # probability negligible while staying instant for the tiny graphs where
+    # giving up is the correct answer.
+    budget = min(_QUAD_SEARCH_BUDGET, max(10_000, 200 * k * k))
+    rejected = 0
     while True:
         e1_batch = rng.integers(0, k, size=batch_size)
         e2_batch = rng.integers(0, k, size=batch_size)
         for e1, e2 in zip(e1_batch.tolist(), e2_batch.tolist()):
-            if e1 == e2:
-                continue
-            a, b = i_arr[e1], j_arr[e1]
-            c, d = i_arr[e2], j_arr[e2]
-            if a != c and a != d and b != c and b != d:
-                yield e1, e2, a, b, c, d
+            if e1 != e2:
+                a, b = i_arr[e1], j_arr[e1]
+                c, d = i_arr[e2], j_arr[e2]
+                if a != c and a != d and b != c and b != d:
+                    rejected = 0
+                    yield e1, e2, a, b, c, d
+                    continue
+            rejected += 1
+            if rejected >= budget:
+                yield None
+                rejected = 0
 
 
 def _coin_flip_stream(rng: np.random.Generator, batch_size: int = 8192) -> Iterator[bool]:
@@ -305,7 +338,10 @@ def randmio_und_v2(
 
     for _ in range(iterations):
         for _attempt in range(max_attempts + 1):
-            e1, e2, a, b, c, d = next(quads)
+            quad = next(quads)
+            if quad is None:
+                return r  # no swappable edge pair exists — leave the graph as is
+            e1, e2, a, b, c, d = quad
             if next(flips):
                 i_arr[e2], j_arr[e2] = d, c
                 c, d = d, c
@@ -349,8 +385,13 @@ def latmio_und_v2(
         flips = _coin_flip_stream(rng)
 
         for _ in range(iterations):
+            exhausted = False
             for _attempt in range(max_attempts + 1):
-                e1, e2, a, b, c, dd = next(quads)
+                quad = next(quads)
+                if quad is None:
+                    exhausted = True  # no swappable edge pair — stop rewiring
+                    break
+                e1, e2, a, b, c, dd = quad
                 if next(flips):
                     i_arr[e2], j_arr[e2] = dd, c
                     c, dd = dd, c
@@ -365,6 +406,8 @@ def latmio_und_v2(
                         j_arr[e1] = dd
                         j_arr[e2] = b
                         break
+            if exhausted:
+                break
 
     ind_rp_reverse = np.argsort(ind_rp)
     return r[np.ix_(ind_rp_reverse, ind_rp_reverse)]


### PR DESCRIPTION
Turns the putative-cell-type spreadsheet from a cosmetic annotation into an analysis: you can now compare subnetworks defined by cell type — excitatory vs inhibitory, or any marker combination you like.

MATLAB only uses `Info.CellTypes` to draw concentric rings around nodes in `StandardisedNetworkPlot.m`, so **this is a feature extension, not a port** — there is no MATLAB parity target, and the tests check correctness and self-consistency instead.

## What it does

Two complementary comparisons, both produced per recording and lag:

**Induced subgraphs** — restrict `adjM` to one cell type's nodes and the edges *among* them, then re-run the **shared** step-4 metric suite. Answers "is the inhibitory network denser / more efficient / more small-world?". These are size-dependent, so every figure annotates `aN`.

**Split whole-network node metrics** — leave the graph intact, label each node with its type, and compare the ND / NS / PC / BC / Eloc distributions. Answers "are inhibitory cells more hub-like *within the whole network*?", which is a different and usually more interesting question. Long format (one row per node × group), because marker membership legitimately overlaps.

Plus **edge mixing**: a group × group density / mean-weight matrix, and a per-node within-group strength fraction.

### Outputs

Five figures per recording/lag under `4A_IndividualNetworkAnalysis/…/{lag}mslag/cellTypeSubnetworks/`, and three batch CSVs in `4_NetworkActivity/` (`Subnetwork_RecordingLevel`, `Subnetwork_NodeLevel`, `Subnetwork_EdgeMix`).

2P peak/STTC networks are routinely >80% dense, so the two graph figures draw only the strongest 3000 edges per group **and say so in the panel caption**. Metrics always use the complete graph.

### Defining groups

From the recording folder's spreadsheet (MATLAB's `rawData/<FN>/*.csv` rule, extended to xlsx). `twop_subnetwork_groups` takes `None` (one group per marker column), `"E/I"` (derived from whichever inhibitory markers are present), or a dict of boolean expressions — `"NeuN+ & ~GAD+ & ~PV+"`, with `&` binding tighter than `|`.

## GUI

The CAT-NAP tab gains a **Cell-type subnetworks** box: enable checkbox, cell-type file picker with auto-detection, a grouping-mode combo, and a grid editor — rows are groups, columns are the spreadsheet's markers, each cell is include / exclude / irrelevant, with a per-row *any of* vs *all of* match. **Unlimited groups** via Add group.

`build_group_expression` / `parse_group_expression_terms` round-trip grid ↔ expression exactly (verified against both shipped presets, and equivalence-checked across every marker combination rather than by string match). Anything the grid cannot represent — nested parentheses, mixed operators, a marker absent from the loaded file — makes `set_groups` return `False` and the panel falls back to a free-text mode, so a hand-written expression is never silently dropped. Group sizes are counted live from the spreadsheet as an upper bound on what a run will see.

## ⚠️ Two infinite-loop fixes in `pipeline/null_models.py` — the part worth reviewing

This is the only change outside the CAT-NAP path. Both loops are faithfully ported from MATLAB/BCT, which has the same bug; MEA arrays are never small enough to hit them, but a cell-type subnetwork is (`SST+` is 3 cells in the example dataset — a literal triangle).

- `randmio_und_signed` (via `participation_coef_norm`) draws four distinct nodes in a bare `while 1`, which cannot terminate for `n < 4`. Now returns the input unchanged.
- `_valid_quad_stream` (via `latmio_und_v2` / `randmio_und_v2`) searches for two edges with four distinct endpoints in a bare `while 1`, which cannot terminate on a triangle, a star, or any degenerate component. Now bounded by a k²-scaled draw budget, after which the caller stops rewiring.

Both only change behaviour in cases where MATLAB would hang forever. Ephys parity is unaffected.

## Verification

Three full pipeline runs on `local/example2pdataWCellTypes` (gitignored): E/I, per-column, and a GUI-authored 4-group config including an overlapping group. All clean, no warnings.

| Suite | Result |
|---|---|
| `python/test_catnap_subnetwork.py` | 45/45 (new) |
| `python/test_gui_cell_type_groups.py` | 30/30 (new; offscreen, no display needed) |
| `python/test_pipeline_catnap.py` | 112/112 parity, unchanged |
| `python/test_pipeline_step4.py` | 60/60 parity, unchanged |
| null models, small-worldness | green |

## Note on interpreting the results

On the example recording the raw `WithinGroupStrengthFrac` looks striking (84% excitatory vs 14% inhibitory) but is almost entirely the 215-vs-34 group-size asymmetry — it sits within ~2% of the size-only null `(n−1)/(N−1)`. The size-normalised readouts are `Subnetwork_EdgeMix.csv` and the split node metrics. This is called out in the docs; a null-normalised enrichment column would be a reasonable follow-up.

## Also not done

`get2pActivityMatrix` → raster plot, and node-size tuning of the base spatial network plot for dense 2P data, both pre-existing Phase 5 gaps unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmPBAbLNCvNb5kBmBdoYiY
