### PR TITLE
feat(python): express mode, run bundles, figure viewer, CAT-NAP resume

### DIFF
--- a/docs/python/catnap.md
+++ b/docs/python/catnap.md
@@ -420,6 +420,52 @@ example dataset if you want a worked example to inspect. For the complete
 output tree — every figure, every CSV and a browsable `report.html` — use
 `python/run_catnap_example.py` instead.
 
+## Re-running from a previous run
+
+```{tip}
+A run made with {doc}`express-mode` writes a single `.meanap` bundle that is
+*also* a resume artifact — point **Use prior analysis** straight at the file.
+```
+
+
+Every run writes one `ExperimentMatFiles/<recording>_catnap.npz` per recording,
+holding the adjacency matrices and activity statistics — the products of what
+MATLAB calls step 2. To re-run the network analysis without rebuilding them,
+set **Start at step** to 4 on the Pipeline tab, tick **Use prior analysis**,
+and point it at the earlier `OutputData…` folder. As in MATLAB, results still
+go to a fresh output folder; the previous run is only ever read.
+
+This skips loading the suite2p data, denoising, and the STTC / probabilistic
+thresholding. It always recomputes the network metrics, the node-cartography
+boundaries and every figure — that is what step 4 *is*, and it is what you are
+usually re-running for (changed plotting options, a different cartography
+setting, an edited cell-type spreadsheet, which is re-read each run rather than
+frozen into the saved file).
+
+How much time this saves depends on where your run spends it. Thresholding
+scales with recordings × lags × `probThreshRepNum`, and denoising — by far the
+most expensive stage — only runs when `Fdenoised.npy` is missing or
+**Redo denoising** is ticked. On the single-recording, single-lag example
+dataset with denoising already cached, a resume saves roughly 13% of a ~5.5 min
+run; with denoising to redo, or a real multi-recording batch, the fraction is
+far larger.
+
+Two things to be aware of:
+
+- **Step 4 is the only resumable point.** CAT-NAP has no step 1 or 3 —
+  adjacency is built in step 2, as in MATLAB — so starting at 2 or 3 is the
+  same as starting at 1, and **Stop at step** has no effect. The run log says
+  so rather than silently ignoring the setting.
+- **Resume the whole batch, not a subset.** The node-cartography boundaries are
+  placed from participation-coefficient and within-module z-score values pooled
+  across *every* recording in the run. Resuming with fewer recordings re-derives
+  them from that subset, so the roles won't match the original run.
+
+With `Random seed` set, a resumed run reproduces the original run's numbers
+exactly (verified on the example dataset: all four CSVs byte-identical).
+Without a seed, the stochastic stages differ between any two runs anyway —
+resumed or not — as they do in MATLAB.
+
 ## Browsing the output
 
 Every run's output folder can be turned into a single self-contained

--- a/docs/python/express-mode.md
+++ b/docs/python/express-mode.md
@@ -1,0 +1,195 @@
+# Express mode and run bundles
+
+A finished MEA-NAP run is mostly pictures. On the bundled example dataset, a
+full run writes **483 figures and 56 MB** — of which the numbers those figures
+were drawn from are about **300 KB**. Every network figure is a pure function
+of that data, so carrying the pictures around means carrying a redundant copy
+roughly twenty times over.
+
+**Express mode** skips the figures that can be rebuilt later and writes a single
+`.meanap` bundle instead. A viewer redraws any figure on demand, in PNG or in
+editable SVG.
+
+```python
+from meanap.params import Params
+params = Params(..., express_mode=True)
+```
+
+Then browse the result:
+
+```bash
+uv run meanap-viewer path/to/OutputData….meanap
+```
+
+## What it costs and what it saves
+
+Measured on the same dataset and settings as the MATLAB-vs-Python comparison
+(`ExampleData/`, two `NGN2_20230208_P1_DIV14` recordings, `Axion64`, lags
+`[10, 25, 50]` ms, 200 thresholding shuffles), both modes run back to back on
+one machine:
+
+| Step | Full | Express |
+|---|---|---|
+| 1. Spike detection | 69.8s | 69.9s |
+| 2. Neuronal activity | 7.7s | 0.0s |
+| 3. Functional connectivity | 14.6s | 14.6s |
+| 4. Network activity | 159.0s | 113.4s |
+| **Total** | **251.1s** | **198.0s** |
+
+| | figures | output folder | bundle |
+|---|---|---|---|
+| Full | 483 | 56.4 MB | — |
+| Express | 6 | 3.2 MB | **2.2 MB** |
+
+**Size is the point: 25× smaller as a single file.** Time is a secondary
+benefit and a bounded one — steps 1 and 3 draw almost nothing, so their 84s can
+never be saved, and step 4 keeps 113s of genuine computation (null models, NMF,
+modularity) once its plotting is removed. Expect **around 20%**, and less on
+datasets where spike detection dominates.
+
+```{note}
+A small single-recording dataset will suggest a much larger saving (~36% on a
+16-channel recording). That is an artefact of the figure count barely shrinking
+while the compute does — don't generalise from it.
+```
+
+## Express mode never changes the numbers
+
+An express run and a full run of the same data with the same
+`random_seed` write **byte-identical** CSVs at both the recording and node
+level, for steps 2 and 4. Express mode changes what is *drawn*, never what is
+*computed*. This is asserted in `python/test_bundle_render.py`, not assumed.
+
+Likewise, figures redrawn from a bundle are **pixel-identical** to the ones the
+pipeline would have written — the renderer calls the same plotting functions
+the pipeline calls, with state reassembled from the bundle, so the two cannot
+drift. All 66 per-recording network figures of the run above were verified this
+way.
+
+## What is in a bundle
+
+A `.meanap` file is a zip whose entries mirror an output folder, so you can
+open it with any zip tool and find plain CSVs inside.
+
+```
+manifest.json                              what this run is, and what can be redrawn
+params.json                                every setting the run used
+ExperimentMatFiles/<rec>_adjM.npz          adjacency matrices (ephys)
+ExperimentMatFiles/<rec>_catnap.npz        adjacency, coordinates, cell types (CAT-NAP)
+ExperimentMatFiles/<rec>_background.npz    mean projection (CAT-NAP, optional)
+4_NetworkActivity/netmet_results.json      every network metric
+4_NetworkActivity/*.csv                    recording- and node-level tables
+2_NeuronalActivity/*.csv, ephys_results.json
+1_SpikeDetection/                          spike times + the checks kept as images
+```
+
+Cell-type information travels *inside* the bundle — marker matrix, the resolved
+grouping, and the expression each group was built from. A recipient with no
+spreadsheet still gets the marker rings and the by-cell-type comparisons.
+
+## Which figures survive, and which don't
+
+Express mode keeps only the quality-control figures that **cannot** be rebuilt,
+because they depend on raw data far too large to carry:
+
+- **spike-detection checks** (electrophysiology) — need the raw voltage;
+- **2P trace figures** (CAT-NAP) — need the full fluorescence matrices.
+
+Everything else is dropped and redrawn on demand. The viewer can currently
+rebuild:
+
+- the per-recording network figure set (4A) — all 11–12 figures, both pipelines;
+- the per-recording activity figures (2A) — rasters, firing-rate and burst
+  heatmaps, burst-detection detail;
+- network metrics by group and age (4B);
+- neuronal or two-photon activity by group and age (2B);
+- CAT-NAP activity split by cell type, and cell-type subnetwork group
+  comparisons.
+
+```{warning}
+One family is dropped and **cannot yet be rebuilt**, so an express run simply
+does not have it: **`cell_type_subnetwork_per_rec`**, CAT-NAP's per-recording
+cell-type subnetwork figures. This isn't fundamental — its inputs *are* in the
+bundle, the reconstruction just isn't wired up — but until it is, re-run
+without `express_mode` if you need those.
+
+Every bundle records what it can and cannot rebuild in `manifest.json`
+(`reconstructable` / `not_reconstructable`), so a viewer can say so rather than
+leave you guessing.
+```
+
+## A bundle is also a resume artifact
+
+Point `prior_analysis_path` at a `.meanap` file and the pipeline resumes from
+it, exactly as it would from an output folder:
+
+```python
+params = Params(
+    prior_analysis=True,
+    prior_analysis_path="path/to/Run.meanap",
+    start_analysis_step=4,
+)
+```
+
+This works with the raw data absent entirely — the bundle carries the adjacency
+matrices and, for electrophysiology, the spike times. So the file you email to
+a collaborator is also the file they can re-run step 4 from, with different
+network settings, and reproduce your metrics exactly.
+
+```{note}
+Spike files are small for a 64-channel recording (~0.3 MB each) but scale with
+channel count and firing rate. On a large batch they may dominate the bundle.
+```
+
+See {doc}`catnap` for the CAT-NAP-specific resume notes, including why you
+should resume the *whole* batch rather than a subset.
+
+## The viewer
+
+```bash
+uv run meanap-viewer path/to/Run.meanap        # or an output folder
+uv run meanap-viewer Run.meanap --port 9000 --no-browser
+```
+
+A local web app: figure list on the left, the figure in the middle, and the
+full Network Viewer control set on the right — node layout, colour map, edge
+threshold and method, maximum edges drawn, node size and scaling, edge widths.
+Changing any of them re-renders through the same Python that drew the original.
+
+Defaults reproduce the pipeline's own figure exactly; the controls are opt-in
+changes on top of it.
+
+Each figure can be downloaded as **PNG, SVG or PDF**. SVG is real vector markup
+with editable paths, so a figure can go straight into Illustrator or Inkscape
+for a manuscript.
+
+Comparison families are shown as a gallery of thumbnails. The styling controls
+are hidden there rather than disabled — they apply to spatial network plots,
+and nothing in a violin-plot gallery reads them.
+
+```{note}
+The gallery renders a whole family at once (the plotting routines emit a folder
+per call and can't be asked for a single figure), so the first view of the
+network family takes a few seconds; it is then cached and instant. Thumbnails
+render at 96 dpi; downloads use the authored resolution.
+```
+
+The viewer binds to `127.0.0.1` by default. A bundle is unpublished data and
+nothing here authenticates anyone — only bind elsewhere on a machine where that
+is deliberate.
+
+## Relationship to `report.html`
+
+{doc}`output-report` describes a different thing, and both are useful:
+
+| | `report.html` | the viewer |
+|---|---|---|
+| needs Python running | no | yes |
+| figures | whatever is on disk | rendered on demand |
+| restyling | no | yes |
+| vector export | no | yes |
+| works on an express run | only the kept checks | fully |
+
+`report.html` is the right artifact for someone who should not have to install
+anything. The viewer is the right one when you want to change a figure and get
+a publication-ready file out.

--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -60,6 +60,13 @@ results.
       Load a real MEA-NAP output file and drive the plotting API directly
       from Python — runnable, with real output baked in.
 
+   .. grid-item-card:: 📦 Express mode & bundles
+      :link: express-mode
+      :link-type: doc
+
+      Skip the figures, ship one small ``.meanap`` file, and redraw any plot
+      on demand — in PNG or editable SVG — with the built-in viewer.
+
    .. grid-item-card:: 📊 Output report
       :link: output-report
       :link-type: doc
@@ -114,5 +121,6 @@ figure.
    network-viewer
    notebooks/network-plotting-tutorial
    output-report
+   express-mode
    matlab-vs-python
    api/index

--- a/docs/python/output-report.md
+++ b/docs/python/output-report.md
@@ -48,3 +48,11 @@ report.html#4_NetworkActivity/4A_IndividualNetworkAnalysis/<group>/<recording>/<
 Opening a link like this auto-expands the sidebar tree and navigates straight
 to that folder — useful for pointing a labmate at one specific plot without
 walking them through the tree by hand.
+
+## Related: the interactive viewer
+
+`report.html` shows the figures a run *wrote*. If you ran with
+{doc}`express-mode`, most figures were never written — use `meanap-viewer`
+instead, which redraws them on demand and can export SVG. The two are
+complementary: `report.html` needs nothing installed, the viewer needs Python
+running but can restyle and re-export.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
 
 [project.scripts]
 meanap-gui = "meanap.gui.app:main"
+meanap-viewer = "meanap.viewer.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/meanap"]

--- a/python/CATNAP_PORT_PLAN.md
+++ b/python/CATNAP_PORT_PLAN.md
@@ -215,10 +215,11 @@ recording is computed and everything that displays a role must come after that:
    `_batch_metric_bounds` for the `_scaled` plot ranges);
 3. plot (per-recording figures, subnetwork analysis, batch comparisons).
 
-Phase 1 keeps only a small `_RecordingState` (adjacency matrices, coords,
+Phase 1 keeps only a small `RecordingState` (adjacency matrices, coords,
 channels, spike counts, duration, suite2p path) — the fluorescence matrices are
 hundreds of MB per recording, so phase 3 re-reads them from disk for the trace
-figures instead of holding a batch's worth in memory.
+figures instead of holding a batch's worth in memory. That same state is what
+Phase 11 persists for re-runs.
 
 **Figure set.** `_plot_recording_lag` gained a `coords_all` parameter and
 `plot_spatial_network_combined` a `coords_override`, so CAT-NAP now draws the
@@ -395,6 +396,34 @@ bound on what a run will see.
 >
 > Both only change behaviour where MATLAB would hang; ephys parity is
 > unaffected (null-model, small-worldness and step-4 suites still green).
+
+### Phase 11 — Re-running from a previous run ✅
+
+MATLAB's step 2 appends `adjMs` to `ExperimentMatFiles/<rec>_<folder>.mat` and
+step 4's `priorAnalysis == 1 && startAnalysisStep == 4` branch loads it back.
+The port had neither half: `runner.py` returned out of the `suite2p_mode`
+branch before the step-range logic ran, so `startAnalysisStep` /
+`stopAnalysisStep` / `priorAnalysis` were ignored, and nothing intermediate was
+written to resume *from*.
+
+`catnap/store.py` now saves one `<rec>_catnap.npz` per recording (the
+`RecordingState` above plus the `calc_twop_activity_stats` dict) and
+`start_analysis_step >= 4` reads it through `InputLocator.catnap_file()`. Step
+4 is the only resumable boundary — CAT-NAP has no step 1 or 3.
+
+Fixed in passing, both in the same loop:
+
+- the metric loop iterated `Params.funcConLagval`, but `suite2pToAdjm` derives
+  a single lag `round(1000 / fs)` for the `F` / `spks` / `denoised F` paths and
+  ignores that list — so those three activity types produced **no** network
+  metrics at all. It now follows the adjacency actually built. Only `peaks` was
+  ever run end to end, which is why this went unnoticed;
+- the whole batch drew from one RNG stream, so metrics depended on recording
+  order and a resumed run would not have reproduced the run it resumed from.
+  Now per-recording, like steps 3/4.
+
+See `PIPELINE_PORT_STATUS.md` § "CAT-NAP resume" for the design choices and
+`python/test_catnap_resume.py` for the tests.
 
 ## Reuse wins
 - Denoising / peak detection (`catnap/denoising.py`) — done.

--- a/python/PIPELINE_PORT_STATUS.md
+++ b/python/PIPELINE_PORT_STATUS.md
@@ -861,13 +861,14 @@ port. `pipeline/resume.py` owns it. Semantics, mirroring MATLAB: **output still
 goes to this run's own (fresh, dated) folder — the prior run is only ever
 read.**
 
-Only two artefacts cross step boundaries in this port, so resuming is a search
-path over two lookups rather than MATLAB's chained-`.mat` machinery:
+Only three artefacts cross step boundaries in this port, so resuming is a
+search path over a few lookups rather than MATLAB's chained-`.mat` machinery:
 
 | Produced by | Consumed by | File |
 |---|---|---|
 | Step 1 | Steps 2, 3, 4 | `1_SpikeDetection/1A_SpikeDetectedData/<rec>_spikes.npz` |
 | Step 3 | Step 4 | `ExperimentMatFiles/<rec>_adjM.npz` |
+| CAT-NAP step 2 | CAT-NAP step 4 | `ExperimentMatFiles/<rec>_catnap.npz` |
 
 `InputLocator` resolves both against, in order: this run's output folder →
 `Params.spike_detected_data` (spike files only, MATLAB's `spikeDetectedData`)
@@ -899,6 +900,72 @@ Verified end to end on the example data: steps 1-3 into folder A, then step 3
 alone and step 4 alone resumed from A with `raw_data` pointed at a
 non-existent folder — same seed reproduced A's adjacency bit-for-bit, and step
 4 produced its CSVs from A's spikes + adjacency.
+
+### CAT-NAP resume (2026-08-06)
+
+The calcium path had none of this: `runner.py` returned straight out of the
+`suite2p_mode` branch before the step-range logic, so `start_analysis_step`,
+`stop_analysis_step` and `prior_analysis` were silently ignored — and nothing
+intermediate was written, so there was nothing to resume from even in
+principle. (Only denoising was reused, and via the *raw* suite2p folder:
+`Fdenoised.npy` & friends are written next to the inputs, not into the output
+folder.) MATLAB has always supported this: its step 2 appends `adjMs` to
+`ExperimentMatFiles/<rec>_<folder>.mat`, and step 4's
+`priorAnalysis == 1 && startAnalysisStep == 4` branch loads it back.
+
+Ported in `catnap/store.py`: phase 1 writes one `<rec>_catnap.npz` per
+recording (adjacency, coords, channels, per-node activity counts, duration,
+the coordinate normalisation, and the `calc_twop_activity_stats` dict), and
+`start_analysis_step >= 4` reads it via `InputLocator.catnap_file()` instead of
+recomputing. Step 4 is the only resumable boundary here, because CAT-NAP has
+no step 1 or 3 — adjacency is built in step 2, as in MATLAB.
+
+Deliberate choices worth knowing:
+
+- **The fluorescence matrices are not stored.** MATLAB saves `F`/`denoisedF`/
+  `spks` because its step 4 re-derives the activity matrix from them; this port
+  stores the per-node quantity step 4 actually consumes (`spike_counts`) and
+  keeps the file small — a resumed run rewrites it into the new output folder
+  so that folder is resumable in turn. Phase 3 still re-reads the suite2p
+  folder for the trace figures and the mean-projection backdrop, and already
+  degrades gracefully when the raw data isn't mounted.
+- **Cell-type groups are re-read, not stored**, so a resumed run picks up an
+  edited spreadsheet rather than freezing the first run's grouping.
+- **Different filename from the ephys `_adjM.npz`.** The two hold different
+  things; pointing a CAT-NAP resume at an ephys output folder now reports a
+  missing input instead of failing deep inside a load.
+- **The phase-2 cartography barrier is batch-wide.** Resuming a *subset* of the
+  batch re-derives the boundaries from that subset alone, so the roles won't
+  match the original run. Documented rather than worked around — pooling is the
+  point of that barrier.
+
+Two bugs fell out of the same code and were fixed alongside:
+
+1. **The metric loop was driven by `Params.funcConLagval`.** `suite2pToAdjm`
+   derives a *single* lag `round(1000 / fs)` for the `F`/`spks`/`denoised F`
+   activity types and ignores `funcConLagval` entirely (MATLAB even overwrites
+   `Params.FuncConLagval` with it). Iterating the Params list meant the key
+   `adjM{lag}mslag` matched nothing and those three activity types produced no
+   network metrics at all. The loop now follows the adjacency that was actually
+   built (`store.sorted_adjm_items`). Only `twop_activity="peaks"` was ever
+   exercised end to end, which is why this survived.
+2. **One RNG stream for the whole batch.** Unlike steps 3/4, CAT-NAP drew every
+   stochastic stage from a single `make_rng(seed, "catnap")`, so a recording's
+   metrics depended on how much randomness the recordings before it consumed —
+   and a resumed run, having skipped the thresholding draws, would have
+   produced different numbers from the run it resumed. Now per-recording:
+   `("catnap", rec)` for adjacency, `("step4", rec)` for network metrics (same
+   label as the ephys path — same work, same recording),
+   `("catnap_subnetwork", rec)` for the subnetwork analysis.
+
+`stop_analysis_step` is still not honoured on this path — the calcium flow is
+one step, not four — but the runner now says so in the log instead of ignoring
+it, as it does for a `start_analysis_step` of 2 or 3.
+
+Tests: `python/test_catnap_resume.py` (46 checks — round-trip including the
+`None`-vs-NaN distinction in the 2P stats, locator resolution, fail-fast,
+resuming with no suite2p folder on disk at all, and a determinism check that
+was confirmed to fail against the old batch-wide RNG before being kept).
 
 ## Random seed (`Params.random_seed`, 2026-07-31)
 
@@ -1351,6 +1418,55 @@ Items 1-4 are genuine MATLAB-side bugs (would affect anyone scripting
 MEA-NAP outside the GUI, e.g. for HPC batch jobs); item 5 is this
 benchmark's own config error, not a MATLAB bug — noted here so a future
 re-run doesn't have to rediscover it.
+
+### Express mode — same dataset, figures skipped (2026-08-06)
+
+`python/benchmark_express.py` re-runs the *same* dataset and config as the
+table above (`ExampleData/`, `NGN2_20230208_P1_DIV14_A2`/`_A3`, `Axion64`,
+lags `[10, 25, 50]`ms, `ProbThreshRepNum=200`) twice — once normally, once
+with `Params.express_mode` — so the two sets of numbers are directly
+comparable. Deliberately not the smaller `local/testBurstDetection` recording:
+a 16-channel single recording flatters express mode, because its figure count
+barely shrinks while its compute does.
+
+| Step | Full | Express | Saved |
+|---|---|---|---|
+| 1. Spike detection | 69.8s | 69.9s | — (untouched) |
+| 2. Neuronal activity | 7.7s | 0.0s | **7.7s** |
+| 3. Functional connectivity | 14.6s | 14.6s | — (untouched) |
+| 4. Network activity | 159.0s | 113.4s | **45.6s** |
+| **Total** | **251.1s** | **198.0s** | **53.1s (21%)** |
+
+| | figures | folder | bundle |
+|---|---|---|---|
+| Full | 483 | 56.4 MB | — |
+| Express | 6 | 3.2 MB | **2.2 MB** |
+
+Size is the real win — **17x** off the folder, **25x** off it as a single
+shareable file. Time is a secondary benefit and *bounded*: steps 1 and 3 draw
+almost nothing, so 84.4s of the 251.1s can never be saved no matter how many
+figures are skipped. Step 4 keeps 113.4s of compute (null models, NMF,
+modularity) after its plotting is removed. Expect ~20%, not the ~36% a small
+single-recording dataset suggests.
+
+The 6 remaining figures are the spike-detection checks (3 per recording) —
+the only family that can't be rebuilt, since it needs the raw voltage.
+
+Verified alongside the timings, not assumed:
+
+- both runs write **byte-identical** CSVs at the recording and node level for
+  steps 2 and 4 — express changes what is drawn, never what is computed;
+- all **66** per-recording 4A figures (2 recordings × 3 lags × 11 figures)
+  re-render from the bundle **pixel-identical** to the full run's, in 13.6s;
+- the bundle is a complete resume artifact: step 4 re-run from the `.meanap`
+  alone, with `raw_data` pointed at a non-existent folder, reproduced the full
+  run's metrics exactly. The ephys spike `.npz` is small enough (~0.3 MB per
+  recording here) to travel with it.
+
+Measured on a 32-core box, so these absolute numbers are *not* comparable to
+the 350.0s in the table above (shared 16-core machine) — the same full run
+takes 251.1s here. The full-vs-express comparison is the meaningful part,
+since both halves ran back to back on the same machine.
 
 ## How to verify changes
 

--- a/python/README.md
+++ b/python/README.md
@@ -139,6 +139,25 @@ generate_report("/path/to/OutputData...")  # writes report.html there, returns i
 
 The same report is deep-linkable — `report.html#4_NetworkActivity/4A_IndividualNetworkAnalysis/<group>/<recording>/<lag>mslag` auto-navigates the sidebar to that folder on load, useful for sharing a link to a specific plot.
 
+## Express mode & run bundles
+
+`Params(express_mode=True)` skips every figure that can be rebuilt from the
+run's own data and writes one shareable `.meanap` bundle instead — 483 figures
+and 56 MB become 6 figures and a 2.2 MB file on the example dataset, with the
+numbers byte-identical either way.
+
+```bash
+uv run meanap-viewer path/to/OutputData….meanap
+```
+
+The viewer redraws any figure on demand with the full Network Viewer control
+set, and exports PNG, **SVG** or PDF. A bundle also works as a resume artifact:
+point `prior_analysis_path` at it to re-run step 4 without the raw data.
+
+One figure family can't be rebuilt yet and is simply absent from an express run
+— CAT-NAP's per-recording cell-type subnetwork figures. See
+`docs/python/express-mode.md`.
+
 ## CAT-NAP (2P)
 
 CAT-NAP is the calcium imaging analysis pathway, triggered by loading a folder that contains suite2p output. It is the Python equivalent of the MATLAB `suite2pToAdjm` / `denoiseSuite2pData` workflow.

--- a/python/benchmark_express.py
+++ b/python/benchmark_express.py
@@ -1,0 +1,143 @@
+"""Time and size a full ephys run against the same run in express mode.
+
+Run from the repo root::
+
+    uv run python python/benchmark_express.py --out /path/for/outputs
+
+Runs the Test Pipeline dataset (``local/testBurstDetection``) through steps 1-4
+twice — once producing every figure, once producing only the data plus the
+spike-detection checks — and reports the per-step durations and the size of
+what each leaves behind. Both runs use the same seed, so the numbers they
+compute are identical and only the drawing differs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.params import Params  # noqa: E402
+from meanap.pipeline.runner import run_pipeline  # noqa: E402
+
+#: The dataset the documented MATLAB-vs-Python comparison used
+#: (PIPELINE_PORT_STATUS.md, "MATLAB vs Python speed comparison"): two Axion64
+#: recordings, three lags, 200 thresholding shuffles. Kept identical here so
+#: these numbers sit alongside those, rather than beside them on a different
+#: dataset — a smaller recording would flatter express mode, since the figure
+#: count barely shrinks while the compute does.
+DATASET = REPO_ROOT / "ExampleData"
+SPREADSHEET = DATASET / "exampleData.csv"
+#: Only the two recordings the published benchmark timed; the spreadsheet also
+#: lists B2/B3 etc.
+SPREADSHEET_RANGE = "2:3"
+
+
+def _params(out_dir: Path, name: str, *, express: bool) -> Params:
+    return Params(
+        raw_data=str(DATASET),
+        spreadsheet_file_name=str(SPREADSHEET),
+        spreadsheet_range=SPREADSHEET_RANGE,
+        output_data_folder=str(out_dir),
+        output_data_folder_name=name,
+        start_analysis_step=1,
+        stop_analysis_step=4,
+        func_con_lag_val=[10, 25, 50],
+        prob_thresh_rep_num=200,
+        channel_layout="Axion64",
+        time_processes=True,
+        random_seed=1,
+        express_mode=express,
+    )
+
+
+def _dir_size(path: Path) -> int:
+    return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+
+
+def _count(path: Path, pattern: str) -> int:
+    return sum(1 for _ in path.rglob(pattern))
+
+
+def _run(out_dir: Path, name: str, *, express: bool) -> dict:
+    print(f"\n{'=' * 70}\n{name} (express={express})\n{'=' * 70}", flush=True)
+    t0 = time.perf_counter()
+    root = run_pipeline(_params(out_dir, name, express=express),
+                        log=lambda m: print(m, flush=True))
+    wall = time.perf_counter() - t0
+
+    durations = {}
+    durations_path = root / "step_durations.json"
+    if durations_path.exists():
+        durations = json.loads(durations_path.read_text())
+
+    bundle = root.with_suffix(".meanap")
+    return {
+        "name": name, "root": root, "wall": wall, "durations": durations,
+        "bytes": _dir_size(root),
+        "figures": _count(root, "*.png"),
+        "bundle_bytes": bundle.stat().st_size if bundle.exists() else None,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not SPREADSHEET.exists():
+        print(f"SKIP: dataset not found at {DATASET}")
+        return 0
+
+    results = [
+        _run(out_dir, "BenchFull", express=False),
+        _run(out_dir, "BenchExpress", express=True),
+    ]
+
+    print(f"\n{'=' * 70}\nRESULTS\n{'=' * 70}")
+    steps = sorted({k for r in results for k in r["durations"] if k != "total"})
+    header = f"{'':<14}" + "".join(f"{s:>12}" for s in steps) + f"{'total':>12}{'wall':>12}"
+    print(header)
+    for r in results:
+        row = f"{r['name']:<14}"
+        for s in steps:
+            row += f"{r['durations'].get(s, float('nan')):>12.1f}"
+        row += f"{r['durations'].get('total', float('nan')):>12.1f}{r['wall']:>12.1f}"
+        print(row)
+
+    print()
+    print(f"{'':<14}{'figures':>12}{'folder MB':>12}{'bundle MB':>12}")
+    for r in results:
+        b = "-" if r["bundle_bytes"] is None else f"{r['bundle_bytes'] / 1e6:.1f}"
+        print(f"{r['name']:<14}{r['figures']:>12}{r['bytes'] / 1e6:>12.1f}{b:>12}")
+
+    full, exp = results
+    if full["durations"].get("total") and exp["durations"].get("total"):
+        saved = full["durations"]["total"] - exp["durations"]["total"]
+        pct = saved / full["durations"]["total"] * 100
+        print(f"\ntime saved: {saved:.1f}s ({pct:.0f}%)")
+    print(f"folder size: {full['bytes'] / 1e6:.1f} MB → {exp['bytes'] / 1e6:.1f} MB "
+          f"({full['bytes'] / max(exp['bytes'], 1):.1f}x smaller)")
+    if exp["bundle_bytes"]:
+        print(f"bundle:      {exp['bundle_bytes'] / 1e6:.1f} MB "
+              f"({full['bytes'] / exp['bundle_bytes']:.0f}x smaller than the full folder)")
+
+    # Per-folder breakdown of where the bytes go.
+    print()
+    for r in results:
+        print(f"{r['name']}:")
+        for sub in sorted(p for p in r["root"].iterdir() if p.is_dir()):
+            print(f"    {sub.name:<28}{_dir_size(sub) / 1e6:>8.1f} MB"
+                  f"{_count(sub, '*.png'):>7} png")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/run_catnap_subnetwork_demo.py
+++ b/python/run_catnap_subnetwork_demo.py
@@ -29,7 +29,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-import numpy as np  # noqa: E402
 
 from meanap.catnap.pipeline import run_catnap_pipeline  # noqa: E402
 from meanap.catnap.subnetwork import EXCITATORY_INHIBITORY_PRESET  # noqa: E402
@@ -91,7 +90,6 @@ def main() -> int:
     run_catnap_pipeline(
         params, recordings, out_root,
         log=lambda m: print(m, flush=True),
-        rng=np.random.default_rng(params.random_seed),
     )
     print(f"\nDone in {time.time() - start:.0f}s → {out_root}")
 

--- a/python/test_bundle_render.py
+++ b/python/test_bundle_render.py
@@ -1,0 +1,934 @@
+"""Test express mode, the ``.meanap`` bundle, and redrawing figures from it.
+
+Run from the repo root::
+
+    uv run python python/test_bundle_render.py
+
+The claim express mode makes is strong: *the figures it doesn't draw can be
+drawn later, identically.* If that is off by so much as an axis limit, the
+bundle is worse than useless — it looks right and isn't. So the load-bearing
+check here is pixel equality between a figure the pipeline drew and the same
+figure redrawn from the bundle alone.
+
+Sections:
+
+  A. bundle round-trip — write, open, and read back the manifest and params,
+     including rejection of things that aren't bundles;
+  B. reconstruction — ``adjMsub`` rebuilt from stored adjacency + active index
+     matches what ``compute_network_metrics`` produced;
+  C. **pixel parity** — full-mode run vs. render-from-bundle, byte-for-byte;
+  D. vector output and styling overrides.
+
+Everything runs on a small synthetic run; no example dataset or MATLAB needed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.catnap.store import (  # noqa: E402
+    RecordingState, quantize_background, save_recording_state,
+)
+from meanap.params import PARAMS_FILENAME, Params  # noqa: E402
+from meanap.pipeline.bundle import (  # noqa: E402
+    BUNDLE_SUFFIX, build_manifest, open_bundle,
+)
+from meanap.pipeline.resume import CATNAP_SUFFIX  # noqa: E402
+from meanap.pipeline.spreadsheet import RecordingInfo  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+N_UNITS = 24
+LAG = 25
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _recordings() -> list[RecordingInfo]:
+    return [RecordingInfo(filename="recA", div=21.0, group="WT"),
+            RecordingInfo(filename="recB", div=21.0, group="KO")]
+
+
+def _adjacency(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    a = rng.random((N_UNITS, N_UNITS))
+    a = (a + a.T) / 2
+    np.fill_diagonal(a, 0)
+    return a
+
+
+def _params(out_dir: Path, **kw) -> Params:
+    p = Params(
+        suite2p_mode=True, func_con_lag_val=[LAG], min_activity_level=0.0,
+        min_number_of_nodes_to_cal_net_met=2, twop_subnetwork_analysis=False,
+        num_2p_traces=0, twop_network_background=False,
+        auto_set_cartography_boundaries=False, random_seed=11,
+        output_data_folder=str(out_dir), start_analysis_step=4,
+        prior_analysis=True,
+    )
+    for k, v in kw.items():
+        setattr(p, k, v)
+    return p
+
+
+def _seed_prior(tmp: Path, name: str = "Prior") -> Path:
+    """A prior run holding just the step-2 state, ready to resume from."""
+    from meanap.pipeline.output_folders import create_output_folders
+
+    from meanap.catnap.subnetwork import CellTypeGroups
+
+    prior = create_output_folders(tmp, name, ["WT", "KO"])
+    # Half the cells excitatory, half inhibitory — enough for the by-cell-type
+    # comparisons to have two series to separate.
+    exc = np.zeros(N_UNITS, bool)
+    exc[: N_UNITS // 2] = True
+    masks = np.column_stack([exc, ~exc])
+    markers = np.eye(N_UNITS, 2)
+    for i, rec in enumerate(_recordings()):
+        state = RecordingState(
+            adjMs={f"adjM{LAG}mslag": _adjacency(20 + i)},
+            coords=np.random.default_rng(i).random((N_UNITS, 2)) * 8.0,
+            channels=np.arange(1, N_UNITS + 1),
+            spike_counts=np.full(N_UNITS, 100.0),
+            duration_s=600.0, plane0=Path("/nonexistent"),
+            markers=(markers, ["NeuN+", "GAD+"]),
+            groups=CellTypeGroups(
+                names=["Excitatory", "Inhibitory"], masks=masks,
+                marker_names=["NeuN+", "GAD+"], marker_matrix=markers,
+                definitions={"Excitatory": "NeuN+ & ~GAD+", "Inhibitory": "GAD+"},
+            ),
+            coord_norm=(0.0, 511.0),
+        )
+        stats = {"FR": np.full(N_UNITS, 1.0), "FRactive": np.full(N_UNITS, 1.0),
+                 "FRmean": 1.0, "numActiveElec": N_UNITS, "unitHeightMean": None}
+        save_recording_state(
+            prior / "ExperimentMatFiles" / f"{rec.filename}{CATNAP_SUFFIX}",
+            state, stats)
+    return prior
+
+
+def _run(tmp: Path, name: str, *, express: bool) -> Path:
+    """Resume a run from the seeded prior, in express or full mode."""
+    from meanap.pipeline.runner import run_pipeline
+    import pandas as pd
+
+    prior = _seed_prior(tmp, f"{name}Prior")
+    sheet = tmp / f"{name}.csv"
+    pd.DataFrame([{"Recording filename": r.filename, "DIV": r.div, "Group": r.group}
+                  for r in _recordings()]).to_csv(sheet, index=False)
+
+    p = _params(tmp, output_data_folder_name=name, express_mode=express,
+                prior_analysis_path=str(prior),
+                spreadsheet_file_name=str(sheet), spreadsheet_range="2:100",
+                raw_data=str(tmp / "no-raw"))
+    return run_pipeline(p, log=lambda m: None)
+
+
+# ── Section A: bundle round-trip ──────────────────────────────────────────────
+
+
+def _bundle_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        root = _run(tmp, "Express", express=True)
+        bundle_path = root.with_suffix(BUNDLE_SUFFIX)
+
+        checks.append(("express run writes a bundle", bundle_path.exists(), ""))
+        checks.append(("bundle is a zip", zipfile.is_zipfile(bundle_path), ""))
+
+        pngs = list(root.rglob("*.png"))
+        checks.append(("express run drew no reconstructable figures",
+                       not pngs, f"{[p.name for p in pngs]}"))
+
+        with open_bundle(bundle_path) as b:
+            checks.append(("manifest records the mode", b.mode == "catnap", b.mode))
+            checks.append(("manifest records express", b.manifest["express"] is True, ""))
+            checks.append(("manifest lists both recordings",
+                           {r["filename"] for r in b.recordings} == {"recA", "recB"},
+                           f"{b.recordings}"))
+            checks.append(("manifest records the lag", b.lags == [LAG], f"{b.lags}"))
+            checks.append(("params round-trip", b.params.random_seed == 11
+                           and b.params.suite2p_mode, ""))
+            checks.append(("no unknown param keys", b.unknown_param_keys == [],
+                           f"{b.unknown_param_keys}"))
+            checks.append(("bundle carries the resume state",
+                           (b.root / "ExperimentMatFiles"
+                            / f"recA{CATNAP_SUFFIX}").exists(), ""))
+            checks.append(("bundle carries the metrics",
+                           (b.root / "4_NetworkActivity"
+                            / "netmet_results.json").exists(), ""))
+            checks.append(("bundle carries params.json",
+                           (b.root / PARAMS_FILENAME).exists(), ""))
+            extracted = b.root
+
+        checks.append(("closing cleans up the extracted copy",
+                       not extracted.exists(), f"{extracted}"))
+
+        # Not-a-bundle inputs must say so plainly.
+        junk = tmp / f"junk{BUNDLE_SUFFIX}"
+        junk.write_text("not a zip")
+        try:
+            open_bundle(junk)
+            msg = ""
+        except ValueError as e:
+            msg = str(e)
+        checks.append(("a non-zip is rejected clearly", "not a zip archive" in msg, msg[:60]))
+
+        # A zip with no manifest is a zip, but not a bundle.
+        plain = tmp / f"plain{BUNDLE_SUFFIX}"
+        with zipfile.ZipFile(plain, "w") as zf:
+            zf.writestr("hello.txt", "hi")
+        try:
+            open_bundle(plain)
+            msg2 = ""
+        except ValueError as e:
+            msg2 = str(e)
+        checks.append(("a zip without a manifest is rejected",
+                       "not a" in msg2 and "bundle" in msg2, msg2[:60]))
+
+        # A newer format must be refused, not half-read.
+        newer = tmp / f"newer{BUNDLE_SUFFIX}"
+        manifest = build_manifest(Params(), _recordings(), mode="catnap", lags=[LAG])
+        manifest["format"] = 999
+        with zipfile.ZipFile(newer, "w") as zf:
+            zf.writestr("manifest.json", json.dumps(manifest))
+        try:
+            open_bundle(newer)
+            msg3 = ""
+        except ValueError as e:
+            msg3 = str(e)
+        checks.append(("a newer format is refused with an upgrade hint",
+                       "Update MEA-NAP" in msg3, msg3[:70]))
+
+    return checks
+
+
+def _zip_slip_checks() -> list[Check]:
+    """A bundle is a file people email each other; it must not escape its dir."""
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        evil = Path(tmp) / f"evil{BUNDLE_SUFFIX}"
+        manifest = build_manifest(Params(), [], mode="catnap", lags=[])
+        with zipfile.ZipFile(evil, "w") as zf:
+            zf.writestr("manifest.json", json.dumps(manifest))
+            zf.writestr("../escaped.txt", "pwned")
+        try:
+            open_bundle(evil)
+            msg = ""
+        except ValueError as e:
+            msg = str(e)
+        checks.append(("a traversal entry is refused", "outside" in msg, msg[:70]))
+        checks.append(("nothing was written outside the temp dir",
+                       not (Path(tmp).parent / "escaped.txt").exists(), ""))
+    return checks
+
+
+# ── Section B: reconstruction ─────────────────────────────────────────────────
+
+
+def _reconstruction_checks() -> list[Check]:
+    from meanap.pipeline.render import load_context
+    from meanap.pipeline.step4 import compute_network_metrics
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        root = _run(tmp, "Express", express=True)
+        with open_bundle(root.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+
+            checks.append(("context finds both recordings",
+                           set(ctx.recordings) == {"recA", "recB"},
+                           f"{sorted(ctx.recordings)}"))
+            checks.append(("context finds the lag", ctx.lags("recA") == [LAG],
+                           f"{ctx.lags('recA')}"))
+
+            # adjMsub must match what the pipeline computed, not merely exist.
+            adj = _adjacency(20)
+            expected = compute_network_metrics(
+                adj, np.full(N_UNITS, 100.0), 600.0, 0.0, 2,
+                exclude_edges_below_threshold=False,
+                params=ctx.params, rng=np.random.default_rng(0),
+            )["adjMsub"]
+            got = ctx.results["recA"][f"{LAG}mslag"]["adjMsub"]
+            checks.append(("adjMsub rebuilt exactly from stored adjacency",
+                           np.array_equal(got, expected),
+                           f"max diff {np.abs(got - expected).max() if got.shape == expected.shape else 'shape'}"))
+
+            # Numeric metrics must come back as arrays, names as lists.
+            nd = ctx.results["recA"][f"{LAG}mslag"]["ND"]
+            checks.append(("numeric metrics restored as arrays",
+                           isinstance(nd, np.ndarray), f"{type(nd)}"))
+    return checks
+
+
+# ── Section C: pixel parity ───────────────────────────────────────────────────
+
+
+def _parity_checks() -> list[Check]:
+    """The load-bearing check: same figure, drawn two ways, byte-identical."""
+    from meanap.pipeline.render import available_figures, load_context, render_figure
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "Full", express=False)
+        express = _run(tmp, "Express", express=True)
+
+        with open_bundle(express.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+            figs = available_figures(ctx, "recA", LAG)
+            checks.append(("bundle advertises figures to redraw", len(figs) >= 5,
+                           f"{len(figs)}"))
+
+            out = tmp / "redrawn"
+            pipeline_dir = (full / "4_NetworkActivity" / "4A_IndividualNetworkAnalysis"
+                            / "WT" / "recA" / f"{LAG}mslag")
+
+            compared = identical = 0
+            mismatched: list[str] = []
+            for spec in figs:
+                original = pipeline_dir / f"{spec.name}.png"
+                if not original.exists():
+                    continue
+                redrawn = render_figure(ctx, "recA", LAG, spec.name, out)
+                compared += 1
+                if _digest(original) == _digest(redrawn):
+                    identical += 1
+                else:
+                    mismatched.append(spec.name)
+
+            checks.append(("every advertised figure exists in the full run",
+                           compared == len(figs), f"{compared}/{len(figs)}"))
+            checks.append((f"redrawn figures are pixel-identical ({identical}/{compared})",
+                           compared > 0 and identical == compared,
+                           f"differ: {mismatched}"))
+
+            # The batch-scaled variants share axes across recordings, so they
+            # are the ones that break if batch_bounds isn't recomputed right.
+            scaled = pipeline_dir / "2_scaled_MEA_NetworkPlot.png"
+            if scaled.exists():
+                redrawn = render_figure(ctx, "recA", LAG, "2_scaled_MEA_NetworkPlot", out)
+                checks.append(("batch-scaled figure matches (pooled bounds recomputed)",
+                               _digest(scaled) == _digest(redrawn), ""))
+    return checks
+
+
+# ── Section D: vector output and restyling ────────────────────────────────────
+
+
+def _vector_checks() -> list[Check]:
+    from meanap.pipeline.render import load_context, render_figure
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        express = _run(tmp, "Express", express=True)
+        with open_bundle(express.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+            out = tmp / "vector"
+
+            svg = render_figure(ctx, "recA", LAG, "2_MEA_NetworkPlot", out, fmt="svg")
+            checks.append(("svg is written", svg.exists() and svg.suffix == ".svg",
+                           f"{svg.name}"))
+            head = svg.read_text(errors="ignore")[:400]
+            checks.append(("svg really is vector markup", "<svg" in head, head[:60]))
+            checks.append(("svg holds editable elements",
+                           "<path" in svg.read_text(errors="ignore"), ""))
+
+            pdf = render_figure(ctx, "recA", LAG, "2_MEA_NetworkPlot", out, fmt="pdf")
+            checks.append(("pdf is written",
+                           pdf.exists() and pdf.read_bytes()[:4] == b"%PDF", ""))
+
+            # Restyling must change the picture without touching the bundle.
+            # ``twop_auto_node_size`` drives node_size_scale, which is one of
+            # the few styling inputs the spatial plotter actually consumes.
+            png = render_figure(ctx, "recA", LAG, "2_MEA_NetworkPlot", out / "a")
+            restyled = render_figure(ctx, "recA", LAG, "2_MEA_NetworkPlot", out / "b",
+                                     overrides={"twop_auto_node_size":
+                                                not ctx.params.twop_auto_node_size})
+            checks.append(("an override changes the rendered figure",
+                           _digest(png) != _digest(restyled), ""))
+            checks.append(("the override did not mutate the context",
+                           ctx.params.twop_auto_node_size
+                           == Params().twop_auto_node_size, ""))
+
+            try:
+                render_figure(ctx, "recA", LAG, "2_MEA_NetworkPlot", out,
+                              overrides={"not_a_real_param": 1})
+                msg = ""
+            except ValueError as e:
+                msg = str(e)
+            checks.append(("an unknown override is rejected",
+                           "Unknown parameter override" in msg, msg[:60]))
+
+            try:
+                render_figure(ctx, "recA", LAG, "no_such_figure", out)
+                msg2 = ""
+            except ValueError as e:
+                msg2 = str(e)
+            checks.append(("an unknown figure name is rejected",
+                           "not one of the figures" in msg2, msg2[:60]))
+    return checks
+
+
+def _style_checks() -> list[Check]:
+    """The Network Viewer control set, driven through the bundle renderer."""
+    from meanap.network_plot import (
+        EDGE_THRESHOLD_METHODS, LAYOUT_OPTIONS, NetworkStyle,
+    )
+    from meanap.pipeline.render import (
+        STYLE_KEYS, load_context, render_figure, style_from_overrides,
+    )
+
+    checks: list[Check] = []
+
+    # The identity style must not perturb anything — this is what keeps the
+    # pipeline's figures byte-stable while the plumbing exists.
+    a = np.array([[0, .5, .1], [.5, 0, .9], [.1, .9, 0]])
+    c = np.array([[0, 0], [1, 0], [0, 1]], float)
+    adj, coords, thresh = NetworkStyle.pipeline_default().prepare(a, c)
+    checks.append(("pipeline default is the identity transform",
+                   np.array_equal(adj, a) and np.array_equal(coords, c)
+                   and thresh == 0.0, f"thresh={thresh}"))
+    checks.append(("no style requested → no NetworkStyle built",
+                   style_from_overrides({"twop_auto_node_size": True}) is None, ""))
+    checks.append(("a styling key builds a NetworkStyle",
+                   isinstance(style_from_overrides({"colormap": "magma"}),
+                              NetworkStyle), ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        express = _run(tmp, "Express", express=True)
+        with open_bundle(express.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+            out = tmp / "styled"
+            base = render_figure(ctx, "recA", LAG, "4_MEA_NetworkPlotNodedegree"
+                                 "Participationcoefficient", out / "base")
+            fig = "4_MEA_NetworkPlotNodedegreeParticipationcoefficient"
+
+            # Every control must visibly change the figure. A knob that renders
+            # identically is a knob that isn't wired up.
+            variants = {
+                "colormap": {"colormap": "magma"},
+                "layout": {"layout": "Circular"},
+                "max_edges": {"max_edges": 3},
+                "edge threshold": {"edge_threshold_method": "Percentile",
+                                   "edge_threshold": 99.0},
+                "node size scale": {"node_size_scale": 3.0},
+                "node scaling method": {"node_scaling_method": "Square"},
+                "min node size": {"min_node_size": 2.0},
+                "edge widths": {"min_edge_width": 2.0, "max_edge_width": 12.0},
+            }
+            for label, ov in variants.items():
+                got = render_figure(ctx, "recA", LAG, fig, out / label, overrides=ov)
+                checks.append((f"control changes the figure: {label}",
+                               _digest(base) != _digest(got), f"{ov}"))
+
+            checks.append(("every style key is covered by a control",
+                           STYLE_KEYS <= {k for ov in variants.values() for k in ov}
+                           | {"node_scaling_power"},
+                           f"{sorted(STYLE_KEYS - {k for ov in variants.values() for k in ov})}"))
+            checks.append(("layout options are the viewer's",
+                           "Circular" in LAYOUT_OPTIONS
+                           and "Percentile" in EDGE_THRESHOLD_METHODS, ""))
+
+            # Styling and vector output must compose.
+            svg = render_figure(ctx, "recA", LAG, fig, out / "svg", fmt="svg",
+                                overrides={"colormap": "magma", "layout": "Circular"})
+            checks.append(("styled vector output works",
+                           svg.suffix == ".svg" and "<svg" in svg.read_text()[:400], ""))
+    return checks
+
+
+def _group_family_checks() -> list[Check]:
+    """2B / 4B batch comparisons redrawn from the bundle, and pixel-checked."""
+    from meanap.pipeline.render import (
+        available_group_families, load_context, render_group_family,
+    )
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "Full", express=False)
+        express = _run(tmp, "Express", express=True)
+
+        with open_bundle(express.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+            fams = {f.key for f in available_group_families(ctx)}
+            checks.append(("network + activity families are available",
+                           {"network", "activity"} <= fams, f"{sorted(fams)}"))
+
+            out = tmp / "groups"
+            total_compared = total_identical = 0
+            mismatched: list[str] = []
+            for key in ("network", "activity"):
+                written = render_group_family(ctx, key, out)
+                checks.append((f"'{key}' family produced figures", len(written) > 0,
+                               f"{len(written)}"))
+                for path in written:
+                    original = full / path.relative_to(out)
+                    if not original.exists():
+                        mismatched.append(f"missing original: {path.name}")
+                        continue
+                    total_compared += 1
+                    if _digest(original) == _digest(path):
+                        total_identical += 1
+                    else:
+                        mismatched.append(path.name)
+
+            checks.append((f"group figures are pixel-identical "
+                           f"({total_identical}/{total_compared})",
+                           total_compared > 0 and total_identical == total_compared,
+                           f"{mismatched[:4]}"))
+
+            svg = render_group_family(ctx, "network", tmp / "groups_svg", fmt="svg")
+            checks.append(("group families render as svg",
+                           bool(svg) and all(p.suffix == ".svg" for p in svg),
+                           f"{len(svg)}"))
+
+            try:
+                render_group_family(ctx, "nonsense", out)
+                msg = ""
+            except ValueError as e:
+                msg = str(e)
+            checks.append(("an unknown family is rejected",
+                           "Unknown figure family" in msg, msg[:50]))
+    return checks
+
+
+def _cell_type_self_contained_checks() -> list[Check]:
+    """Cell types must travel *in* the bundle, not via the spreadsheet.
+
+    A bundle is shared with people who have neither the raw data nor the
+    ``PutativeCellType_*`` spreadsheet. If the marker rings or the by-cell-type
+    comparisons quietly reached back for that file, they would render fine on
+    the machine that produced the bundle and be blank or wrong everywhere else
+    — the worst kind of failure. So this deletes the spreadsheet outright
+    before rendering, and demands pixel equality against the run that had it.
+    """
+    from meanap.catnap.store import load_recording_state
+    from meanap.pipeline.render import load_context, render_figure, render_group_family
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "Full", express=False)
+        express = _run(tmp, "Express", express=True)
+
+        # The state carries markers and the resolved grouping.
+        state, _ = load_recording_state(
+            express / "ExperimentMatFiles" / f"recA{CATNAP_SUFFIX}", Path("."))
+        checks.append(("markers stored in the bundle state",
+                       state.markers is not None
+                       and state.markers[1] == ["NeuN+", "GAD+"],
+                       f"{None if state.markers is None else state.markers[1]}"))
+        checks.append(("resolved groups stored in the bundle state",
+                       state.groups is not None and state.groups.n_groups > 0,
+                       f"{None if state.groups is None else state.groups.names}"))
+
+        bundle_path = express.with_suffix(BUNDLE_SUFFIX)
+
+        # Now make the world hostile: no spreadsheet, no raw data, and the
+        # original output folder gone. Only the bundle survives.
+        import shutil
+        for stray in tmp.glob("*.csv"):
+            stray.unlink()
+        shutil.rmtree(express)
+        checks.append(("spreadsheet and output folder removed",
+                       not list(tmp.glob("*.csv")) and not express.exists(), ""))
+
+        with open_bundle(bundle_path) as b:
+            ctx = load_context(b)
+            checks.append(("groups survive the round trip",
+                           _groups_of(ctx, "recA") is not None, ""))
+
+            out = tmp / "orphan"
+            # The marker rings live on the spatial network plots.
+            fig = "2_MEA_NetworkPlot"
+            redrawn = render_figure(ctx, "recA", LAG, fig, out)
+            original = (full / "4_NetworkActivity" / "4A_IndividualNetworkAnalysis"
+                        / "WT" / "recA" / f"{LAG}mslag" / f"{fig}.png")
+            checks.append(("network plot with marker rings is identical "
+                           "without the spreadsheet",
+                           _digest(original) == _digest(redrawn), ""))
+
+            written = render_group_family(ctx, "cell_type", out)
+            checks.append(("by-cell-type comparisons render with no spreadsheet",
+                           len(written) > 0, f"{len(written)}"))
+            same = sum(1 for p in written
+                       if (full / p.relative_to(out)).exists()
+                       and _digest(full / p.relative_to(out)) == _digest(p))
+            checks.append((f"…and are pixel-identical ({same}/{len(written)})",
+                           written and same == len(written), ""))
+    return checks
+
+
+def _groups_of(ctx, recording):
+    from meanap.pipeline.render import _states
+
+    entry = _states(ctx).get(recording)
+    return None if entry is None else entry[0].groups
+
+
+def _gallery_cache_checks() -> list[Check]:
+    """Thumbnail resolution + caching: the gallery's cost model.
+
+    A family is all-or-nothing — the group plotters emit a folder per call and
+    can't be asked for one figure — so a gallery pays the whole render or none
+    of it. These checks pin the two things that make that acceptable: the
+    thumbnail resolution actually reduces cost, and the second view is free.
+    """
+    import time
+
+    from meanap.pipeline.figure_output import (
+        DEFAULT_THUMBNAIL_DPI, current_dpi, figure_dpi,
+    )
+    from meanap.pipeline.render import gallery, load_context, render_group_family
+    from meanap.pipeline.render_cache import RenderCache, bundle_identity, cache_key
+
+    checks: list[Check] = []
+
+    # The override must be scoped, or one request's resolution leaks into the
+    # next — the reason this is a ContextVar and not a module global.
+    checks.append(("no override by default", current_dpi() is None, ""))
+    with figure_dpi(96):
+        inner = current_dpi()
+    checks.append(("override applies inside the block", inner == 96, f"{inner}"))
+    checks.append(("…and is restored after", current_dpi() is None, ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        express = _run(tmp, "Express", express=True)
+        bundle_path = express.with_suffix(BUNDLE_SUFFIX)
+
+        with open_bundle(bundle_path) as b:
+            ctx = load_context(b)
+
+            full = render_group_family(ctx, "network", tmp / "full_dpi")
+            thumb = render_group_family(ctx, "network", tmp / "thumb",
+                                        dpi=DEFAULT_THUMBNAIL_DPI)
+            checks.append(("same figure count at both resolutions",
+                           len(full) == len(thumb), f"{len(full)} vs {len(thumb)}"))
+            full_mb = sum(p.stat().st_size for p in full) / 1e6
+            thumb_mb = sum(p.stat().st_size for p in thumb) / 1e6
+            checks.append((f"thumbnails are smaller ({full_mb:.1f} → {thumb_mb:.1f} MB)",
+                           thumb_mb < full_mb * 0.6, ""))
+
+            # Caching: second call must not re-render.
+            with RenderCache.in_temp() as cache:
+                t0 = time.perf_counter()
+                first, cached1 = gallery(ctx, "network", cache)
+                t_first = time.perf_counter() - t0
+
+                t0 = time.perf_counter()
+                second, cached2 = gallery(ctx, "network", cache)
+                t_second = time.perf_counter() - t0
+
+                checks.append(("first view renders", not cached1 and len(first) > 0,
+                               f"{len(first)}"))
+                checks.append(("second view is a cache hit", cached2, ""))
+                checks.append(("…and returns the same files",
+                               [p.name for p in first] == [p.name for p in second], ""))
+                checks.append((f"cache hit is far faster "
+                               f"({t_first:.1f}s → {t_second * 1000:.0f}ms)",
+                               t_second < t_first / 10, ""))
+
+                # A different style must not collide with the cached entry.
+                restyled, cached3 = gallery(ctx, "network", cache,
+                                            overrides={"custom_grp_order": ["KO", "WT"]})
+                checks.append(("a restyled view is a separate entry", not cached3, ""))
+
+                # A partial render must not be served.
+                key = cache_key(bundle_identity(ctx.root), "network",
+                                fmt="png", dpi=DEFAULT_THUMBNAIL_DPI)
+                (cache.path_for(key) / ".complete").unlink()
+                checks.append(("an incomplete entry counts as a miss",
+                               cache.get(key) is None, ""))
+
+            # Identity is content-based, so a renamed copy still hits.
+            import shutil
+            twin = tmp / f"Renamed{BUNDLE_SUFFIX}"
+            shutil.copy(bundle_path, twin)
+            checks.append(("bundle identity follows content, not filename",
+                           bundle_identity(bundle_path) == bundle_identity(twin), ""))
+            twin.write_bytes(twin.read_bytes() + b"x")
+            checks.append(("…and changes when the bytes change",
+                           bundle_identity(bundle_path) != bundle_identity(twin), ""))
+    return checks
+
+
+def _ephys_render_checks() -> list[Check]:
+    """The renderer must read electrophysiology output too, not just CAT-NAP.
+
+    The two pipelines store their per-recording arrays differently — ephys in
+    ``<rec>_adjM.npz`` (adjacency + channels, node positions derived from the
+    channel layout), CAT-NAP in ``<rec>_catnap.npz`` (adjacency + explicit
+    coordinates + cell types). The renderer takes whichever is present rather
+    than branching on mode, so this checks the ephys shape end to end without
+    needing a real ephys run.
+    """
+    import json as _json
+
+    from meanap.pipeline.output_folders import create_output_folders
+    from meanap.pipeline.render import (
+        available_figures, load_context, render_figure,
+    )
+    from meanap.pipeline.resume import ADJM_SUFFIX
+    from meanap.pipeline.step4 import _convert_numpy, compute_network_metrics
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        root = create_output_folders(tmp, "Ephys", ["WT"])
+
+        # Step 3's file shape: bare adjacency keys plus a `_raw` copy the
+        # metrics were *not* computed from, and the channel list.
+        n = 16
+        adj = _adjacency(31)[:n, :n]
+        channels = np.arange(1, n + 1)
+        np.savez(root / "ExperimentMatFiles" / f"recE{ADJM_SUFFIX}",
+                 channels=channels,
+                 **{f"adjM{LAG}mslag": adj, f"adjM{LAG}mslag_raw": adj * 0.5})
+
+        params = Params(channel_layout="MCS60", random_seed=5)
+        metrics = compute_network_metrics(
+            adj, np.full(n, 100.0), 600.0, 0.0, 2,
+            exclude_edges_below_threshold=False, params=params,
+            rng=np.random.default_rng(5))
+        results = {"recE": {f"{LAG}mslag": {k: v for k, v in metrics.items()
+                                            if k != "adjMsub"}}}
+        with open(root / "4_NetworkActivity" / "netmet_results.json", "w") as fh:
+            _json.dump(_convert_numpy(results), fh)
+        import pandas as pd
+        pd.DataFrame([{"FileName": "recE", "Grp": "WT", "DIV": 58, "Lag": f"{LAG}mslag"}]
+                     ).to_csv(root / "4_NetworkActivity"
+                              / "NetworkActivity_RecordingLevel.csv", index=False)
+        from meanap.params import save_params
+        save_params(params, root)
+
+        ctx = load_context(root)
+        checks.append(("ephys output loads as a render context",
+                       ctx.mode == "ephys" and "recE" in ctx.recordings,
+                       f"{ctx.mode}"))
+        checks.append(("adjacency found in the _adjM.npz",
+                       "adjMsub" in ctx.results["recE"][f"{LAG}mslag"], ""))
+        got = ctx.results["recE"][f"{LAG}mslag"]["adjMsub"]
+        checks.append(("…and it is the thresholded matrix, not the _raw copy",
+                       np.allclose(got, metrics["adjMsub"]), ""))
+
+        figs = available_figures(ctx, "recE", LAG)
+        checks.append(("figures are offered for an ephys recording",
+                       len(figs) >= 5, f"{len(figs)}"))
+        checks.append(("the field-of-view figure is not offered (no projection)",
+                       not any(f.name == "12_MeanImageAndNetwork" for f in figs), ""))
+
+        out = tmp / "rendered"
+        drawn = render_figure(ctx, "recE", LAG, "2_MEA_NetworkPlot", out)
+        checks.append(("an ephys network plot renders",
+                       drawn.exists() and drawn.stat().st_size > 5000,
+                       f"{drawn.stat().st_size if drawn.exists() else 0}"))
+        svg = render_figure(ctx, "recE", LAG, "2_MEA_NetworkPlot", out, fmt="svg")
+        checks.append(("…and as svg", "<svg" in svg.read_text()[:400], ""))
+        # Colour-map changes need a figure that *has* a colour metric —
+        # 2_MEA_NetworkPlot draws flat cyan nodes, so it is deliberately
+        # immune. Use the participation-coefficient plot instead.
+        coloured = "4_MEA_NetworkPlotNodedegreeParticipationcoefficient"
+        base = render_figure(ctx, "recE", LAG, coloured, out / "c")
+        restyled = render_figure(ctx, "recE", LAG, coloured, out / "d",
+                                 overrides={"colormap": "magma"})
+        checks.append(("colour map applies on the ephys path",
+                       _digest(base) != _digest(restyled), ""))
+        moved = render_figure(ctx, "recE", LAG, "2_MEA_NetworkPlot", out / "e",
+                              overrides={"layout": "Circular"})
+        checks.append(("layout applies on the ephys path",
+                       _digest(drawn) != _digest(moved), ""))
+
+        # ── step-2 activity figures (rasters, heatmaps, burst detail) ────────
+        from meanap.pipeline.io import save_spike_times_npz
+        from meanap.pipeline.render import (
+            available_activity_figures, render_activity_figure,
+        )
+        from meanap.pipeline.resume import SPIKE_SUBDIR
+        from meanap.pipeline.step2 import convert_numpy
+
+        checks.append(("no activity figures without spike times",
+                       available_activity_figures(ctx, "recE") == [], ""))
+
+        rng = np.random.default_rng(9)
+        spike_times = {ch: np.sort(rng.uniform(0, 600, rng.integers(20, 200)))
+                       for ch in range(n)}
+        save_spike_times_npz(
+            root / SPIKE_SUBDIR / "recE_spikes.npz",
+            {ch: {"bior1p5": t} for ch, t in spike_times.items()},
+            channels, 25000.0, duration_s=600.0)
+        ephys = {
+            "FR": np.array([len(t) / 600.0 for t in spike_times.values()]),
+            "channelBurstRate": rng.random(n) * 5,
+            "channelBurstDur": rng.random(n) * 200,
+        }
+        with open(root / "2_NeuronalActivity" / "ephys_results.json", "w") as fh:
+            _json.dump(convert_numpy({"recE": ephys}), fh)
+
+        ctx2 = load_context(root)
+        figs = available_activity_figures(ctx2, "recE")
+        names = {f.name for f in figs}
+        checks.append(("activity figures appear once spikes + stats exist",
+                       len(figs) >= 5, f"{len(figs)}"))
+        checks.append(("the raster and burst detail are always offered",
+                       {"3_Raster", "8_BurstDetectionInfo"} <= names, f"{sorted(names)}"))
+        checks.append(("a heatmap with no metric is not offered",
+                       "6_ISIwithinBurst_heatmap" not in names, f"{sorted(names)}"))
+
+        act_out = tmp / "activity"
+        raster = render_activity_figure(ctx2, "recE", "3_Raster", act_out)
+        checks.append(("the raster renders",
+                       raster.exists() and raster.stat().st_size > 5000,
+                       f"{raster.stat().st_size if raster.exists() else 0}"))
+        heat = render_activity_figure(ctx2, "recE", "2_Heatmap", act_out)
+        checks.append(("a heatmap renders", heat.exists(), ""))
+        svg2 = render_activity_figure(ctx2, "recE", "3_Raster", act_out, fmt="svg")
+        checks.append(("activity figures render as svg",
+                       "<svg" in svg2.read_text()[:400], ""))
+        again = render_activity_figure(ctx2, "recE", "3_Raster", act_out / "b")
+        checks.append(("rendering twice is deterministic",
+                       _digest(raster) == _digest(again), ""))
+        try:
+            render_activity_figure(ctx2, "recE", "not_a_figure", act_out)
+            msg = ""
+        except ValueError as e:
+            msg = str(e)
+        checks.append(("an unknown activity figure is rejected",
+                       "not one of the activity figures" in msg, msg[:60]))
+    return checks
+
+
+def _manifest_honesty_checks() -> list[Check]:
+    """The manifest must not promise a figure the viewer cannot draw.
+
+    A bundle is read by someone who wasn't there when it was made. If its
+    manifest lists a family the renderer has no code for, they get a dead
+    button and no explanation — worse than the manifest saying nothing. So the
+    advertised set is asserted against what ``render`` actually implements.
+    """
+    from meanap.pipeline.bundle import (
+        RECONSTRUCTABLE_FAMILIES, UNRECONSTRUCTABLE_FAMILIES,
+    )
+    from meanap.pipeline.render import GROUP_FAMILIES
+
+    checks: list[Check] = []
+
+    # Every group family the renderer implements must be advertised, under the
+    # manifest's naming.
+    implemented = {f.key for f in GROUP_FAMILIES}
+    expected = {
+        "network": "4B_group_comparisons",
+        "activity": "2B_activity_comparisons",
+        "ephys_activity": "2B_activity_comparisons",
+        "cell_type": "cell_type_activity",
+        "subnetwork": "cell_type_subnetwork_groups",
+    }
+    checks.append(("every implemented family has a manifest name",
+                   implemented <= set(expected),
+                   f"{sorted(implemented - set(expected))}"))
+    advertised = set(RECONSTRUCTABLE_FAMILIES)
+    mapped = {expected[k] for k in implemented if k in expected}
+    checks.append(("every implemented family is advertised",
+                   mapped <= advertised, f"{sorted(mapped - advertised)}"))
+    per_recording = {"4A_individual_network", "2A_individual_activity"}
+    checks.append(("nothing is advertised that isn't implemented",
+                   advertised - mapped <= per_recording,
+                   f"{sorted(advertised - mapped - per_recording)}"))
+    checks.append(("the two lists are disjoint",
+                   not (advertised & set(UNRECONSTRUCTABLE_FAMILIES)),
+                   f"{sorted(advertised & set(UNRECONSTRUCTABLE_FAMILIES))}"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _run(Path(tmp), "Express", express=True)
+        with open_bundle(root.with_suffix(BUNDLE_SUFFIX)) as b:
+            checks.append(("the manifest records what it cannot rebuild",
+                           set(b.manifest["not_reconstructable"])
+                           == set(UNRECONSTRUCTABLE_FAMILIES), ""))
+            checks.append(("can_reconstruct agrees with the manifest",
+                           b.can_reconstruct("4B_group_comparisons")
+                           and b.can_reconstruct("2A_individual_activity")
+                           and not b.can_reconstruct("3_edge_threshold_checks"), ""))
+    return checks
+
+
+def _background_checks() -> list[Check]:
+    """Quantisation must be applied before plotting, or parity is unprovable."""
+    checks: list[Check] = []
+    rng = np.random.default_rng(3)
+    img = rng.random((1280, 1280))
+    q = quantize_background((img, (0.0, 8.0, 0.0, 8.0)))
+    checks.append(("large projections are decimated",
+                   max(q[0].shape) <= 1024, f"{q[0].shape}"))
+    checks.append(("quantising is idempotent (stable across a save/load)",
+                   np.array_equal(q[0], quantize_background(q)[0]), ""))
+    checks.append(("extent is preserved", q[1] == (0.0, 8.0, 0.0, 8.0), f"{q[1]}"))
+    small = quantize_background((np.ones((4, 4)), (0, 1, 0, 1)))
+    checks.append(("a flat image doesn't divide by zero",
+                   small is not None and np.isfinite(small[0]).all(), ""))
+    checks.append(("None passes through", quantize_background(None) is None, ""))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Express mode, .meanap bundles, and figure reconstruction")
+    print("=" * 70)
+
+    total_pass = total = 0
+    for title, build in [
+        ("Section A1 — bundle round-trip:", _bundle_checks),
+        ("Section A2 — hostile archives:", _zip_slip_checks),
+        ("Section B — reconstructing derived state:", _reconstruction_checks),
+        ("Section C — pixel parity with the pipeline:", _parity_checks),
+        ("Section D1 — vector output and restyling:", _vector_checks),
+        ("Section D2 — the Network Viewer control set:", _style_checks),
+        ("Section D3 — 2B / 4B batch comparisons:", _group_family_checks),
+        ("Section D3b — cell types without the spreadsheet:",
+         _cell_type_self_contained_checks),
+        ("Section D4 — thumbnail resolution and caching:", _gallery_cache_checks),
+        ("Section D5 — electrophysiology output:", _ephys_render_checks),
+        ("Section D6 — manifest honesty:", _manifest_honesty_checks),
+        ("Section D7 — mean-projection quantisation:", _background_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_catnap_group_plots.py
+++ b/python/test_catnap_group_plots.py
@@ -370,9 +370,8 @@ def _runner_tail_checks() -> list[Check]:
     models), so this exercises the wiring — the pieces that break when a
     signature or a folder name drifts — without recomputing any of it.
     """
-    from meanap.catnap.pipeline import (
-        _RecordingState, _plot_group_comparisons, _save_catnap_results,
-    )
+    from meanap.catnap.pipeline import _plot_group_comparisons, _save_catnap_results
+    from meanap.catnap.store import RecordingState
     from meanap.catnap.subnetwork import CellTypeGroups
     from meanap.params import Params
     from meanap.pipeline.output_folders import create_output_folders
@@ -393,7 +392,7 @@ def _runner_tail_checks() -> list[Check]:
     exc[: N_UNITS // 2] = True
     masks = np.column_stack([exc, ~exc])
     states = {
-        r.filename: _RecordingState(
+        r.filename: RecordingState(
             adjMs={}, coords=np.zeros((N_UNITS, 2)), channels=channels[r.filename],
             spike_counts=np.ones(N_UNITS), duration_s=600.0, plane0=Path("."),
             groups=CellTypeGroups(["Excitatory", "Inhibitory"], masks,

--- a/python/test_catnap_resume.py
+++ b/python/test_catnap_resume.py
@@ -1,0 +1,532 @@
+"""Test resuming a CAT-NAP run from a previous run's output ("start at step 4").
+
+Run from the repo root::
+
+    uv run python python/test_catnap_resume.py
+
+MATLAB's ``MEApipeline.m`` appends ``adjMs`` to each recording's
+``ExperimentMatFiles/<rec>_<folder>.mat`` at the end of step 2, and its
+``priorAnalysis == 1 && startAnalysisStep == 4`` branch loads that back instead
+of calling ``suite2pToAdjm`` again. This checks the port of that:
+
+  - **round-trip** — everything phases 2/3 need survives a save/load, including
+    the ``None``-valued 2P metrics that the non-``peaks`` activity types leave
+    unset (``None`` is not NaN downstream);
+  - **wiring** — a resumed run reads the prior file and never touches the
+    suite2p folder, and a fresh run writes one file per recording;
+  - **fail fast** — resuming with nothing to resume from raises instead of
+    quietly producing empty CSVs, which is how a mis-set path used to present;
+  - **lag selection** — the network-metric loop is driven by the adjacency
+    matrices that were actually built, not by ``Params.funcConLagval``, which
+    for the ``corr`` activity types is a different list entirely.
+
+All sections run on synthetic data — no MATLAB and no example dataset needed.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.catnap.store import (  # noqa: E402
+    RecordingState, load_recording_state, save_recording_state, sorted_adjm_items,
+)
+from meanap.params import Params  # noqa: E402
+from meanap.pipeline.resume import (  # noqa: E402
+    CATNAP_SUFFIX, build_input_locator, missing_step_inputs,
+)
+from meanap.pipeline.spreadsheet import RecordingInfo  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+N_UNITS = 8
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _state(lags=(25, 10)) -> RecordingState:
+    """A state with lags deliberately out of order, to pin down the sort."""
+    rng = np.random.default_rng(0)
+    adjMs = {f"adjM{lag}mslag": rng.random((N_UNITS, N_UNITS)) for lag in lags}
+    return RecordingState(
+        adjMs=adjMs,
+        coords=rng.random((N_UNITS, 2)) * 8.0,
+        channels=np.arange(1, N_UNITS + 1),
+        spike_counts=rng.integers(0, 50, N_UNITS).astype(float),
+        duration_s=612.5,
+        plane0=Path("/nonexistent/suite2p/plane0"),
+        coord_norm=(3.0, 511.0),
+    )
+
+
+def _stats() -> dict:
+    """Stats shaped like the non-``peaks`` path: scalars, arrays, ints, Nones."""
+    return {
+        "FR": np.linspace(0.1, 2.0, N_UNITS),
+        "FRactive": np.full(N_UNITS, np.nan),
+        "FRmean": 1.05,
+        "FRstd": 0.5,
+        "numActiveElec": 6,
+        "ISImean": float("nan"),
+        "ISI": np.full(N_UNITS, np.nan),
+        # The 2P-specific metrics are None (not NaN) for F/spks/denoised F.
+        "unitHeightMean": None,
+        "unitPeakDurMean": None,
+        "unitEventAreaMean": None,
+        "unitEventAreaSum": None,
+        "recHeightMean": float("nan"),
+    }
+
+
+def _recordings(n: int = 2) -> list[RecordingInfo]:
+    return [RecordingInfo(filename=f"rec{i}", div=21.0, group="WT") for i in range(n)]
+
+
+# ── Section A: store round-trip ───────────────────────────────────────────────
+
+
+def _roundtrip_checks() -> list[Check]:
+    checks: list[Check] = []
+    state, stats = _state(), _stats()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / f"rec0{CATNAP_SUFFIX}"
+        save_recording_state(path, state, stats)
+        checks.append(("save writes the .npz", path.exists(), ""))
+
+        plane0 = Path("/some/other/place/plane0")
+        got, got_stats = load_recording_state(path, plane0)
+
+    checks.append(("adjacency keys preserved",
+                   set(got.adjMs) == set(state.adjMs),
+                   f"{sorted(got.adjMs)}"))
+    checks.append(("adjacency values exact",
+                   all(np.array_equal(got.adjMs[k], state.adjMs[k]) for k in state.adjMs),
+                   ""))
+    checks.append(("coords exact", np.array_equal(got.coords, state.coords), ""))
+    checks.append(("channels exact", np.array_equal(got.channels, state.channels), ""))
+    checks.append(("spike_counts exact",
+                   np.array_equal(got.spike_counts, state.spike_counts), ""))
+    checks.append(("duration_s exact", got.duration_s == state.duration_s,
+                   f"{got.duration_s}"))
+    checks.append(("coord_norm exact", got.coord_norm == state.coord_norm,
+                   f"{got.coord_norm}"))
+    checks.append(("plane0 comes from the caller, not the file",
+                   got.plane0 == Path("/some/other/place/plane0"), f"{got.plane0}"))
+    checks.append(("groups/markers left for the caller to re-read",
+                   got.groups is None and got.markers is None, ""))
+
+    checks.append(("stat keys preserved", set(got_stats) == set(stats),
+                   f"{sorted(set(stats) ^ set(got_stats))}"))
+    checks.append(("stat arrays exact",
+                   np.array_equal(got_stats["FR"], stats["FR"]), ""))
+    checks.append(("NaN-filled stat arrays survive as NaN",
+                   np.isnan(got_stats["FRactive"]).all(), ""))
+    checks.append(("scalar floats stay scalar floats",
+                   isinstance(got_stats["FRmean"], float)
+                   and got_stats["FRmean"] == 1.05, f"{got_stats['FRmean']!r}"))
+    checks.append(("ints stay ints (numActiveElec)",
+                   isinstance(got_stats["numActiveElec"], int)
+                   and got_stats["numActiveElec"] == 6,
+                   f"{got_stats['numActiveElec']!r}"))
+    checks.append(("None stats restore as None, not NaN",
+                   all(got_stats[k] is None for k in
+                       ("unitHeightMean", "unitPeakDurMean",
+                        "unitEventAreaMean", "unitEventAreaSum")), ""))
+    checks.append(("NaN scalars stay NaN (not confused with None)",
+                   got_stats["recHeightMean"] is not None
+                   and np.isnan(got_stats["recHeightMean"]), ""))
+
+    # Version handling is asymmetric on purpose. A file from the *future* is
+    # refused — its keys may mean something else. An *older* file is read, its
+    # newer fields simply absent: every bump so far only added optional keys,
+    # and a bundle's recipient has no raw data, so "re-run from step 1" would
+    # be advice they cannot take.
+    def _restamp(path: Path, version: int) -> None:
+        with np.load(path) as data:
+            arrays = {k: data[k] for k in data.files}
+        arrays["catnap_format"] = np.array(version)
+        np.savez(path, **arrays)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        newer = Path(tmp) / f"rec0{CATNAP_SUFFIX}"
+        save_recording_state(newer, state, stats)
+        _restamp(newer, 99)
+        try:
+            load_recording_state(newer, Path("."))
+            msg = ""
+        except ValueError as e:
+            msg = str(e)
+        checks.append(("a newer format is refused", bool(msg), ""))
+        checks.append(("…with an upgrade hint, not 'rerun from step 1'",
+                       "Update MEA-NAP" in msg, msg[:70]))
+
+        older = Path(tmp) / f"rec1{CATNAP_SUFFIX}"
+        save_recording_state(older, state, stats)
+        _restamp(older, 1)
+        try:
+            back, _ = load_recording_state(older, Path("."))
+            ok = np.array_equal(back.coords, state.coords)
+        except Exception as e:
+            ok, back = False, e
+        checks.append(("an older format still loads", ok, f"{back}"))
+
+        unmarked = Path(tmp) / f"rec2{CATNAP_SUFFIX}"
+        save_recording_state(unmarked, state, stats)
+        _restamp(unmarked, 0)
+        try:
+            load_recording_state(unmarked, Path("."))
+            msg2 = ""
+        except ValueError as e:
+            msg2 = str(e)
+        checks.append(("a file with no format marker is rejected",
+                       "format marker" in msg2, msg2[:60]))
+
+    return checks
+
+
+def _lag_order_checks() -> list[Check]:
+    """The metric loop must follow the adjacency that was built.
+
+    ``suite2p_to_adjm`` derives a *single* lag ``round(1000 / fs)`` for the
+    ``F``/``spks``/``denoised F`` paths and ignores ``funcConLagval`` entirely
+    (``suite2pToAdjm.m`` even overwrites ``Params.FuncConLagval`` with it), so
+    driving the loop from Params produced no metrics at all for those types.
+    """
+    checks: list[Check] = []
+    state = _state(lags=(25, 10))
+
+    pairs = sorted_adjm_items(state.adjMs)
+    checks.append(("lags come back ascending, not in dict order",
+                   [lag for lag, _ in pairs] == [10, 25],
+                   f"{[lag for lag, _ in pairs]}"))
+    checks.append(("each lag carries its own matrix",
+                   all(np.array_equal(m, state.adjMs[f"adjM{lag}mslag"])
+                       for lag, m in pairs), ""))
+
+    # The corr-path case: a derived lag that appears in no Params list.
+    derived = RecordingState(
+        adjMs={"adjM33mslag": np.zeros((2, 2))}, coords=np.zeros((2, 2)),
+        channels=np.array([1, 2]), spike_counts=np.zeros(2), duration_s=1.0,
+        plane0=Path("."),
+    )
+    params_lags = [10, 25, 50]
+    checks.append(("a derived lag absent from funcConLagval is still analysed",
+                   [lag for lag, _ in sorted_adjm_items(derived.adjMs)] == [33]
+                   and 33 not in params_lags, ""))
+    return checks
+
+
+# ── Section B: locator + fail-fast wiring ─────────────────────────────────────
+
+
+def _locator_checks() -> list[Check]:
+    checks: list[Check] = []
+    recordings = _recordings(2)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        prior = Path(tmp) / "OutputData01Jan2026"
+        (prior / "ExperimentMatFiles").mkdir(parents=True)
+        (prior / "1_SpikeDetection" / "1A_SpikeDetectedData").mkdir(parents=True)
+        out = Path(tmp) / "OutputData02Jan2026"
+        (out / "ExperimentMatFiles").mkdir(parents=True)
+
+        params = Params(suite2p_mode=True, prior_analysis=True,
+                        prior_analysis_path=str(prior), start_analysis_step=4)
+        locator = build_input_locator(params, out)
+
+        checks.append(("nothing saved yet → catnap_file is None",
+                       locator.catnap_file("rec0") is None, ""))
+        missing = missing_step_inputs(locator, recordings, 4, suite2p_mode=True)
+        checks.append(("all recordings reported missing",
+                       set(missing) == {"rec0", "rec1"}, f"{sorted(missing)}"))
+        checks.append(("the gap names CAT-NAP step 2, not step 3",
+                       "step 2" in missing["rec0"][0], f"{missing['rec0']}"))
+
+        # An ephys _adjM.npz must NOT satisfy a CAT-NAP resume.
+        np.savez(prior / "ExperimentMatFiles" / "rec0_adjM.npz", channels=np.arange(4))
+        checks.append(("an ephys _adjM.npz does not satisfy CAT-NAP",
+                       locator.catnap_file("rec0") is None, ""))
+        checks.append(("…and the ephys locator still finds it",
+                       locator.adjm_file("rec0") is not None, ""))
+
+        # Now save a real CAT-NAP file for one of the two recordings.
+        save_recording_state(
+            prior / "ExperimentMatFiles" / f"rec0{CATNAP_SUFFIX}", _state(), _stats())
+        checks.append(("prior CAT-NAP file is found",
+                       locator.catnap_file("rec0") is not None, ""))
+        missing = missing_step_inputs(locator, recordings, 4, suite2p_mode=True)
+        checks.append(("only the unsaved recording is missing",
+                       set(missing) == {"rec1"}, f"{sorted(missing)}"))
+
+        # This run's own output wins over the prior run's copy.
+        save_recording_state(
+            out / "ExperimentMatFiles" / f"rec0{CATNAP_SUFFIX}", _state(), _stats())
+        checks.append(("this run's output shadows the prior run",
+                       locator.catnap_file("rec0").parent.parent == out,
+                       f"{locator.catnap_file('rec0')}"))
+
+        # start_step < 4 never asks for the file.
+        checks.append(("start step 1 reports nothing missing",
+                       missing_step_inputs(locator, recordings, 1, suite2p_mode=True) == {},
+                       ""))
+    return checks
+
+
+def _fail_fast_checks() -> list[Check]:
+    """A step-4 resume with nothing to resume from must raise, not run empty."""
+    from meanap.pipeline.runner import _check_catnap_resume_inputs
+
+    checks: list[Check] = []
+    recordings = _recordings(2)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "OutputData02Jan2026"
+        (out / "ExperimentMatFiles").mkdir(parents=True)
+        params = Params(suite2p_mode=True, start_analysis_step=4)
+        locator = build_input_locator(params, out)
+
+        try:
+            _check_catnap_resume_inputs(locator, recordings, params, lambda m: None)
+            err = ""
+        except ValueError as e:
+            err = str(e)
+        checks.append(("no inputs at all → ValueError", bool(err), ""))
+        checks.append(("the message says how to fix it",
+                       "prior analysis" in err.lower() and "start at step 1" in err,
+                       err[:80]))
+
+        # One of two present → warn and continue, not raise.
+        save_recording_state(
+            out / "ExperimentMatFiles" / f"rec0{CATNAP_SUFFIX}", _state(), _stats())
+        logs: list[str] = []
+        try:
+            _check_catnap_resume_inputs(locator, recordings, params, logs.append)
+            raised = False
+        except ValueError:
+            raised = True
+        checks.append(("partial inputs warn rather than raise", not raised, ""))
+        checks.append(("the skipped recording is named",
+                       any("rec1" in line for line in logs), f"{logs}"))
+    return checks
+
+
+# ── Section C: pipeline reads the prior run instead of suite2p ────────────────
+
+
+def _pipeline_resume_checks() -> list[Check]:
+    """Drive ``run_catnap_pipeline`` itself with no suite2p folder on disk.
+
+    That is the point of the check: if the resume path touched the raw data at
+    all, this would skip every recording. The recordings' plane0 paths do not
+    exist, so a run that produces metrics can only have got them from the
+    prior ``.npz``.
+    """
+    from meanap.catnap import pipeline as cat
+    from meanap.pipeline.output_folders import create_output_folders
+
+    checks: list[Check] = []
+    recordings = _recordings(1)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        prior = create_output_folders(tmp, "OutputPrior", ["WT"])
+        # A small, dense, symmetric adjacency so the network metrics are
+        # well-defined without needing a real recording behind them.
+        rng = np.random.default_rng(1)
+        adj = rng.random((N_UNITS, N_UNITS))
+        adj = (adj + adj.T) / 2
+        np.fill_diagonal(adj, 0)
+        state = _state(lags=(25,))
+        state.adjMs = {"adjM25mslag": adj}
+        state.spike_counts = np.full(N_UNITS, 100.0)
+        save_recording_state(
+            prior / "ExperimentMatFiles" / f"rec0{CATNAP_SUFFIX}", state, _stats())
+
+        out = create_output_folders(tmp, "OutputResumed", ["WT"])
+        params = Params(
+            suite2p_mode=True, prior_analysis=True, prior_analysis_path=str(prior),
+            start_analysis_step=4, raw_data=str(Path(tmp) / "no-raw-data-here"),
+            func_con_lag_val=[25], min_activity_level=0.0,
+            min_number_of_nodes_to_cal_net_met=2, twop_subnetwork_analysis=False,
+            num_2p_traces=0, twop_network_background=False,
+            auto_set_cartography_boundaries=False, random_seed=7,
+        )
+        logs: list[str] = []
+        cat.run_catnap_pipeline(params, recordings, out, logs.append)
+
+        text = "\n".join(logs)
+        checks.append(("resumed run logs that it reused the prior adjacency",
+                       "reusing adjacency matrices" in text, text[:200]))
+        checks.append(("no suite2p folder was read",
+                       "loading suite2p data" not in text
+                       and "building adjacency matrices" not in text, ""))
+        checks.append(("network metrics still ran",
+                       "network metrics (lag=25ms)" in text, ""))
+
+        rec_csv = out / "4_NetworkActivity" / "NetworkActivity_RecordingLevel.csv"
+        checks.append(("recording-level CSV written", rec_csv.exists(), ""))
+        if rec_csv.exists():
+            import pandas as pd
+            df = pd.read_csv(rec_csv)
+            checks.append(("CSV holds the resumed recording",
+                           len(df) == 1 and df["FileName"][0] == "rec0",
+                           f"{len(df)} rows"))
+
+        twop_csv = (out / "2_NeuronalActivity"
+                    / "TwoPhotonActivity_RecordingLevel.csv")
+        checks.append(("activity stats came back too (step-2 CSV written)",
+                       twop_csv.exists(), ""))
+
+        # The resumed run re-seeds its own folder, so it is itself resumable.
+        reseeded = out / "ExperimentMatFiles" / f"rec0{CATNAP_SUFFIX}"
+        checks.append(("resumed run rewrites the state into its own folder",
+                       reseeded.exists(), ""))
+        if reseeded.exists():
+            again, _ = load_recording_state(reseeded, Path("."))
+            checks.append(("re-seeded adjacency is unchanged",
+                           np.allclose(again.adjMs["adjM25mslag"], adj), ""))
+
+    return checks
+
+
+def _determinism_checks() -> list[Check]:
+    """A seeded resume must reproduce the numbers of the run it resumed from.
+
+    CAT-NAP used to draw every stochastic stage from one batch-wide generator,
+    so a recording's metrics depended on how much randomness the recordings
+    (and lags) before it had consumed. A resumed run skips the thresholding
+    draws entirely, which would have shifted every metric — the resume would
+    "work" while quietly changing the answers. Per-recording streams derived
+    from ``random_seed`` (as ``step3``/``step4`` already do) remove that
+    coupling, which is what this pins down.
+
+    Two recordings with *different* adjacency, so a stream shared across the
+    batch would show up as the second recording's metrics moving when the
+    first's inputs are reordered.
+    """
+    from meanap.catnap import pipeline as cat
+    from meanap.pipeline.output_folders import create_output_folders
+
+    import pandas as pd
+
+    checks: list[Check] = []
+    recordings = _recordings(2)
+
+    def _adj(seed: int) -> np.ndarray:
+        rng = np.random.default_rng(seed)
+        a = rng.random((N_UNITS, N_UNITS))
+        a = (a + a.T) / 2
+        np.fill_diagonal(a, 0)
+        return a
+
+    def _run(tmp: Path, name: str, order: list[RecordingInfo]) -> "pd.DataFrame":
+        prior = create_output_folders(tmp, f"{name}Prior", ["WT"])
+        for rec in order:
+            st = _state(lags=(25,))
+            # Keyed by name, not batch position, so reversing the order changes
+            # only the order — each recording keeps its own adjacency.
+            st.adjMs = {"adjM25mslag": _adj(10 + int(rec.filename[-1]))}
+            st.spike_counts = np.full(N_UNITS, 100.0)
+            save_recording_state(
+                prior / "ExperimentMatFiles" / f"{rec.filename}{CATNAP_SUFFIX}",
+                st, _stats())
+        out = create_output_folders(tmp, name, ["WT"])
+        params = Params(
+            suite2p_mode=True, prior_analysis=True, prior_analysis_path=str(prior),
+            start_analysis_step=4, raw_data=str(tmp / "no-raw"),
+            func_con_lag_val=[25], min_activity_level=0.0,
+            min_number_of_nodes_to_cal_net_met=2, twop_subnetwork_analysis=False,
+            num_2p_traces=0, twop_network_background=False,
+            auto_set_cartography_boundaries=False, random_seed=7,
+        )
+        cat.run_catnap_pipeline(params, order, out, lambda m: None)
+        return pd.read_csv(out / "4_NetworkActivity" / "NetworkActivity_NodeLevel.csv")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        first = _run(tmp, "RunA", recordings)
+        second = _run(tmp, "RunB", recordings)
+        reversed_ = _run(tmp, "RunC", list(reversed(recordings)))
+
+    num = [c for c in first.columns if first[c].dtype.kind == "f"]
+    checks.append(("two seeded resumes agree exactly",
+                   first[num].equals(second[num]), ""))
+
+    # Same recording, same seed, different position in the batch.
+    key = ["FileName", "Channel"]
+    a = first.sort_values(key).reset_index(drop=True)
+    c = reversed_.sort_values(key).reset_index(drop=True)
+    checks.append(("recording order does not change the metrics",
+                   np.allclose(a[num].to_numpy(), c[num].to_numpy(), equal_nan=True),
+                   "batch-wide RNG stream leaking between recordings"))
+    return checks
+
+
+def _missing_prior_checks() -> list[Check]:
+    """A recording with no saved state is skipped, and says so."""
+    from meanap.catnap import pipeline as cat
+    from meanap.pipeline.output_folders import create_output_folders
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        out = create_output_folders(tmp, "OutputResumed", ["WT"])
+        params = Params(suite2p_mode=True, start_analysis_step=4,
+                        raw_data=str(Path(tmp) / "nope"), func_con_lag_val=[25],
+                        auto_set_cartography_boundaries=False,
+                        twop_subnetwork_analysis=False, num_2p_traces=0)
+        logs: list[str] = []
+        cat.run_catnap_pipeline(params, _recordings(1), out, logs.append)
+        text = "\n".join(logs)
+        checks.append(("missing prior state → SKIP, not a crash",
+                       "SKIP: no saved step-2 data" in text, text[:200]))
+        checks.append(("run still completes",
+                       "CAT-NAP pipeline complete." in text, ""))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("CAT-NAP resume from a previous run (start at step 4)")
+    print("=" * 70)
+
+    total_pass = total = 0
+    for title, build in [
+        ("Section A1 — step-2 state round-trip:", _roundtrip_checks),
+        ("Section A2 — lag selection follows the adjacency built:", _lag_order_checks),
+        ("Section B1 — locator finds the right file:", _locator_checks),
+        ("Section B2 — fail fast with nothing to resume from:", _fail_fast_checks),
+        ("Section C1 — pipeline resumes without the raw data:", _pipeline_resume_checks),
+        ("Section C2 — a resume reproduces the original numbers:", _determinism_checks),
+        ("Section C3 — a recording with no saved state:", _missing_prior_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_viewer_server.py
+++ b/python/test_viewer_server.py
@@ -1,0 +1,220 @@
+"""Test the local web viewer: real HTTP requests against a real bundle.
+
+Run from the repo root::
+
+    uv run python python/test_viewer_server.py
+
+Driven over a socket rather than by calling handlers directly, because the
+things most likely to break are at that boundary — query-string coercion, the
+content types a browser needs to display an SVG inline, the download headers,
+and the path guard on cached assets.
+
+The behaviour worth protecting above all: **an unstyled request must return the
+figure the pipeline drew.** The viewer is only trustworthy if its default view
+is the real one, so that is checked byte-for-byte against a full pipeline run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "python"))
+
+from test_bundle_render import (  # noqa: E402
+    BUNDLE_SUFFIX, LAG, _digest, _run,
+)
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+def _get(url: str) -> tuple[int, bytes, dict]:
+    """GET, returning ``(status, body, headers)`` without raising on 4xx/5xx."""
+    try:
+        with urllib.request.urlopen(url, timeout=120) as r:
+            return r.status, r.read(), dict(r.headers)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), dict(e.headers)
+
+
+def _all_checks() -> list[Check]:
+    from meanap.viewer.server import serve
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "Full", express=False)
+        express = _run(tmp, "Express", express=True)
+        bundle = express.with_suffix(BUNDLE_SUFFIX)
+
+        httpd, service = serve(bundle, port=0, background=True)
+        base = f"http://127.0.0.1:{httpd.server_address[1]}"
+        try:
+            # ── the page ────────────────────────────────────────────────────
+            status, body, headers = _get(base + "/")
+            checks.append(("page is served", status == 200, str(status)))
+            checks.append(("page is html",
+                           headers.get("Content-Type", "").startswith("text/html"), ""))
+            checks.append(("page has the control panel and gallery containers",
+                           b'id="controls-panel"' in body and b'id="gallery"' in body, ""))
+
+            # ── manifest ────────────────────────────────────────────────────
+            status, body, _ = _get(base + "/api/manifest")
+            man = json.loads(body)
+            checks.append(("manifest is served", status == 200, str(status)))
+            checks.append(("manifest lists both recordings",
+                           {r["name"] for r in man["recordings"]} == {"recA", "recB"},
+                           f"{[r['name'] for r in man['recordings']]}"))
+            rec = man["recordings"][0]
+            checks.append(("manifest lists lags and figures",
+                           rec["lags"] == [LAG] and len(rec["figures"][str(LAG)]) >= 5,
+                           f"{rec['lags']}"))
+            checks.append(("manifest advertises comparison families",
+                           len(man["families"]) >= 2, f"{man['families']}"))
+            checks.append(("manifest carries the control schema",
+                           len(man["controls"]) == 11,
+                           f"{len(man['controls'])}"))
+            checks.append(("controls declare kind, default and options",
+                           all({"key", "kind", "default", "options"} <= set(c)
+                               for c in man["controls"]), ""))
+
+            fig = "2_MEA_NetworkPlot"
+
+            # ── the load-bearing one: default view == the pipeline's figure ──
+            status, body, headers = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}")
+            checks.append(("figure is served", status == 200, str(status)))
+            checks.append(("figure is a png",
+                           headers.get("Content-Type") == "image/png",
+                           headers.get("Content-Type", "")))
+            served = tmp / "served.png"
+            served.write_bytes(body)
+            original = (full / "4_NetworkActivity" / "4A_IndividualNetworkAnalysis"
+                        / "WT" / "recA" / f"{LAG}mslag" / f"{fig}.png")
+            checks.append(("unstyled request is pixel-identical to the pipeline's",
+                           _digest(original) == _digest(served), ""))
+
+            # ── styling ─────────────────────────────────────────────────────
+            _, styled, _ = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&colormap=magma")
+            checks.append(("a styling parameter changes the image",
+                           styled != body, ""))
+            _, same, _ = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&colormap=viridis")
+            checks.append(("passing a default is a no-op (still the pipeline's)",
+                           same == body, ""))
+            _, layout, _ = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}"
+                "&layout=Circular&max_edges=4&node_size_scale=2")
+            checks.append(("several controls compose", layout not in (body, styled), ""))
+
+            # ── vector formats and downloads ────────────────────────────────
+            status, svg, headers = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&fmt=svg")
+            checks.append(("svg is served as svg",
+                           status == 200 and "svg" in headers.get("Content-Type", ""),
+                           headers.get("Content-Type", "")))
+            checks.append(("svg body is vector markup", b"<svg" in svg[:400], ""))
+            status, pdf, headers = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&fmt=pdf")
+            checks.append(("pdf is served", status == 200 and pdf[:4] == b"%PDF", ""))
+            _, _, headers = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&fmt=svg&download=1")
+            checks.append(("download sets an attachment filename",
+                           "attachment" in headers.get("Content-Disposition", ""),
+                           headers.get("Content-Disposition", "")))
+
+            # ── families ────────────────────────────────────────────────────
+            status, body, _ = _get(base + "/api/family?key=network")
+            fam = json.loads(body)
+            checks.append(("family renders", status == 200 and fam["count"] > 50,
+                           f"{fam.get('count')}"))
+            checks.append(("first family view is not cached", fam["cached"] is False, ""))
+            checks.append(("family items carry asset refs, not file paths",
+                           all("asset" in i and not i["asset"].startswith("/")
+                               for i in fam["items"]), ""))
+            _, body2, _ = _get(base + "/api/family?key=network")
+            checks.append(("second family view is cached",
+                           json.loads(body2)["cached"] is True, ""))
+
+            asset = fam["items"][0]["asset"]
+            status, img, headers = _get(
+                base + "/api/asset?path=" + urllib.parse.quote(asset))
+            checks.append(("a family asset is served",
+                           status == 200 and headers.get("Content-Type") == "image/png",
+                           str(status)))
+
+            # ── step-2 activity figures ─────────────────────────────────────
+            # This fixture is a CAT-NAP bundle, which has no step-2 ephys data,
+            # so the correct answer is an empty list — not a broken endpoint.
+            # The ephys path is covered in test_bundle_render.py, against a
+            # bundle that actually has spike times.
+            act = man["recordings"][0].get("activity", [])
+            checks.append(("a CAT-NAP bundle offers no ephys activity figures",
+                           act == [], f"{act}"))
+            status, body, _ = _get(base + "/api/activity?rec=recA&name=3_Raster")
+            checks.append(("asking for one anyway is a 400 with a reason",
+                           status == 400
+                           and "step-2 activity data" in json.loads(body)["error"],
+                           str(status)))
+
+            # ── errors are actionable, not stack traces ─────────────────────
+            status, body, _ = _get(base + "/api/asset?path=../../../etc/passwd")
+            checks.append(("path traversal on assets is refused",
+                           status == 404, str(status)))
+            status, body, _ = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&fmt=exe")
+            checks.append(("an unsupported format is rejected with 400",
+                           status == 400 and "unsupported format"
+                           in json.loads(body)["error"], str(status)))
+            status, body, _ = _get(
+                f"{base}/api/figure?rec=recA&lag={LAG}&name={fig}&layout=Nonsense")
+            checks.append(("an invalid control value is rejected with 400",
+                           status == 400 and "layout" in json.loads(body)["error"],
+                           str(status)))
+            status, body, _ = _get(f"{base}/api/figure?rec=recA&lag={LAG}")
+            checks.append(("a missing parameter is reported by name",
+                           status == 400 and "name" in json.loads(body)["error"],
+                           str(status)))
+            status, body, _ = _get(base + "/api/figure?rec=ghost&lag=25&name=" + fig)
+            checks.append(("an unknown recording is a 400, not a 500",
+                           status == 400, str(status)))
+            status, _, _ = _get(base + "/api/nope")
+            checks.append(("unknown routes 404", status == 404, str(status)))
+        finally:
+            httpd.shutdown()
+            service.close()
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("MEA-NAP web viewer")
+    print("=" * 70)
+    total_pass, total = _report("Serving a bundle over HTTP:", _all_checks())
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meanap/catnap/group_plots.py
+++ b/src/meanap/catnap/group_plots.py
@@ -95,6 +95,15 @@ SUBNET_NODE_METRICS = {
 
 # ── Two-photon activity ───────────────────────────────────────────────────────
 
+def _named(template: str, fmt: str) -> str:
+    """Retarget a ``…png`` filename template at another image format.
+
+    The templates below are the canonical figure names; only the container
+    changes when a viewer asks for vector output.
+    """
+    return f"{template[:-4]}.{fmt}" if template.endswith(".png") else template
+
+
 def twop_stats_frames(
     recordings: list,
     all_stats: dict[str, dict],
@@ -157,6 +166,7 @@ def plot_twop_group_comparisons(
     out_dir: Path,
     custom_grp_order: list[str] | None = None,
     channels_by_rec: dict[str, np.ndarray] | None = None,
+    fmt: str = "png",
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Draw the ``2B_GroupComparisons`` figures for two-photon activity.
 
@@ -188,7 +198,8 @@ def plot_twop_group_comparisons(
             if key not in df.columns:
                 continue
             plot_half_violin_by_x(
-                df, key, label, x_kind, directory / pattern.format(key=key),
+                df, key, label, x_kind,
+                directory / _named(pattern, fmt).format(key=key),
                 group_order=custom_grp_order,
             )
 
@@ -312,6 +323,7 @@ def plot_activity_by_cell_type(
     composition: pd.DataFrame,
     out_dir: Path,
     custom_grp_order: list[str] | None = None,
+    fmt: str = "png",
     cell_type_order: list[str] | None = None,
 ) -> None:
     """Two-photon activity and cell-type composition, split by cell type.
@@ -346,7 +358,8 @@ def plot_activity_by_cell_type(
             if key not in df.columns:
                 continue
             plot_half_violin_by_x(
-                df, key, label, x_kind, directory / pattern.format(key=key),
+                df, key, label, x_kind,
+                directory / _named(pattern, fmt).format(key=key),
                 group_order=custom_grp_order,
                 series_col="CellType", series_order=order,
             )
@@ -370,6 +383,7 @@ def plot_subnetwork_group_comparisons(
     node_rows: list[dict],
     out_dir: Path,
     custom_grp_order: list[str] | None = None,
+    fmt: str = "png",
 ) -> None:
     """Compare cell-type subnetworks across experimental groups and ages.
 
@@ -422,6 +436,6 @@ def plot_subnetwork_group_comparisons(
                             continue
                         plot_half_violin_by_x(
                             df_ct, key, f"{label} — {cell_type}", x_kind,
-                            directory / pattern.format(key=key, ct=safe),
+                            directory / _named(pattern, fmt).format(key=key, ct=safe),
                             group_order=custom_grp_order,
                         )

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -17,7 +17,6 @@ folders the ephys path produces.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
@@ -32,7 +31,15 @@ from meanap.catnap.group_plots import (
 from meanap.catnap.loader import load_suite2p
 from meanap.catnap.subnetwork import WHOLE_NETWORK
 from meanap.catnap.stats import calc_twop_activity_stats
+from meanap.catnap.store import (
+    BACKGROUND_SUFFIX, RecordingState, load_recording_state, quantize_background,
+    save_background, save_recording_state, sorted_adjm_items,
+)
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
+from meanap.pipeline.resume import (
+    ADJM_SUBDIR, CATNAP_SUFFIX, InputLocator, build_input_locator,
+)
+from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo
 from meanap.pipeline.step4 import (
     _apply_cartography_boundaries, _batch_metric_bounds, _convert_numpy,
@@ -41,35 +48,11 @@ from meanap.pipeline.step4 import (
 
 _NEEDS_DENOISING = ("peaks", "denoised F", "spks")
 
-
-@dataclass
-class _RecordingState:
-    """What phase 3 needs about a recording, without its activity matrices.
-
-    ``suite2p_to_adjm`` returns the full ``(n_frames, n_units)`` fluorescence,
-    denoised-fluorescence and spks matrices — hundreds of MB per recording, so
-    holding them for a whole batch across the cartography barrier is not an
-    option. Everything here is small (adjacency matrices are ``n_units²``); the
-    trace figures re-read the suite2p folder at ``plane0`` instead.
-    """
-
-    adjMs: dict[str, np.ndarray]
-    coords: np.ndarray
-    channels: np.ndarray
-    spike_counts: np.ndarray
-    duration_s: float
-    plane0: Path
-    #: User-defined cell-type groups (E/I, per-marker, …) — drives the
-    #: subnetwork analysis and the by-cell-type activity comparisons.
-    groups: object | None = None
-    #: ``(n_channels, n_markers)`` raw marker membership + names, straight from
-    #: the spreadsheet. Distinct from ``groups``: this is the cell's full
-    #: genetic identity, drawn as concentric rings on the network plots, and it
-    #: is not collapsed into whatever grouping the user chose.
-    markers: tuple[np.ndarray, list[str]] | None = None
-    #: ``(min, max)`` used to normalise the pixel centroids onto ``coords`` —
-    #: needed to map the mean projection image into the same frame.
-    coord_norm: tuple[float, float] = (0.0, 1.0)
+#: ``Params.startAnalysisStep`` at or above which a CAT-NAP run reads the prior
+#: run's adjacency instead of rebuilding it. There is no step 1 or 3 on this
+#: path (adjacency is built in step 2, as in MATLAB), so 4 is the only boundary
+#: that means anything.
+RESUME_STEP = 4
 
 
 def suite2p_plane0_dir(raw_data: str, filename: str) -> Path:
@@ -117,7 +100,7 @@ def run_catnap_pipeline(
     output_root: Path,
     log: Callable[[str], None] = print,
     should_cancel: CancelCheck = None,
-    rng: np.random.Generator | None = None,
+    locator: InputLocator | None = None,
 ) -> None:
     """Run the CAT-NAP path over all recordings, writing NetMet JSON + CSVs.
 
@@ -132,81 +115,96 @@ def run_catnap_pipeline(
 
     The barrier matters: cartography roles are re-derived in phase 2, so every
     figure and CSV that shows a role has to be produced after it. Phase 1 keeps
-    only a small per-recording state (:class:`_RecordingState`) — the raw
-    fluorescence matrices are hundreds of MB per recording and are re-read from
-    disk in phase 3 for the trace figures.
+    only a small per-recording state (:class:`~meanap.catnap.store.RecordingState`)
+    — the raw fluorescence matrices are hundreds of MB per recording and are
+    re-read from disk in phase 3 for the trace figures.
+
+    **Resuming.** Phase 1 writes each recording's adjacency + activity stats to
+    ``ExperimentMatFiles/<rec>_catnap.npz`` (:mod:`meanap.catnap.store`). When
+    ``params.start_analysis_step >= 4`` it reads that back from ``locator``
+    instead of recomputing, skipping the expensive part — denoising, STTC and
+    the circular-shift thresholding — exactly as MATLAB's
+    ``priorAnalysis``/``startAnalysisStep = 4`` branch does. The file is
+    rewritten into *this* run's output folder either way, so a resumed run is
+    itself resumable. Network metrics, cartography and every figure are always
+    recomputed: that is what step 4 *is*.
+
+    Note the batch reduce in phase 2 pools PC/Z over every recording that
+    phase 1 produced, so resuming a subset of the batch places the cartography
+    boundaries from that subset alone — the roles will not match the original
+    run's unless the same recordings are present.
+
+    Stochastic stages draw from per-recording generators derived from
+    ``params.random_seed`` (see :mod:`meanap.pipeline.rng`), the same scheme the
+    ephys steps use. A single batch-wide stream would make every recording's
+    metrics depend on how much randomness the recordings before it consumed —
+    which a resumed run, having skipped the thresholding draws entirely, would
+    change. With per-recording streams a seeded resume reproduces the numbers
+    of the run it resumed from.
     """
-    from meanap.catnap.denoising import process_suite2p_folder
+    if locator is None:
+        locator = build_input_locator(params, output_root)
 
-    if rng is None:
-        rng = np.random.default_rng()
-
-    lag_values = params.func_con_lag_val
     min_nodes = params.min_number_of_nodes_to_cal_net_met
     net_dir = output_root / "4_NetworkActivity"
     net_dir.mkdir(parents=True, exist_ok=True)
+    state_dir = output_root / ADJM_SUBDIR
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    resuming = params.start_analysis_step >= RESUME_STEP
 
     all_results: dict[str, dict] = {}
     all_stats: dict[str, dict] = {}
     all_channels: dict[str, np.ndarray] = {}
-    states: dict[str, _RecordingState] = {}
+    states: dict[str, RecordingState] = {}
     subnetwork_tables: dict[str, list] = {"summary": [], "node": [], "mix": []}
 
-    # ── Phase 1: compute ──────────────────────────────────────────────────────
+    # ── Phase 1: compute (or reload) ──────────────────────────────────────────
     for rec in recordings:
         check_cancel(should_cancel)
         plane0 = suite2p_plane0_dir(params.raw_data, rec.filename)
-        if not (plane0 / "stat.npy").exists():
-            log(f"  [{rec.filename}] SKIP: no suite2p output at {plane0}")
+
+        loaded = (
+            _load_recording(locator, rec, plane0, log) if resuming else
+            _compute_recording(params, rec, plane0, log,
+                               make_rng(params.random_seed, "catnap", rec.filename))
+        )
+        if loaded is None:
             continue
+        state, stats = loaded
 
-        log(f"  [{rec.filename}] loading suite2p data…")
-        data = load_suite2p(plane0)
+        # Always re-read: cheap, and it means a resumed run picks up an edited
+        # cell-type spreadsheet instead of freezing the first run's grouping.
+        # A bundle carries a copy of the markers for recipients who have no
+        # spreadsheet at all, so the live reading only wins when it found one.
+        groups, markers = _resolve_cell_types(params, rec, state.channels, log)
+        if groups is not None or state.groups is None:
+            state.groups = groups
+        if markers is not None or state.markers is None:
+            state.markers = markers
 
-        if params.twop_activity in _NEEDS_DENOISING and (
-            data.F_denoised is None or params.twop_redo_denoising
-        ):
-            log(f"  [{rec.filename}] denoising ({data.F.shape[0]} ROIs)…")
-            process_suite2p_folder(
-                plane0,
-                overwrite=params.twop_redo_denoising,
-                denoising_threshold=params.twop_denoising_threshold,
-                time_before_peak_s=params.twop_denoising_time_before_peak,
-                time_after_peak_s=params.twop_denoising_time_after_peak,
-            )
-            data = load_suite2p(plane0)
+        all_stats[rec.filename] = stats
+        all_channels[rec.filename] = state.channels
+        states[rec.filename] = state
 
-        log(f"  [{rec.filename}] building adjacency matrices…")
-        res = suite2p_to_adjm(
-            data, params.twop_activity, lag_values,
-            remove_nodes_with_no_peaks=params.remove_nodes_with_no_peaks,
-            prob_thresh_tail=params.prob_thresh_tail,
-            prob_thresh_rep_num=params.prob_thresh_rep_num,
-            rng=rng,
-        )
-        duration_s = res.F.shape[0] / res.fs
-        spike_counts = _spike_counts(res, params.twop_activity)
+        try:
+            save_recording_state(
+                state_dir / f"{rec.filename}{CATNAP_SUFFIX}", state, stats)
+        except Exception as e:
+            log(f"  [{rec.filename}] warning: could not save step-2 data for "
+                f"re-runs: {e}")
 
-        all_stats[rec.filename] = _activity_stats_for(res, params, duration_s)
-        all_channels[rec.filename] = res.channels
-        groups, markers = _resolve_cell_types(params, rec, res.channels, log)
-        states[rec.filename] = _RecordingState(
-            adjMs=res.adjMs, coords=res.coords, channels=res.channels,
-            spike_counts=spike_counts, duration_s=duration_s, plane0=plane0,
-            groups=groups, markers=markers, coord_norm=res.coord_norm,
-        )
-
+        # Same label as the ephys path: this is the same work on the same
+        # recording, and one generator serves every lag (as in step4.py).
+        metric_rng = make_rng(params.random_seed, "step4", rec.filename)
         rec_results: dict = {}
-        for lag_ms in lag_values:
-            key = f"adjM{lag_ms}mslag"
-            if key not in res.adjMs:
-                continue
+        for lag_ms, adj in sorted_adjm_items(state.adjMs):
             log(f"  [{rec.filename}] network metrics (lag={lag_ms}ms)…")
             metrics = compute_network_metrics(
-                res.adjMs[key], spike_counts, duration_s,
+                adj, state.spike_counts, state.duration_s,
                 params.min_activity_level, min_nodes,
                 exclude_edges_below_threshold=params.exclude_edges_below_threshold,
-                params=params, rng=rng,
+                params=params, rng=metric_rng,
             )
             rec_results[f"{lag_ms}mslag"] = metrics
         all_results[rec.filename] = rec_results
@@ -218,7 +216,11 @@ def run_catnap_pipeline(
     # almost every node lands in role 1.
     if params.auto_set_cartography_boundaries and all_results:
         check_cancel(should_cancel)
-        _apply_cartography_boundaries(params, all_results, log, out_dir=net_dir)
+        # ``out_dir=None`` suppresses the pooled PC/Z landscape scatter — a
+        # figure, and one the bundle's metrics can redraw.
+        _apply_cartography_boundaries(
+            params, all_results, log,
+            out_dir=None if params.express_mode else net_dir)
 
     # Pooled node-metric ranges, so the ``_scaled`` network plots of different
     # recordings share an axis.
@@ -235,13 +237,24 @@ def run_catnap_pipeline(
         # and the trace figures both need the suite2p folder re-opened, and the
         # subnetwork figures want the same backdrop as the whole-network ones.
         data, background = _reload_for_plots(params, rec, state, log)
+        # Captured, not just drawn: figure 12 is the one plot that needs pixels
+        # rather than metrics, so a bundle has to carry the projection or it
+        # could never be reconstructed.
+        try:
+            save_background(
+                state_dir / f"{rec.filename}{BACKGROUND_SUFFIX}", background)
+        except Exception as e:
+            log(f"  [{rec.filename}] warning: could not save mean projection: {e}")
+
         _plot_recording(params, rec, state, all_results[rec.filename],
                         batch_bounds, output_root, log, data, background)
 
         if params.twop_subnetwork_analysis:
             _run_subnetwork_analysis(
                 params, rec, state, all_results[rec.filename],
-                min_nodes, output_root, subnetwork_tables, log, rng, background,
+                min_nodes, output_root, subnetwork_tables, log,
+                make_rng(params.random_seed, "catnap_subnetwork", rec.filename),
+                background,
             )
 
     _save_catnap_results(recordings, all_results, all_stats, all_channels, net_dir, log)
@@ -251,6 +264,81 @@ def run_catnap_pipeline(
         subnetwork_tables, states, output_root, log,
     )
     log("  CAT-NAP pipeline complete.")
+
+
+def _compute_recording(
+    params: Params, rec: RecordingInfo, plane0: Path, log, rng,
+) -> tuple[RecordingState, dict] | None:
+    """Build one recording's adjacency + activity stats from its suite2p folder.
+
+    This is the expensive half of the CAT-NAP path — denoising, then STTC with
+    ``prob_thresh_rep_num`` circular-shift surrogates per lag — and the half a
+    step-4 resume skips. Returns ``None`` (having logged why) when the
+    recording has no suite2p output to read.
+    """
+    from meanap.catnap.denoising import process_suite2p_folder
+
+    if not (plane0 / "stat.npy").exists():
+        log(f"  [{rec.filename}] SKIP: no suite2p output at {plane0}")
+        return None
+
+    log(f"  [{rec.filename}] loading suite2p data…")
+    data = load_suite2p(plane0)
+
+    if params.twop_activity in _NEEDS_DENOISING and (
+        data.F_denoised is None or params.twop_redo_denoising
+    ):
+        log(f"  [{rec.filename}] denoising ({data.F.shape[0]} ROIs)…")
+        process_suite2p_folder(
+            plane0,
+            overwrite=params.twop_redo_denoising,
+            denoising_threshold=params.twop_denoising_threshold,
+            time_before_peak_s=params.twop_denoising_time_before_peak,
+            time_after_peak_s=params.twop_denoising_time_after_peak,
+        )
+        data = load_suite2p(plane0)
+
+    log(f"  [{rec.filename}] building adjacency matrices…")
+    res = suite2p_to_adjm(
+        data, params.twop_activity, params.func_con_lag_val,
+        remove_nodes_with_no_peaks=params.remove_nodes_with_no_peaks,
+        prob_thresh_tail=params.prob_thresh_tail,
+        prob_thresh_rep_num=params.prob_thresh_rep_num,
+        rng=rng,
+    )
+    duration_s = res.F.shape[0] / res.fs
+
+    state = RecordingState(
+        adjMs=res.adjMs, coords=res.coords, channels=res.channels,
+        spike_counts=_spike_counts(res, params.twop_activity),
+        duration_s=duration_s, plane0=plane0, coord_norm=res.coord_norm,
+    )
+    return state, _activity_stats_for(res, params, duration_s)
+
+
+def _load_recording(
+    locator: InputLocator, rec: RecordingInfo, plane0: Path, log,
+) -> tuple[RecordingState, dict] | None:
+    """Read one recording's step-2 products back from a previous run.
+
+    Mirrors MEApipeline.m's ``priorAnalysis == 1 && startAnalysisStep == 4``
+    branch, which loads ``adjMs`` out of the prior ``ExperimentMatFiles`` rather
+    than calling ``suite2pToAdjm`` again. Returns ``None`` (having logged why)
+    when the file is absent or unreadable, so one bad recording costs the batch
+    that recording and not the run.
+    """
+    path = locator.catnap_file(rec.filename)
+    if path is None:
+        log(f"  [{rec.filename}] SKIP: no saved step-2 data "
+            f"({rec.filename}{CATNAP_SUFFIX}) to resume from")
+        return None
+    try:
+        state, stats = load_recording_state(path, plane0)
+    except Exception as e:
+        log(f"  [{rec.filename}] SKIP: could not read {path}: {e}")
+        return None
+    log(f"  [{rec.filename}] reusing adjacency matrices from {path}")
+    return state, stats
 
 
 def _mean_image_background(mean_img, coord_norm) -> tuple | None:
@@ -339,7 +427,10 @@ def _reload_for_plots(params, rec, state, log):
 
     background = None
     if params.twop_network_background:
-        background = _mean_image_background(data.mean_img, state.coord_norm)
+        # Quantised here, before anything draws it, so the pipeline's figure and
+        # a viewer's reconstruction come from the same array (see store.py).
+        background = quantize_background(
+            _mean_image_background(data.mean_img, state.coord_norm))
         if background is None:
             log(f"  [{rec.filename}] note: no mean projection in ops — "
                 "network plots drawn without a backdrop")
@@ -360,6 +451,11 @@ def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, 
     Runs after the cartography barrier, so the cartography scatter and the
     circular cartography plot show the batch-derived boundaries and the roles
     that the CSVs report.
+
+    In express mode only the trace figures are drawn. They are the one family
+    here that cannot be rebuilt from the run's own outputs — they need the full
+    fluorescence matrices, which are hundreds of MB and deliberately not carried
+    — whereas every network figure is a pure function of data the bundle holds.
     """
     from meanap.catnap.plotting import plot_2p_traces
     from meanap.pipeline.step4 import _plot_recording_lag
@@ -373,6 +469,9 @@ def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, 
                            num_traces=params.num_2p_traces)
         except Exception as e:
             log(f"  [{rec.filename}] warning: 2P trace plots failed: {e}")
+
+    if params.express_mode:
+        return
 
     for lag_key, metrics in rec_results.items():
         if "adjMsub" not in metrics:
@@ -452,6 +551,11 @@ def _run_subnetwork_analysis(
         tables["summary"].extend(dict(base, **row) for row in summary.to_dict("records"))
         tables["node"].extend(dict(base, **row) for row in node_df.to_dict("records"))
         tables["mix"].extend(dict(base, **row) for row in edge_mix.to_dict("records"))
+
+        # The metrics above are data and always computed; only the figures below
+        # are reconstructable from them, so express mode stops here.
+        if params.express_mode:
+            continue
 
         title = f"{rec.filename}  {lag_ms} ms lag"
         coords_active = state.coords[active]
@@ -588,31 +692,40 @@ def _plot_group_comparisons(
     from meanap.pipeline.plotting_step4 import plot_step4_group_comparisons
 
     order = params.custom_grp_order or None
-    log("  Generating group comparison plots…")
+    express = params.express_mode
+    log("  Writing batch tables…" if express else "  Generating group comparison plots…")
 
+    # The pooled frames are *data*, not figures — express mode still needs them
+    # for the CSVs. In full mode the plotter derives the same frames internally
+    # (``plot_twop_group_comparisons`` calls ``twop_stats_frames`` itself), so
+    # neither path recomputes anything the other doesn't.
     df_node = pd.DataFrame()
     try:
-        _, df_node = gp.plot_twop_group_comparisons(
-            recordings, all_stats, output_root / "2_NeuronalActivity",
-            custom_grp_order=order, channels_by_rec=all_channels,
-        )
+        if express:
+            _, df_node = gp.twop_stats_frames(recordings, all_stats, all_channels)
+        else:
+            _, df_node = gp.plot_twop_group_comparisons(
+                recordings, all_stats, output_root / "2_NeuronalActivity",
+                custom_grp_order=order, channels_by_rec=all_channels,
+            )
     except Exception as e:
-        log(f"  Warning: two-photon activity group comparison plots failed: {e}")
+        log(f"  Warning: two-photon activity group comparisons failed: {e}")
 
     # The same activity metrics again, split by cell type, plus how many cells
     # of each type each recording had.
     groups_by_rec = {name: st.groups for name, st in states.items() if st.groups}
     if groups_by_rec:
         try:
-            by_type = gp.add_cell_type_column(df_node, groups_by_rec, all_channels)
             composition = gp.composition_frame(
                 recordings, groups_by_rec, all_channels,
                 active_by_rec=_active_channels(df_node),
             )
-            gp.plot_activity_by_cell_type(
-                by_type, composition, output_root / "2_NeuronalActivity",
-                custom_grp_order=order,
-            )
+            if not express:
+                by_type = gp.add_cell_type_column(df_node, groups_by_rec, all_channels)
+                gp.plot_activity_by_cell_type(
+                    by_type, composition, output_root / "2_NeuronalActivity",
+                    custom_grp_order=order,
+                )
             if not composition.empty:
                 composition.to_csv(
                     output_root / "2_NeuronalActivity" / "CellTypeComposition.csv",
@@ -620,6 +733,9 @@ def _plot_group_comparisons(
                 )
         except Exception as e:
             log(f"  Warning: by-cell-type activity comparisons failed: {e}")
+
+    if express:
+        return
 
     try:
         plot_step4_group_comparisons(

--- a/src/meanap/catnap/plotting.py
+++ b/src/meanap/catnap/plotting.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+from meanap.pipeline.figure_output import savefig
 import matplotlib
 
 matplotlib.use("Agg")
@@ -91,7 +92,7 @@ def plot_2p_traces(
 
         fig.tight_layout()
         out_path = out_dir / f"unit_{roi + 1}_2ptraces.png"
-        fig.savefig(out_path, dpi=120)
+        savefig(fig, out_path, default_dpi=120)
         plt.close(fig)
         saved.append(out_path)
 

--- a/src/meanap/catnap/store.py
+++ b/src/meanap/catnap/store.py
@@ -1,0 +1,324 @@
+"""Persisting CAT-NAP's step-2 products so a later run can resume at step 4.
+
+``MEApipeline.m`` appends ``adjMs`` (and the activity data it was derived from)
+to each recording's ``ExperimentMatFiles/<rec>_<folder>.mat`` at the end of
+step 2 — that append is what lets ``Params.priorAnalysis = 1`` +
+``Params.startAnalysisStep = 4`` re-run the network analysis without redoing
+``suite2pToAdjm``. This module is the port of it: one
+``ExperimentMatFiles/<rec>_catnap.npz`` per recording, holding exactly what
+phases 2 and 3 of :func:`~meanap.catnap.pipeline.run_catnap_pipeline` need and
+nothing else.
+
+What is deliberately *not* stored:
+
+- **the fluorescence matrices** (``F`` / ``denoisedF`` / ``spks``) — hundreds of
+  MB per recording, and phase 3 already re-reads them from the suite2p folder
+  for the trace figures, so a copy here would be dead weight. MATLAB does store
+  them, because its one chained ``.mat`` is also how step 4 gets the activity
+  matrix; this port keeps the derived per-node quantities (``spike_counts``)
+  instead, which is all that step 4 actually consumes.
+- **cell-type groups and markers** — cheap to re-read from the spreadsheet, and
+  re-reading means a resumed run picks up an edited grouping rather than
+  freezing whatever the first run happened to use.
+
+The file therefore stays small (adjacency is ``n_units²``), which matters: a
+resumed run rewrites it into the new output folder so that folder is itself
+resumable, and chains of resumes shouldn't each cost a full data copy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+__all__ = [
+    "RecordingState",
+    "save_recording_state",
+    "load_recording_state",
+    "save_background",
+    "load_background",
+    "lag_from_adjm_key",
+    "sorted_adjm_items",
+    "BACKGROUND_SUFFIX",
+]
+
+#: Bumped when the stored key set changes incompatibly. A mismatch raises
+#: rather than silently half-loading a file from an older port.
+#:
+#: 2 — added the cell-type marker matrix, so a shared bundle can draw the
+#:     marker rings without the recipient having the spreadsheet.
+#: 3 — added the resolved cell-type groups, needed by the by-cell-type activity
+#:     comparisons (the grouping is a user choice, not derivable from markers).
+FORMAT_VERSION = 3
+
+_ADJ_PREFIX = "adj__"
+_STAT_PREFIX = "stat__"
+
+#: Suffix of the optional per-recording mean-projection file (CAT-NAP only).
+BACKGROUND_SUFFIX = "_background.npz"
+
+
+@dataclass
+class RecordingState:
+    """What phases 2 and 3 need about a recording, without its activity matrices.
+
+    ``suite2p_to_adjm`` returns the full ``(n_frames, n_units)`` fluorescence,
+    denoised-fluorescence and spks matrices — hundreds of MB per recording, so
+    holding them for a whole batch across the cartography barrier is not an
+    option. Everything here is small (adjacency matrices are ``n_units²``); the
+    trace figures re-read the suite2p folder at ``plane0`` instead.
+    """
+
+    adjMs: dict[str, np.ndarray]
+    coords: np.ndarray
+    channels: np.ndarray
+    spike_counts: np.ndarray
+    duration_s: float
+    plane0: Path
+    #: User-defined cell-type groups (E/I, per-marker, …) — drives the
+    #: subnetwork analysis and the by-cell-type activity comparisons.
+    groups: object | None = None
+    #: ``(n_channels, n_markers)`` raw marker membership + names, straight from
+    #: the spreadsheet. Distinct from ``groups``: this is the cell's full
+    #: genetic identity, drawn as concentric rings on the network plots, and it
+    #: is not collapsed into whatever grouping the user chose.
+    markers: tuple[np.ndarray, list[str]] | None = None
+    #: ``(min, max)`` used to normalise the pixel centroids onto ``coords`` —
+    #: needed to map the mean projection image into the same frame.
+    coord_norm: tuple[float, float] = (0.0, 1.0)
+
+
+def lag_from_adjm_key(key: str) -> int:
+    """``'adjM25mslag'`` → ``25``."""
+    return int(key[len("adjM"):-len("mslag")])
+
+
+def sorted_adjm_items(adjMs: dict[str, np.ndarray]) -> list[tuple[int, np.ndarray]]:
+    """``adjMs`` as ``(lag_ms, matrix)`` pairs, ascending by lag.
+
+    Sorting rather than trusting dict order keeps a resumed run's log lines,
+    CSV row order and figure order identical to the run that produced the file,
+    regardless of how the lags were listed in Params or how the ``.npz`` stored
+    them.
+    """
+    return sorted(
+        ((lag_from_adjm_key(k), v) for k, v in adjMs.items()),
+        key=lambda pair: pair[0],
+    )
+
+
+def save_recording_state(path: Path, state: RecordingState, stats: dict) -> None:
+    """Write one recording's step-2 products to ``path`` (an ``.npz``).
+
+    ``stats`` is a :func:`~meanap.catnap.stats.calc_twop_activity_stats` dict;
+    its ``None`` values (the 2P-specific metrics, absent for the non-``peaks``
+    activity types) are recorded by name and restored as ``None``, since
+    downstream code distinguishes "not applicable" from NaN.
+    """
+    arrays: dict[str, np.ndarray] = {
+        "catnap_format": np.array(FORMAT_VERSION),
+        "coords": np.asarray(state.coords, dtype=float),
+        "channels": np.asarray(state.channels),
+        "spike_counts": np.asarray(state.spike_counts, dtype=float),
+        "duration_s": np.array(float(state.duration_s)),
+        "coord_norm": np.asarray(state.coord_norm, dtype=float),
+    }
+    for key, adj in state.adjMs.items():
+        arrays[f"{_ADJ_PREFIX}{key}"] = np.asarray(adj, dtype=float)
+
+    # Cell-type markers. A local re-run re-reads these from the spreadsheet
+    # (see the loader), but a bundle shared with someone who has no spreadsheet
+    # still needs them to draw the marker rings.
+    if state.markers is not None:
+        marker_matrix, marker_names = state.markers
+        arrays["marker_matrix"] = np.asarray(marker_matrix, dtype=float)
+        arrays["marker_names"] = np.asarray(list(marker_names), dtype=str)
+
+    # The resolved grouping (E/I, per-marker, a custom expression …) is a user
+    # choice that markers alone don't determine, and the by-cell-type activity
+    # comparisons need it. Stored flat so this module keeps no dependency on
+    # catnap.subnetwork.
+    groups = state.groups
+    if groups is not None and getattr(groups, "n_groups", 0):
+        arrays["group_names"] = np.asarray(list(groups.names), dtype=str)
+        arrays["group_masks"] = np.asarray(groups.masks, dtype=bool)
+        # The expression each group was built from ("NeuN+ & ~GAD+"). Not needed
+        # to redraw anything, but it is how a reader knows what a group *means*
+        # — and the spreadsheet it came from won't travel with the bundle.
+        arrays["group_definitions"] = np.asarray(
+            [str(groups.definitions.get(n, "")) for n in groups.names], dtype=str)
+
+    none_keys: list[str] = []
+    for key, value in stats.items():
+        if value is None:
+            none_keys.append(key)
+        else:
+            arrays[f"{_STAT_PREFIX}{key}"] = np.asarray(value)
+    # dtype=str keeps this a plain unicode array, so loading never needs
+    # allow_pickle (which we don't want enabled on files a user may be
+    # pointing at from an arbitrary prior-analysis folder).
+    arrays["stat_none"] = np.asarray(none_keys, dtype=str)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(path, **arrays)
+
+
+def load_recording_state(path: Path, plane0: Path) -> tuple[RecordingState, dict]:
+    """Read back what :func:`save_recording_state` wrote.
+
+    Returns ``(state, stats)``. ``plane0`` is supplied by the caller rather than
+    stored, so a resumed run looks for the suite2p folder under the *current*
+    ``Params.rawData`` — the prior run's raw data may not even be mounted, and
+    the figures that want it already degrade gracefully when it isn't.
+
+    ``groups`` / ``markers`` are left unset; the caller re-reads them from the
+    cell-type spreadsheet.
+    """
+    with np.load(path) as data:
+        keys = set(data.files)
+        # Older files are readable: every bump so far has *added* optional keys
+        # (markers in 2, groups in 3), and the reads below already treat those
+        # as optional. Refusing them would be actively wrong for a shared
+        # bundle — the recipient has no raw data, so "re-run from step 1" is
+        # advice they cannot take. Only a file from the future is refused,
+        # because its keys may mean something different.
+        fmt = int(data["catnap_format"]) if "catnap_format" in keys else 0
+        if fmt > FORMAT_VERSION:
+            raise ValueError(
+                f"{path.name} is a CAT-NAP step-2 file in format {fmt}; this "
+                f"version reads up to format {FORMAT_VERSION}. Update MEA-NAP "
+                "to open it."
+            )
+        if fmt < 1:
+            raise ValueError(
+                f"{path.name} does not look like a CAT-NAP step-2 file "
+                "(no format marker)."
+            )
+
+        adjMs = {k[len(_ADJ_PREFIX):]: data[k]
+                 for k in data.files if k.startswith(_ADJ_PREFIX)}
+
+        stats: dict = {}
+        for k in data.files:
+            if not k.startswith(_STAT_PREFIX):
+                continue
+            value = data[k]
+            stats[k[len(_STAT_PREFIX):]] = value.item() if value.ndim == 0 else value
+        for name in data["stat_none"]:
+            stats[str(name)] = None
+
+        markers = None
+        if "marker_matrix" in keys:
+            markers = (data["marker_matrix"], [str(n) for n in data["marker_names"]])
+
+        groups = None
+        if "group_names" in keys:
+            from meanap.catnap.subnetwork import CellTypeGroups
+
+            marker_matrix, marker_names = (
+                markers if markers is not None
+                else (np.zeros((len(data["channels"]), 0)), []))
+            names = [str(n) for n in data["group_names"]]
+            definitions = {}
+            if "group_definitions" in keys:
+                definitions = {n: str(d) for n, d in
+                               zip(names, data["group_definitions"]) if str(d)}
+            groups = CellTypeGroups(
+                names=names,
+                masks=np.asarray(data["group_masks"], dtype=bool),
+                marker_names=list(marker_names),
+                marker_matrix=np.asarray(marker_matrix),
+                definitions=definitions,
+            )
+
+        state = RecordingState(
+            adjMs=adjMs,
+            coords=data["coords"],
+            channels=data["channels"],
+            spike_counts=data["spike_counts"],
+            duration_s=float(data["duration_s"]),
+            plane0=plane0,
+            groups=groups,
+            markers=markers,
+            coord_norm=tuple(float(v) for v in data["coord_norm"]),
+        )
+
+    return state, stats
+
+
+#: Longest edge kept for the stored mean projection. One figure displays it, a
+#: few inches wide at 150 dpi — under 1000 px on screen — so anything beyond
+#: this is bytes nobody can see. suite2p projections are routinely 1280² or
+#: larger, where the full-precision array is 6.5 MB against ~350 KB here.
+MAX_BACKGROUND_PX = 1024
+
+
+def quantize_background(background: tuple | None) -> tuple | None:
+    """Reduce a mean projection to what actually gets stored and drawn.
+
+    Decimates to :data:`MAX_BACKGROUND_PX` and rounds to 256 grey levels. The
+    pipeline runs its backdrop through this *before* plotting, so the figure it
+    draws and the figure a viewer redraws from the bundle come from a
+    bit-identical array — a lossy backdrop that differed between the two would
+    make the reconstruction impossible to verify.
+    """
+    if background is None:
+        return None
+    image, extent = background
+    img = np.asarray(image, dtype=float)
+    if img.ndim != 2 or img.size == 0:
+        return None
+
+    step = max(1, -(-max(img.shape) // MAX_BACKGROUND_PX))  # ceil division
+    img = img[::step, ::step]
+
+    lo, hi = float(np.nanmin(img)), float(np.nanmax(img))
+    span = hi - lo
+    if not np.isfinite(span) or span <= 0:
+        return np.zeros_like(img), extent
+    levels = np.round((img - lo) / span * 255.0)
+    return lo + levels / 255.0 * span, extent
+
+
+def save_background(path: Path, background: tuple | None) -> None:
+    """Store a recording's mean-projection backdrop and its coordinate extent.
+
+    Kept out of the state file because it is produced in a later phase (the
+    image is only read when the plotting phase re-opens the suite2p folder) and
+    because it is optional — one figure depends on it.
+
+    Expects an already-:func:`quantize_background`-ed image; the 256 levels are
+    stored as ``uint8`` plus the range needed to restore them exactly.
+    """
+    if background is None:
+        return
+    image, extent = background
+    img = np.asarray(image, dtype=float)
+    lo, hi = float(np.nanmin(img)), float(np.nanmax(img))
+    span = hi - lo
+    levels = (np.round((img - lo) / span * 255.0).astype(np.uint8) if span > 0
+              else np.zeros(img.shape, dtype=np.uint8))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        path, levels=levels, value_range=np.array([lo, hi], dtype=float),
+        extent=np.asarray(extent, dtype=float),
+    )
+
+
+def load_background(path: Path) -> tuple | None:
+    """Read back what :func:`save_background` wrote, or ``None`` if absent.
+
+    Restores the exact float array the pipeline plotted, because the pipeline
+    quantized before plotting (see :func:`quantize_background`).
+    """
+    if not path.exists():
+        return None
+    with np.load(path) as data:
+        lo, hi = (float(v) for v in data["value_range"])
+        span = hi - lo
+        levels = np.asarray(data["levels"], dtype=float)
+        image = lo + levels / 255.0 * span if span > 0 else levels
+        return image, tuple(float(v) for v in data["extent"])

--- a/src/meanap/catnap/subnetwork_plotting.py
+++ b/src/meanap/catnap/subnetwork_plotting.py
@@ -30,6 +30,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
+from meanap.pipeline.figure_output import savefig
 import pandas as pd
 
 from meanap.catnap.subnetwork import CellTypeGroups, WHOLE_NETWORK
@@ -229,7 +230,7 @@ def plot_subnetwork_spatial(
                  else "  ·  ".join(captions), fontsize=10)
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -290,7 +291,7 @@ def plot_subnetwork_panels(
         fig.suptitle(title, fontsize=12)
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -347,7 +348,7 @@ def plot_node_metrics_by_group(
         fig.suptitle(title, fontsize=12)
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -414,7 +415,7 @@ def plot_subnetwork_metric_bars(
         fig.suptitle(title, fontsize=12)
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -468,5 +469,5 @@ def plot_edge_mix_matrix(
         fig.suptitle(title, fontsize=12)
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)

--- a/src/meanap/network_plot.py
+++ b/src/meanap/network_plot.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
 import scipy.io as sio
@@ -278,6 +280,84 @@ EDGE_THRESHOLD_METHODS = [
 ]
 
 
+@dataclass(frozen=True)
+class NetworkStyle:
+    """Styling knobs for a spatial network plot — the Network Viewer control set.
+
+    The viewer tab and the pipeline draw the same networks through
+    :func:`plot_network`, but until now only the viewer could restyle them: its
+    controls lived in the Qt panel, so a pipeline figure was stuck with the
+    defaults and a viewer could not reproduce a pipeline figure exactly. This
+    dataclass is that control set, extracted so both sides — and the bundle
+    renderer behind the web viewer — drive the same code.
+
+    :meth:`pipeline_default` is deliberately *not* the viewer's defaults: it is
+    the styling the pipeline has always used (no edge limiting, no derived
+    threshold, electrode coordinates). Passing it must leave existing figures
+    byte-identical, which is what lets the renderer prove parity.
+    """
+
+    #: Cap on the number of strongest edges drawn; ``None`` draws all of them.
+    max_edges: int | None = None
+    #: One of :data:`EDGE_THRESHOLD_METHODS`.
+    edge_threshold_method: str = "Absolute value"
+    #: Interpreted per method: a weight for "Absolute value", else a percentile.
+    edge_threshold: float = 0.0
+    #: One of :data:`LAYOUT_OPTIONS`.
+    layout: str = "Original (electrodes)"
+    node_size_scale: float | str = 1.0
+    #: One of :data:`NODE_SCALING_METHODS`.
+    node_scaling_method: str = "Linear"
+    node_scaling_power: float = 1.0
+    min_node_size: float = 0.01
+    min_edge_width: float = 0.001
+    max_edge_width: float = 4.0
+    #: Any matplotlib colormap name, applied to the node-colour metric.
+    colormap: str = "viridis"
+
+    @classmethod
+    def pipeline_default(cls, node_size_scale: float | str = 1.0) -> "NetworkStyle":
+        """The styling the pipeline draws with — the identity transform."""
+        return cls(node_size_scale=node_size_scale)
+
+    @classmethod
+    def from_params(cls, params, node_size_scale: float | str = 1.0) -> "NetworkStyle":
+        """Build from a :class:`~meanap.params.Params`' network-plot fields.
+
+        These fields drive the Network Viewer, not the pipeline's own figures,
+        so this is what a viewer should start from — not what
+        ``_plot_recording_lag`` uses by default.
+        """
+        method = str(getattr(params, "network_plot_edge_threshold_method", "percentile"))
+        percentile_like = method.lower().startswith("percentile")
+        return cls(
+            max_edges=(getattr(params, "max_num_edges_to_plot", 0) or None),
+            edge_threshold_method="Percentile" if percentile_like else "Absolute value",
+            edge_threshold=(params.network_plot_edge_threshold_percentile
+                            if percentile_like else params.network_plot_edge_threshold),
+            layout=str(getattr(params, "node_layout", "MEA")).replace(
+                "MEA", "Original (electrodes)"),
+            node_size_scale=node_size_scale,
+        )
+
+    def prepare(self, adj_m: np.ndarray, coords: np.ndarray):
+        """Apply the topology-affecting knobs.
+
+        Returns ``(adjM, coords, edge_thresh)`` — edge subsampling first, then
+        the threshold derived *on the subsampled matrix*, then the layout, in
+        the order ``PlotIndvNetMet.m`` uses and the viewer panel mirrors.
+        """
+        adj = limit_edges_for_plotting(adj_m, self.max_edges)
+        percentile_like = self.edge_threshold_method.startswith("Percentile")
+        edge_thresh = get_edge_threshold(
+            adj,
+            method=self.edge_threshold_method,
+            threshold=0.0 if percentile_like else self.edge_threshold,
+            percentile=self.edge_threshold if percentile_like else 90.0,
+        )
+        return adj, compute_node_coords(adj, coords, self.layout), edge_thresh
+
+
 def limit_edges_for_plotting(
     adjM: np.ndarray,
     max_edges: int | None = None,
@@ -492,6 +572,7 @@ def plot_network(
     node_size_scale: float | str = 1.0,
     node_scaling_method: str = "Linear",
     node_scaling_power: float = 1.0,
+    colormap: str = "viridis",
 ) -> None:
     """Render the MEA network onto *ax*.
 
@@ -601,7 +682,7 @@ def plot_network(
         and not np.all(np.isnan(z2))
     )
     if use_colormap:
-        cmap = matplotlib.colormaps["viridis"]
+        cmap = matplotlib.colormaps[colormap]
         if z2_bounds_override is not None:
             z2_min, z2_max = (float(v) for v in z2_bounds_override)
         else:

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -135,6 +135,12 @@ class Params:
     verbose_level: str = "Normal"
     time_processes: bool = False
     output_spreadsheet_file_type: str = "csv"
+    # Express mode: skip every figure that can be rebuilt from the run's data,
+    # and write a single shareable ``.meanap`` bundle instead. Only the
+    # quality-control figures that depend on raw data too large to carry (2P
+    # traces; step-1 spike-detection checks) are still saved as images. A viewer
+    # reconstructs the rest on demand — see pipeline/bundle.py.
+    express_mode: bool = False
 
     # ── Parallelism ──────────────────────────────────────────────────────────
     # None = auto-size against available cores/RAM (see pipeline/parallel.py).
@@ -232,3 +238,49 @@ class Params:
             "axionStimCSV": self.axion_stim_csv,
             "fs": self.fs,
         }
+
+
+#: Name of the parameter snapshot written into every output folder.
+PARAMS_FILENAME = "params.json"
+
+
+def save_params(params: Params, output_root: Path | str) -> Path:
+    """Write ``params.json`` into an output folder.
+
+    Two reasons this exists. Reproducibility: until now an output folder
+    recorded nothing about the settings that produced it, so a run could not be
+    repeated from its own results. And reconstruction: nearly every plotting
+    routine reads ``Params`` (channel layout, colour maps, node sizing, group
+    order, edge-threshold rules), so a bundle that omits it cannot redraw
+    anything faithfully.
+    """
+    import dataclasses
+    import json
+
+    path = Path(output_root) / PARAMS_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(dataclasses.asdict(params), fh, indent=2, sort_keys=True)
+    return path
+
+
+def load_params(path: Path | str) -> tuple[Params, list[str]]:
+    """Read a ``params.json`` back, tolerating version skew.
+
+    Returns ``(params, unknown_keys)``. Fields the file doesn't carry keep their
+    defaults; fields this version doesn't know are dropped and reported rather
+    than raising, because bundles get shared between people running different
+    versions of the port and a single renamed field should not make a whole run
+    unopenable.
+    """
+    import dataclasses
+    import json
+
+    with open(path) as fh:
+        raw = json.load(fh)
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path} does not contain a parameter object")
+
+    known = {f.name for f in dataclasses.fields(Params)}
+    unknown = sorted(set(raw) - known)
+    return Params(**{k: v for k, v in raw.items() if k in known}), unknown

--- a/src/meanap/pipeline/bundle.py
+++ b/src/meanap/pipeline/bundle.py
@@ -1,0 +1,302 @@
+"""The ``.meanap`` run bundle — one shareable file per analysis run.
+
+A full run's output folder is mostly pictures: 92 MB and 603 PNGs for one
+recording of the CAT-NAP example dataset, against roughly 1 MB of the data
+those pictures were drawn from. Every network figure is a pure function of that
+data, so carrying the pictures around is carrying a ~90× redundant copy.
+
+Express mode (``Params.express_mode``) therefore skips every figure that can be
+rebuilt and writes only the data, plus the handful of quality-control figures
+that *cannot* be rebuilt because they depend on raw recordings far too large to
+carry — the 2P traces, and on the electrophysiology side the spike-detection
+checks. :func:`write_bundle` then packs the folder into a single file that can
+be emailed, attached to a paper, or dropped in a shared drive, and
+:func:`open_bundle` turns it back into something the pipeline and the viewer
+can both read.
+
+**Layout.** A bundle is a zip whose entries mirror an output folder:
+
+===================================  =========================================
+``manifest.json``                    format version, mode, recordings, lags,
+                                     which figure families are reconstructable
+``params.json``                      the settings the run used
+``ExperimentMatFiles/<rec>_catnap.npz``   adjacency, coords, activity stats
+``ExperimentMatFiles/<rec>_background.npz``  mean projection (optional)
+``4_NetworkActivity/…``              metrics JSON + the CSVs
+``2_NeuronalActivity/…``             activity CSVs + kept trace figures
+``1_SpikeDetection/1B_…``            kept spike-detection checks (ephys)
+===================================  =========================================
+
+Mirroring the folder rather than inventing a schema buys three things: the
+existing ``report.py`` browser works on an extracted bundle unchanged; resuming
+from a bundle needs no new lookup logic, because :mod:`meanap.pipeline.resume`
+already knows these paths; and anyone without this software can open the zip
+and find plain CSVs.
+
+**Opening extracts.** Bundles are ~1 MB, so :func:`open_bundle` unpacks to a
+temporary directory and hands back a real path. That keeps every consumer —
+resume, the renderer, the report browser — working on ordinary files rather
+than each growing its own zip-aware I/O path.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from meanap.params import PARAMS_FILENAME, Params, load_params
+
+__all__ = [
+    "BUNDLE_SUFFIX",
+    "MANIFEST_NAME",
+    "FORMAT_VERSION",
+    "RECONSTRUCTABLE_FAMILIES",
+    "UNRECONSTRUCTABLE_FAMILIES",
+    "RunBundle",
+    "write_bundle",
+    "open_bundle",
+    "is_bundle",
+]
+
+BUNDLE_SUFFIX = ".meanap"
+MANIFEST_NAME = "manifest.json"
+FORMAT_VERSION = 1
+
+#: Folders whose figures are reconstructable from the bundle's data, and so are
+#: never packed even when a *full* (non-express) run is bundled. Everything else
+#: in the output folder is carried verbatim.
+_RECONSTRUCTABLE_DIRS = (
+    "4_NetworkActivity/4A_IndividualNetworkAnalysis",
+    "4_NetworkActivity/4B_GroupComparisons",
+    "2_NeuronalActivity/2B_GroupComparisons",
+    "3_EdgeThresholdingCheck",
+)
+
+#: Figure families a viewer can rebuild from a bundle. Must correspond to what
+#: :mod:`meanap.pipeline.render` actually implements — ``test_bundle_render.py``
+#: asserts that, because a manifest that overclaims is worse than one that says
+#: nothing: it promises a figure the viewer will never produce.
+#:
+#: (Not derived from ``render.GROUP_FAMILIES`` directly because ``render``
+#: imports this module, and the cycle isn't worth breaking for four strings.)
+RECONSTRUCTABLE_FAMILIES = (
+    "4A_individual_network",        # the per-recording network figure set
+    "4B_group_comparisons",         # network metrics by group and age
+    "2B_activity_comparisons",      # activity by group and age (both pipelines)
+    "cell_type_activity",           # CAT-NAP: activity split by cell type
+    "cell_type_subnetwork_groups",  # CAT-NAP: subnetwork *group* comparisons
+    "2A_individual_activity",       # ephys: rasters, heatmaps, burst detail
+)
+
+#: Figure families express mode drops that the viewer cannot currently rebuild,
+#: so they are simply absent until the run is repeated without express mode.
+#: Stated in the manifest rather than left to be discovered: silently missing
+#: figures are the failure mode this whole feature has to avoid.
+#:
+#: The first is *not* fundamental — its inputs are in the bundle, the
+#: reconstruction is just not wired up yet. The last two genuinely cannot be
+#: rebuilt at any size: they depend on raw data a bundle deliberately omits.
+UNRECONSTRUCTABLE_FAMILIES = (
+    "cell_type_subnetwork_per_rec",   # CAT-NAP: per-recording subnetwork figures
+    "3_edge_threshold_checks",        # needs the surrogate distributions
+    "1B_spike_detection_checks",      # needs the raw voltage (kept as images)
+)
+
+
+def is_bundle(path: Path | str) -> bool:
+    """Whether *path* looks like a bundle file (as opposed to an output folder)."""
+    p = Path(path)
+    return p.is_file() and p.suffix == BUNDLE_SUFFIX
+
+
+@dataclass
+class RunBundle:
+    """An opened bundle: a real directory plus the manifest that describes it.
+
+    Use as a context manager (or call :meth:`close`) so the extracted copy is
+    cleaned up; ``root`` stays valid until then.
+    """
+
+    root: Path
+    manifest: dict
+    params: Params
+    #: Params keys the bundle carried that this version doesn't know — a
+    #: version-skew signal worth surfacing rather than silently dropping.
+    unknown_param_keys: list[str] = field(default_factory=list)
+    _tempdir: str | None = None
+
+    # ── description ──────────────────────────────────────────────────────────
+
+    @property
+    def mode(self) -> str:
+        """``"catnap"``, ``"ephys"`` … — which pipeline produced this run."""
+        return str(self.manifest.get("mode", "unknown"))
+
+    @property
+    def recordings(self) -> list[dict]:
+        """``[{"filename", "group", "div"}, …]`` as recorded at write time."""
+        return list(self.manifest.get("recordings", []))
+
+    @property
+    def lags(self) -> list[int]:
+        return [int(v) for v in self.manifest.get("lags", [])]
+
+    def can_reconstruct(self, family: str) -> bool:
+        return family in self.manifest.get("reconstructable", [])
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        if self._tempdir is not None:
+            shutil.rmtree(self._tempdir, ignore_errors=True)
+            self._tempdir = None
+
+    def __enter__(self) -> "RunBundle":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+def build_manifest(
+    params: Params,
+    recordings: list,
+    *,
+    mode: str,
+    lags: list[int] | None = None,
+    embedded_figures: list[str] | None = None,
+) -> dict:
+    """The manifest for a run, describing what a viewer can and cannot redraw.
+
+    ``embedded_figures`` names the families packed as images because they are
+    *not* reconstructable — the honest counterpart to ``reconstructable``.
+    """
+    return {
+        "format": FORMAT_VERSION,
+        "mode": mode,
+        "express": bool(params.express_mode),
+        "lags": [int(v) for v in (lags if lags is not None else params.func_con_lag_val)],
+        "recordings": [
+            {"filename": r.filename, "group": r.group, "div": r.div}
+            for r in recordings
+        ],
+        "reconstructable": list(RECONSTRUCTABLE_FAMILIES),
+        "not_reconstructable": list(UNRECONSTRUCTABLE_FAMILIES),
+        "embedded_figures": list(embedded_figures or []),
+    }
+
+
+def _is_reconstructable_member(rel: Path) -> bool:
+    posix = rel.as_posix()
+    return any(posix.startswith(d) for d in _RECONSTRUCTABLE_DIRS)
+
+
+def write_bundle(
+    output_root: Path | str,
+    manifest: dict,
+    dest: Path | str | None = None,
+) -> Path:
+    """Pack an output folder into a single ``.meanap`` file.
+
+    ``dest`` defaults to ``<output_root>.meanap`` beside the folder. Figures
+    under the reconstructable folders are skipped even if present, so bundling
+    a full (non-express) run still produces a small file rather than a zipped
+    copy of every PNG.
+
+    Returns the path written.
+    """
+    root = Path(output_root)
+    if not root.is_dir():
+        raise ValueError(f"Not an output folder: {root}")
+
+    dest = Path(dest) if dest is not None else root.with_suffix(BUNDLE_SUFFIX)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(root / MANIFEST_NAME, "w") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(root)
+            if _is_reconstructable_member(rel):
+                continue
+            zf.write(path, rel.as_posix())
+
+    return dest
+
+
+def open_bundle(path: Path | str) -> RunBundle:
+    """Extract a bundle to a temporary directory and read its manifest.
+
+    Raises :class:`ValueError` with an actionable message on anything that
+    isn't a readable bundle of a format this version understands — a bundle is
+    something users hand to each other, so the failure modes are "someone sent
+    me the wrong file" and "someone sent me a newer file", and both deserve to
+    be said plainly.
+    """
+    src = Path(path)
+    if not src.is_file():
+        raise ValueError(f"Bundle not found: {src}")
+    if not zipfile.is_zipfile(src):
+        raise ValueError(
+            f"{src.name} is not a MEA-NAP bundle (not a zip archive). Bundles are "
+            f"written by an express-mode run and end in '{BUNDLE_SUFFIX}'."
+        )
+
+    tmp = tempfile.mkdtemp(prefix="meanap-bundle-")
+    try:
+        with zipfile.ZipFile(src) as zf:
+            _extract_safely(zf, Path(tmp))
+
+        root = Path(tmp)
+        manifest_path = root / MANIFEST_NAME
+        if not manifest_path.exists():
+            raise ValueError(
+                f"{src.name} has no {MANIFEST_NAME} — it is a zip, but not a "
+                "MEA-NAP bundle."
+            )
+        with open(manifest_path) as fh:
+            manifest = json.load(fh)
+
+        fmt = int(manifest.get("format", 0))
+        if fmt > FORMAT_VERSION:
+            raise ValueError(
+                f"{src.name} is a format-{fmt} bundle; this version reads up to "
+                f"format {FORMAT_VERSION}. Update MEA-NAP to open it."
+            )
+
+        params, unknown = Params(), []
+        if (root / PARAMS_FILENAME).exists():
+            params, unknown = load_params(root / PARAMS_FILENAME)
+
+        return RunBundle(root=root, manifest=manifest, params=params,
+                         unknown_param_keys=unknown, _tempdir=tmp)
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+
+def _extract_safely(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract, refusing entries that would escape *dest*.
+
+    Bundles travel between people, so a malicious or merely malformed archive
+    with ``../`` or absolute paths must not be able to write outside the
+    temporary directory (the "zip slip" problem). Python's ``extractall`` has
+    guarded against this since 3.6.2 for most cases, but the check is cheap and
+    the consequence of being wrong is arbitrary file overwrite.
+    """
+    dest = dest.resolve()
+    for member in zf.infolist():
+        target = (dest / member.filename).resolve()
+        if not target.is_relative_to(dest):
+            raise ValueError(
+                f"Refusing to extract '{member.filename}': it points outside the "
+                "extraction directory."
+            )
+    zf.extractall(dest)

--- a/src/meanap/pipeline/figure_output.py
+++ b/src/meanap/pipeline/figure_output.py
@@ -1,0 +1,62 @@
+"""Resolution control for saved figures.
+
+Every plotting routine hard-codes the resolution it was tuned for — 150 dpi for
+network plots, 300 for the dense multi-panel ones. Those are the right numbers
+for a figure you are going to look at closely, and the wrong ones for a gallery
+of 109 thumbnails: at 96 dpi the same batch renders in roughly half the time and
+a quarter of the bytes, and nobody can tell the difference in a 300-pixel-wide
+tile.
+
+Rather than thread a ``dpi`` argument through a dozen plot functions and three
+layers of callers, the override lives in a :class:`~contextvars.ContextVar` and
+the plotters resolve it at save time via :func:`savefig`. A
+:class:`contextvars.ContextVar` — not a module global — because a viewer serves
+requests concurrently, and two requests asking for different resolutions must
+not race. Each thread gets its own value, and :func:`figure_dpi` restores the
+previous one on exit.
+
+The default is ``None``, meaning "whatever the plot function asked for", so
+nothing changes for the pipeline and figure parity is unaffected.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from pathlib import Path
+
+__all__ = ["DEFAULT_THUMBNAIL_DPI", "figure_dpi", "current_dpi", "savefig"]
+
+#: Resolution for gallery thumbnails. Chosen by measurement: against the
+#: as-authored mix of 150/300 dpi, 96 dpi cut a 109-figure batch from 11.5 s to
+#: 6.1 s and from 8.0 MB to 2.1 MB. Below this the axis labels start to suffer.
+DEFAULT_THUMBNAIL_DPI = 96
+
+_dpi_override: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "meanap_figure_dpi", default=None,
+)
+
+
+@contextmanager
+def figure_dpi(dpi: int | None):
+    """Render figures at *dpi* within this block; ``None`` leaves them alone."""
+    token = _dpi_override.set(dpi)
+    try:
+        yield
+    finally:
+        _dpi_override.reset(token)
+
+
+def current_dpi() -> int | None:
+    """The resolution override in force, or ``None``."""
+    return _dpi_override.get()
+
+
+def savefig(fig, path: Path, *, default_dpi: int, **kwargs) -> None:
+    """Save *fig*, honouring any active override in preference to *default_dpi*.
+
+    Creates the parent directory, so callers don't each repeat that.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, dpi=current_dpi() or default_dpi, **kwargs)

--- a/src/meanap/pipeline/plotting_step2.py
+++ b/src/meanap/pipeline/plotting_step2.py
@@ -2,6 +2,8 @@ import math
 from pathlib import Path
 
 import numpy as np
+from meanap.pipeline.figure_output import savefig
+from meanap.pipeline.rng import derive_seed_int
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 import seaborn as sns
@@ -12,21 +14,36 @@ from meanap.pipeline.plotting_step4 import plot_half_violin_by_x
 # Create 85% parula colormap
 parula_85 = LinearSegmentedColormap.from_list('parula_85', parula_data[:int(len(parula_data)*0.85)])
 
-def plot_firing_rate_distribution(ephys: dict, out_path: Path):
+def plot_firing_rate_distribution(ephys: dict, out_path: Path, seed: int | None = None):
+    """Violin + jittered strip of per-electrode firing rate.
+
+    ``seed`` fixes the strip plot's jitter. seaborn draws it from numpy's
+    *legacy global* random state and offers no seed argument, so the state is
+    set and restored around the call rather than threaded through. Without
+    this the figure differs between two otherwise-identical seeded runs — and
+    between the pipeline's copy and one redrawn from a bundle.
+    """
     fr = ephys.get("FR", [])
     if len(fr) == 0:
         return
-        
-    fig, ax = plt.subplots(figsize=(4, 6))
-    sns.violinplot(y=fr, ax=ax, inner=None, color="lightgray")
-    sns.stripplot(y=fr, ax=ax, color="black", size=4, jitter=True)
+
+    state = np.random.get_state() if seed is not None else None
+    if seed is not None:
+        np.random.seed(seed)
+    try:
+        fig, ax = plt.subplots(figsize=(4, 6))
+        sns.violinplot(y=fr, ax=ax, inner=None, color="lightgray")
+        sns.stripplot(y=fr, ax=ax, color="black", size=4, jitter=True)
+    finally:
+        if state is not None:
+            np.random.set_state(state)
     
     ax.set_ylabel("Mean firing rate per electrode (Hz)")
     ax.set_title("Firing Rate by Electrode")
     
     ax.set_ylim(bottom=0)
     plt.tight_layout()
-    fig.savefig(out_path, dpi=300)
+    savefig(fig, out_path, default_dpi=300)
     plt.close(fig)
 
 def _draw_heatmap_panel(ax, xs, ys, metric, valid_mask, vmin, vmax, cmap, clabel, panel_title):
@@ -88,7 +105,7 @@ def plot_heatmap(
         fig, ax = plt.subplots(figsize=(6, 5))
         _draw_heatmap_panel(ax, xs, ys, metric, valid_mask, vmin, recording_vmax, cmap, clabel, title)
         plt.tight_layout()
-        fig.savefig(out_path, dpi=300)
+        savefig(fig, out_path, default_dpi=300)
         plt.close(fig)
         return
 
@@ -102,7 +119,7 @@ def plot_heatmap(
     _draw_heatmap_panel(ax_batch, xs, ys, metric, valid_mask, vmin, batch_vmax, cmap,
                         clabel, f"{title}\nscaled to entire dataset")
     plt.tight_layout()
-    fig.savefig(out_path, dpi=300)
+    savefig(fig, out_path, default_dpi=300)
     plt.close(fig)
 
 def plot_raster(
@@ -154,7 +171,7 @@ def plot_raster(
     ax_batch.set_xlabel("Time (s)")
 
     plt.tight_layout()
-    fig.savefig(out_path, dpi=300)
+    savefig(fig, out_path, default_dpi=300)
     plt.close(fig)
 
 def plot_burst_detection_info(spike_times_dict: dict, ephys: dict, duration_s: float, fs: float, out_path: Path):
@@ -239,8 +256,27 @@ def plot_burst_detection_info(spike_times_dict: dict, ephys: dict, duration_s: f
                 ax_isi.set_title("ISI Distribution")
     
     plt.tight_layout()
-    fig.savefig(out_path, dpi=300)
+    savefig(fig, out_path, default_dpi=300)
     plt.close(fig)
+
+#: The per-channel heatmaps, as ``(figure name, ephys key, title, colour-bar
+#: label, colormap)``. One list rather than six near-identical call sites, so
+#: the pipeline and the bundle renderer cannot disagree about which figures
+#: exist or what they are called.
+ACTIVITY_HEATMAPS = (
+    ("2_Heatmap.png", "FR", "Firing Rate", "Mean FR (Hz)", "viridis"),
+    ("3_BurstRate_heatmap.png", "channelBurstRate", "Burst Rate",
+     "Burst Rate (bursts/min)", "plasma"),
+    ("4_BurstDur_heatmap.png", "channelBurstDur", "Burst Duration",
+     "Duration (ms)", "plasma"),
+    ("5_FractSpikesInBursts_heatmap.png", "channelFracSpikesInBursts",
+     "Fraction Spikes in Bursts", "Fraction", "plasma"),
+    ("6_ISIwithinBurst_heatmap.png", "channelISIwithinBurst", "ISI Within Burst",
+     "ISI (ms)", "plasma"),
+    ("7_ISIoutsideBurst_heatmap.png", "channeISIoutsideBurst",
+     "ISI Outside Burst", "ISI (ms)", "plasma"),
+)
+
 
 def plot_neuronal_activity_checks(
     rec,
@@ -254,36 +290,58 @@ def plot_neuronal_activity_checks(
     output_root: Path,
     spike_freq_max: float | None = None,
     batch_max: dict | None = None,
-):
+    fmt: str = "png",
+    only: str | None = None,
+) -> list[Path]:
+    """Draw one recording's step-2 activity figures.
+
+    ``fmt`` selects the image format (``svg``/``pdf`` give vector output) and
+    ``only`` restricts the call to the single figure with that base name — the
+    two hooks the bundle viewer needs to render one plot per request. Both
+    default to the pipeline's behaviour: every figure, as PNG.
+
+    Returns the paths actually written.
+    """
     out_dir = output_root / rec.group / rec.filename
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    plot_firing_rate_distribution(ephys, out_dir / "1_FiringRateByElectrode.png")
+    written: list[Path] = []
+
+    def want(name: str) -> Path | None:
+        stem = Path(name).stem
+        if only is not None and stem != only:
+            return None
+        path = out_dir / f"{stem}.{fmt}"
+        written.append(path)
+        return path
 
     channel_layout = getattr(params, "channel_layout", "Axion64")
     bmax = batch_max or {}
 
-    if "FR" in ephys:
-        plot_heatmap(ephys["FR"], chs, "Firing Rate", "Mean FR (Hz)", out_dir / "2_Heatmap.png", channel_layout=channel_layout, batch_max=bmax.get("FR"))
+    if (p := want("1_FiringRateByElectrode.png")) is not None:
+        plot_firing_rate_distribution(
+            ephys, p,
+            seed=derive_seed_int(params.random_seed, "step2-plots", rec.filename))
 
-    plot_raster(
-        spike_times_dict, duration_s, out_dir / "3_Raster.png",
-        spike_freq_max=spike_freq_max,
-        raster_upper_percentile=getattr(params, "raster_plot_upper_percentile", 99.0),
-    )
+    for name, key, title, cbar, cmap in ACTIVITY_HEATMAPS:
+        if key not in ephys:
+            continue
+        if (p := want(name)) is not None:
+            plot_heatmap(ephys[key], chs, title, cbar, p, cmap=cmap,
+                         channel_layout=channel_layout, batch_max=bmax.get(key))
 
-    if "channelBurstRate" in ephys:
-        plot_heatmap(ephys["channelBurstRate"], chs, "Burst Rate", "Burst Rate (bursts/min)", out_dir / "3_BurstRate_heatmap.png", cmap="plasma", channel_layout=channel_layout, batch_max=bmax.get("channelBurstRate"))
-    if "channelBurstDur" in ephys:
-        plot_heatmap(ephys["channelBurstDur"], chs, "Burst Duration", "Duration (ms)", out_dir / "4_BurstDur_heatmap.png", cmap="plasma", channel_layout=channel_layout, batch_max=bmax.get("channelBurstDur"))
-    if "channelFracSpikesInBursts" in ephys:
-        plot_heatmap(ephys["channelFracSpikesInBursts"], chs, "Fraction Spikes in Bursts", "Fraction", out_dir / "5_FractSpikesInBursts_heatmap.png", cmap="plasma", channel_layout=channel_layout, batch_max=bmax.get("channelFracSpikesInBursts"))
-    if "channelISIwithinBurst" in ephys:
-        plot_heatmap(ephys["channelISIwithinBurst"], chs, "ISI Within Burst", "ISI (ms)", out_dir / "6_ISIwithinBurst_heatmap.png", cmap="plasma", channel_layout=channel_layout, batch_max=bmax.get("channelISIwithinBurst"))
-    if "channeISIoutsideBurst" in ephys:
-        plot_heatmap(ephys["channeISIoutsideBurst"], chs, "ISI Outside Burst", "ISI (ms)", out_dir / "7_ISIoutsideBurst_heatmap.png", cmap="plasma", channel_layout=channel_layout, batch_max=bmax.get("channeISIoutsideBurst"))
-        
-    plot_burst_detection_info(spike_times_dict, ephys, duration_s, fs, out_dir / "8_BurstDetectionInfo.png")
+    if (p := want("3_Raster.png")) is not None:
+        plot_raster(
+            spike_times_dict, duration_s, p,
+            spike_freq_max=spike_freq_max,
+            raster_upper_percentile=getattr(params, "raster_plot_upper_percentile", 99.0),
+        )
+
+    if (p := want("8_BurstDetectionInfo.png")) is not None:
+        plot_burst_detection_info(spike_times_dict, ephys, duration_s, fs, p)
+
+    return [p for p in written if p.exists()]
+
 
 import pandas as pd
 
@@ -341,14 +399,15 @@ def _plot_violin(df: pd.DataFrame, metric: str, group_col: str, out_path: Path, 
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
     fig.tight_layout()
-    fig.savefig(out_path, dpi=300, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=300, bbox_inches="tight")
     plt.close(fig)
 
 def plot_step2_group_comparisons(
     recordings: list,
     all_ephys: dict,
     out_dir: Path,
-    custom_grp_order: list[str] | None = None
+    custom_grp_order: list[str] | None = None,
+    fmt: str = "png",
 ) -> None:
     """Generate group comparison plots for step 2."""
     rec_rows = []
@@ -398,7 +457,7 @@ def plot_step2_group_comparisons(
     
     for k, name in EPHYS_REC_METRICS.items():
         plot_half_violin_by_x(df_rec, k, name, "group",
-                              grp_dir / f"{k}_byGroup.png", group_order=custom_grp_order)
+                              grp_dir / f"{k}_byGroup.{fmt}", group_order=custom_grp_order)
 
     # 1_NodeByGroup
     node_grp_dir = out_dir / "2B_GroupComparisons" / "1_NodeByGroup"
@@ -406,7 +465,7 @@ def plot_step2_group_comparisons(
 
     for k, name in EPHYS_NODE_METRICS.items():
         plot_half_violin_by_x(df_node, k, name, "group",
-                              node_grp_dir / f"{k}_byGroup_node.png", group_order=custom_grp_order)
+                              node_grp_dir / f"{k}_byGroup_node.{fmt}", group_order=custom_grp_order)
 
     # 4_RecordingsByAge
     age_dir = out_dir / "2B_GroupComparisons" / "4_RecordingsByAge" / "HalfViolinPlots"
@@ -414,7 +473,7 @@ def plot_step2_group_comparisons(
 
     for k, name in EPHYS_REC_METRICS.items():
         plot_half_violin_by_x(df_rec, k, name, "DIV",
-                              age_dir / f"{k}_byDIV.png", group_order=custom_grp_order)
+                              age_dir / f"{k}_byDIV.{fmt}", group_order=custom_grp_order)
 
     # 2_NodeByAge
     node_age_dir = out_dir / "2B_GroupComparisons" / "2_NodeByAge"
@@ -422,4 +481,4 @@ def plot_step2_group_comparisons(
 
     for k, name in EPHYS_NODE_METRICS.items():
         plot_half_violin_by_x(df_node, k, name, "DIV",
-                              node_age_dir / f"{k}_byDIV_node.png", group_order=custom_grp_order)
+                              node_age_dir / f"{k}_byDIV_node.{fmt}", group_order=custom_grp_order)

--- a/src/meanap/pipeline/plotting_step4.py
+++ b/src/meanap/pipeline/plotting_step4.py
@@ -11,6 +11,11 @@ Not ported: null-model panels (small-worldness — stochastic, see
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from meanap.network_plot import NetworkStyle
+
 from pathlib import Path
 
 import matplotlib
@@ -19,6 +24,7 @@ matplotlib.use("Agg")
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
+from meanap.pipeline.figure_output import savefig
 
 from meanap.network_plot import plot_network
 from meanap.params import Params
@@ -93,7 +99,7 @@ def plot_connectivity_stats(
 
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -116,6 +122,7 @@ def plot_spatial_network(
     cell_types: tuple[np.ndarray, list[str]] | None = None,
     background: tuple | None = None,
     node_size_scale: float | str = 1.0,
+    style: "NetworkStyle | None" = None,
 ) -> None:
     """Spatial network plot, port of the base ``2_MEA_NetworkPlot.png`` from
     ``StandardisedNetworkPlot.m`` (reuses ``network_plot.py``'s
@@ -142,6 +149,18 @@ def plot_spatial_network(
         return
     sub, coords, z_sub, z2_sub, ct_matrix = prepared
 
+    # ``style`` carries the Network Viewer control set (edge subsampling and
+    # threshold, layout, node scaling, edge widths, colormap). Left as None the
+    # pipeline's long-standing styling applies unchanged — see
+    # NetworkStyle.pipeline_default, which the renderer relies on for parity.
+    from meanap.network_plot import NetworkStyle
+
+    if style is None:
+        # No restyling: keep the caller's edge_thresh and coordinates exactly.
+        style = NetworkStyle.pipeline_default(node_size_scale)
+    else:
+        sub, coords, edge_thresh = style.prepare(sub, coords)
+
     scaled = z_scale_override is not None
     title_suffix = " (scaled to data batch)" if scaled else ""
     fig, ax = plt.subplots(figsize=(8, 8))
@@ -152,11 +171,17 @@ def plot_spatial_network(
         z2_bounds_override=z2_bounds_override,
         edge_bounds_override=edge_bounds_override,
         cell_type_matrix=ct_matrix, cell_type_names=ct_names,
-        background=background, node_size_scale=node_size_scale,
+        background=background,
+        node_size_scale=style.node_size_scale,
+        node_scaling_method=style.node_scaling_method,
+        node_scaling_power=style.node_scaling_power,
+        min_node_size=style.min_node_size,
+        min_ew=style.min_edge_width, max_ew=style.max_edge_width,
+        colormap=style.colormap,
     )
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -219,7 +244,7 @@ def plot_network_beside_field(
 
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -322,7 +347,7 @@ def plot_spatial_network_combined(
     )
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150)
+    savefig(fig, out_path, default_dpi=150)
     plt.close(fig)
 
 
@@ -463,7 +488,7 @@ def plot_node_cartography(
         ax.legend(loc="upper left", bbox_to_anchor=(1.02, 1.0), fontsize=8, frameon=False)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -779,7 +804,7 @@ def plot_circular_module_network(
         )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -920,7 +945,7 @@ def plot_circular_cartography_network(
         current_y -= 0.08
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -1218,7 +1243,7 @@ def plot_half_violin_by_x(
                  ha="center", va="bottom", fontsize=8, color="0.5")
 
     fig.tight_layout()
-    fig.savefig(out_path, dpi=300, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=300, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -1320,8 +1345,8 @@ def plot_node_cartography_by_lag(
                       bbox_to_anchor=(1.01, 0.5), fontsize=8, frameon=False)
 
         fig.tight_layout()
-        fig.savefig(out_dir / f"NodeCartography{_lag_num(lag)}mslag.png",
-                    dpi=300, bbox_inches="tight")
+        savefig(fig, out_dir / f"NodeCartography{_lag_num(lag)}mslag.png",
+                default_dpi=300, bbox_inches="tight")
         plt.close(fig)
 
 
@@ -1362,7 +1387,7 @@ def plot_density_landscape(
     ax.spines["right"].set_visible(False)
     fig.tight_layout()
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=300, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=300, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -1453,7 +1478,7 @@ def plot_graph_metrics_by_lag(
             plt.close(fig)
             continue
         fig.tight_layout()
-        fig.savefig(out_dir / f"{metric}.png", dpi=300, bbox_inches="tight")
+        savefig(fig, out_dir / f"{metric}.png", default_dpi=300, bbox_inches="tight")
         plt.close(fig)
 
 
@@ -1614,7 +1639,7 @@ def plot_graph_metrics_by_node(
                 ax.set_ylim(*ylim)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 import pandas as pd
@@ -1691,14 +1716,15 @@ def _plot_violin(df: pd.DataFrame, metric: str, group_col: str, out_path: Path, 
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
     fig.tight_layout()
-    fig.savefig(out_path, dpi=300, bbox_inches="tight")
+    savefig(fig, out_path, default_dpi=300, bbox_inches="tight")
     plt.close(fig)
 
 def plot_step4_group_comparisons(
     recordings: list,
     all_results: dict,
     out_dir: Path,
-    custom_grp_order: list[str] | None = None
+    custom_grp_order: list[str] | None = None,
+    fmt: str = "png",
 ) -> None:
     """Generate group comparison plots for step 4."""
     rec_rows = []
@@ -1760,7 +1786,7 @@ def plot_step4_group_comparisons(
         df_rec_lag = df_rec[df_rec["Lag"] == lag]
         for k, name in NETMET_REC_METRICS.items():
             plot_half_violin_by_x(df_rec_lag, k, name, "group",
-                                  lag_grp_dir / f"{k}_byGroup.png",
+                                  lag_grp_dir / f"{k}_byGroup.{fmt}",
                                   group_order=custom_grp_order)
 
         lag_node_grp_dir = node_grp_dir / f"Lag{lag_str}ms" if "ms" not in str(lag_str) else node_grp_dir / f"Lag{lag_str}"
@@ -1769,7 +1795,7 @@ def plot_step4_group_comparisons(
         df_node_lag = df_node[df_node["Lag"] == lag]
         for k, name in NETMET_NODE_METRICS.items():
             plot_half_violin_by_x(df_node_lag, k, name, "group",
-                                  lag_node_grp_dir / f"{k}_byGroup_node.png",
+                                  lag_node_grp_dir / f"{k}_byGroup_node.{fmt}",
                                   group_order=custom_grp_order)
         
     # 4_RecordingsByAge and 2_NodeByAge
@@ -1785,7 +1811,7 @@ def plot_step4_group_comparisons(
         df_rec_lag = df_rec[df_rec["Lag"] == lag]
         for k, name in NETMET_REC_METRICS.items():
             plot_half_violin_by_x(df_rec_lag, k, name, "DIV",
-                                  lag_age_dir / f"{k}_byDIV.png",
+                                  lag_age_dir / f"{k}_byDIV.{fmt}",
                                   group_order=custom_grp_order)
 
         lag_node_age_dir = node_age_dir / f"Lag{lag_str}ms" if "ms" not in str(lag_str) else node_age_dir / f"Lag{lag_str}"
@@ -1794,7 +1820,7 @@ def plot_step4_group_comparisons(
         df_node_lag = df_node[df_node["Lag"] == lag]
         for k, name in NETMET_NODE_METRICS.items():
             plot_half_violin_by_x(df_node_lag, k, name, "DIV",
-                                  lag_node_age_dir / f"{k}_byDIV_node.png",
+                                  lag_node_age_dir / f"{k}_byDIV_node.{fmt}",
                                   group_order=custom_grp_order)
 
     # 5_GraphMetricsByLag — network metric vs. STTC lag, one figure per metric

--- a/src/meanap/pipeline/render.py
+++ b/src/meanap/pipeline/render.py
@@ -1,0 +1,756 @@
+"""Redraw a run's figures from a bundle, on demand.
+
+Express mode ships the data and drops the pictures; this module puts the
+pictures back. It is deliberately thin: every figure is produced by calling
+:func:`meanap.pipeline.step4._plot_recording_lag` — *the same function the
+pipeline calls* — with state reassembled from the bundle. No plotting code is
+duplicated here, so a reconstructed figure cannot drift from the one the
+pipeline would have drawn. :func:`python/test_bundle_render.py` pins that down
+by rendering both ways and comparing pixels.
+
+Three things have to be rebuilt from what the bundle stores:
+
+``adjMsub``
+    The active-node subgraph every network figure draws. Not stored, because it
+    is a pure function of the full adjacency (in the state ``.npz``) and
+    ``activeChannelIndex`` (in the metrics JSON) — see
+    :func:`meanap.pipeline.step4.compute_network_metrics`, which this mirrors.
+``batch_bounds``
+    Pooled node-metric ranges for the ``_scaled`` figure variants. Recomputed
+    across every recording in the bundle, exactly as the pipeline's phase 2
+    does, so the batch-scaled plots keep their shared axes.
+numpy arrays
+    JSON round-trips arrays to lists; the plotters want arrays back.
+
+Two capabilities the pipeline itself doesn't need fall out for free. Any figure
+can be emitted as **SVG or PDF** — vector, editable, publication-ready —
+because matplotlib picks the format from the suffix. And ``overrides`` re-renders
+with different styling (node size, edge threshold, colour map) without touching
+the stored results, which is what makes an interactive viewer possible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from meanap.params import Params
+from meanap.pipeline.bundle import RunBundle
+from meanap.pipeline.resume import ADJM_SUFFIX, CATNAP_SUFFIX
+from meanap.pipeline.spreadsheet import RecordingInfo
+
+__all__ = [
+    "FIGURES",
+    "GROUP_FAMILIES",
+    "VECTOR_FORMATS",
+    "FigureSpec",
+    "RenderContext",
+    "available_figures",
+    "available_activity_figures",
+    "ACTIVITY_FIGURES",
+    "available_group_families",
+    "load_context",
+    "render_figure",
+    "render_activity_figure",
+    "render_group_family",
+    "gallery",
+    "cached_figure",
+    "style_from_overrides",
+]
+
+#: Formats that produce editable vector output rather than pixels.
+VECTOR_FORMATS = ("svg", "pdf")
+
+
+@dataclass(frozen=True)
+class FigureSpec:
+    """One redrawable figure: its file stem and a human-readable label."""
+
+    name: str
+    label: str
+    #: Metrics key that must be present for this figure to exist.
+    requires: str | None = None
+
+
+#: The 4A figure set, keyed by the base filename ``_plot_recording_lag`` writes.
+#: ``requires`` mirrors that function's own guards so a viewer can list only
+#: what a given recording actually has, rather than offering a button that
+#: silently produces nothing.
+FIGURES: tuple[FigureSpec, ...] = (
+    FigureSpec("1_adjM{lag}msConnectivityStats", "Connectivity statistics"),
+    FigureSpec("2_MEA_NetworkPlot", "Network — node degree", "ND"),
+    FigureSpec("3_MEA_NetworkPlotNodedegreeBetweennesscentrality",
+               "Network — betweenness centrality", "BC"),
+    FigureSpec("4_MEA_NetworkPlotNodedegreeParticipationcoefficient",
+               "Network — participation coefficient", "PC"),
+    FigureSpec("5_MEA_NetworkPlotNodestrengthLocalefficiency",
+               "Network — local efficiency", "Eloc"),
+    FigureSpec("6_circular_NetworkPlotNodedegreeModule", "Circular — modules", "Ci"),
+    FigureSpec("7_adjM{lag}msGraphMetricsByNode", "Graph metrics by node", "ND"),
+    FigureSpec("9_adjM{lag}msNodeCartography", "Node cartography", "PC"),
+    FigureSpec("9_circular_NetworkPlotNodeCartography",
+               "Circular — cartography", "NdCartDiv"),
+    FigureSpec("10_MEA_NetworkPlotNodedegreeAveragecontrollability",
+               "Network — average controllability", "aveControl"),
+    FigureSpec("11_MEA_NetworkPlotNodedegreeModalcontrollability",
+               "Network — modal controllability", "modalControl"),
+    FigureSpec("12_MeanImageAndNetwork", "Field of view beside network"),
+)
+
+
+#: The step-2 per-recording activity figures, in the order the pipeline writes
+#: them. ``requires`` is the ``ephys`` key each needs; the two with ``None``
+#: are always available because they are drawn from the spike times.
+ACTIVITY_FIGURES: tuple[FigureSpec, ...] = (
+    FigureSpec("1_FiringRateByElectrode", "Firing rate by electrode"),
+    FigureSpec("2_Heatmap", "Firing rate heatmap", "FR"),
+    FigureSpec("3_Raster", "Raster"),
+    FigureSpec("3_BurstRate_heatmap", "Burst rate heatmap", "channelBurstRate"),
+    FigureSpec("4_BurstDur_heatmap", "Burst duration heatmap", "channelBurstDur"),
+    FigureSpec("5_FractSpikesInBursts_heatmap", "Fraction of spikes in bursts",
+               "channelFracSpikesInBursts"),
+    FigureSpec("6_ISIwithinBurst_heatmap", "ISI within burst",
+               "channelISIwithinBurst"),
+    FigureSpec("7_ISIoutsideBurst_heatmap", "ISI outside bursts",
+               "channeISIoutsideBurst"),
+    FigureSpec("8_BurstDetectionInfo", "Burst detection detail"),
+)
+
+#: Per-channel metrics whose heatmap colour ceiling is pooled across the batch
+#: (MATLAB's ``maxValStruct``). Must match step 2's own list, or a rebuilt
+#: heatmap would use a different colour scale from the pipeline's.
+_ACTIVITY_BATCH_METRICS = (
+    "FR", "channelBurstRate", "channelBurstDur",
+    "channelFracSpikesInBursts", "channelISIwithinBurst", "channeISIoutsideBurst",
+)
+
+
+@dataclass
+class RenderContext:
+    """Everything needed to redraw one bundle's figures, loaded once.
+
+    Loading is not free (metrics JSON plus one ``.npz`` per recording), and a
+    viewer answers many requests against the same bundle, so callers should
+    build this once and reuse it.
+    """
+
+    params: Params
+    recordings: dict[str, RecordingInfo]
+    results: dict[str, dict]
+    batch_bounds: dict[str, tuple[float, float] | None]
+    root: Path
+    mode: str = "catnap"
+
+    def lags(self, recording: str) -> list[int]:
+        return sorted(int(k.replace("mslag", ""))
+                      for k in self.results.get(recording, {}))
+
+
+def _to_arrays(obj):
+    """Undo the array→list flattening ``_convert_numpy`` applies for JSON."""
+    if isinstance(obj, dict):
+        return {k: _to_arrays(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        # Only numeric lists become arrays; a list of strings (marker names,
+        # say) must stay a list or the plotters' string handling breaks.
+        flat = np.asarray(obj)
+        return flat if flat.dtype.kind in "fiub" else obj
+    return obj
+
+
+def load_context(bundle: RunBundle | Path | str) -> RenderContext:
+    """Assemble a :class:`RenderContext` from an opened bundle or a folder.
+
+    Accepts a plain output folder too, so the renderer works against a run that
+    was never bundled — useful for regenerating one figure as SVG after a
+    normal run.
+    """
+    if isinstance(bundle, RunBundle):
+        root, params, mode = bundle.root, bundle.params, bundle.mode
+        rec_rows = bundle.recordings
+    else:
+        from meanap.params import PARAMS_FILENAME, load_params
+        root = Path(bundle)
+        params = (load_params(root / PARAMS_FILENAME)[0]
+                  if (root / PARAMS_FILENAME).exists() else Params())
+        mode = "catnap" if params.suite2p_mode else "ephys"
+        rec_rows = _recordings_from_csv(root)
+
+    recordings = {
+        r["filename"]: RecordingInfo(
+            filename=r["filename"], div=float(r.get("div") or 0), group=r.get("group", ""),
+        )
+        for r in rec_rows
+    }
+
+    metrics_path = root / "4_NetworkActivity" / "netmet_results.json"
+    if not metrics_path.exists():
+        raise ValueError(
+            f"No network metrics in {root} — expected "
+            "4_NetworkActivity/netmet_results.json. This run may predate express "
+            "mode, or may not have reached step 4."
+        )
+    with open(metrics_path) as fh:
+        results = _to_arrays(json.load(fh))
+
+    # adjMsub is derived, not stored — see the module docstring.
+    for rec_name, per_lag in results.items():
+        state_path = _state_file(root, rec_name)
+        if state_path is None:
+            continue
+        with np.load(state_path) as data:
+            adj_keys = _adjacency_keys(data)
+            for lag_key, metrics in per_lag.items():
+                full_key = f"adjM{lag_key.replace('mslag', '')}mslag"
+                if full_key not in adj_keys or "activeChannelIndex" not in metrics:
+                    continue
+                metrics["adjMsub"] = _active_subgraph(
+                    data[adj_keys[full_key]], metrics["activeChannelIndex"])
+
+    from meanap.pipeline.step4 import _batch_metric_bounds
+    batch_bounds = {m: _batch_metric_bounds(results, m)
+                    for m in ("ND", "NS", "BC", "PC", "Eloc")}
+
+    return RenderContext(params=params, recordings=recordings, results=results,
+                         batch_bounds=batch_bounds, root=root, mode=mode)
+
+
+def _state_file(root: Path, recording: str) -> Path | None:
+    """The per-recording array file, whichever pipeline produced it.
+
+    CAT-NAP writes ``<rec>_catnap.npz`` (adjacency, coords, cell types); the
+    electrophysiology path writes ``<rec>_adjM.npz`` (adjacency + channels).
+    Both hold what the 4A figures need — for ephys, node positions come from
+    the channel layout rather than being stored — so the renderer takes
+    whichever is present instead of having two code paths.
+    """
+    for suffix in (CATNAP_SUFFIX, ADJM_SUFFIX):
+        path = root / "ExperimentMatFiles" / f"{recording}{suffix}"
+        if path.exists():
+            return path
+    return None
+
+
+def _adjacency_keys(data) -> dict[str, str]:
+    """Map ``adjM{lag}mslag`` → the key holding it in *data*.
+
+    CAT-NAP prefixes its adjacency entries (``adj__``) to keep them apart from
+    the stats in the same file; step 3 stores them bare, alongside a ``_raw``
+    (pre-thresholding) copy that the metrics were *not* computed from.
+    """
+    prefixed = {k[len("adj__"):]: k for k in data.files if k.startswith("adj__")}
+    if prefixed:
+        return prefixed
+    return {k: k for k in data.files
+            if k.startswith("adjM") and k.endswith("mslag")}
+
+
+def _active_subgraph(adj_m: np.ndarray, active_index) -> np.ndarray:
+    """Rebuild ``adjMsub`` exactly as ``compute_network_metrics`` does.
+
+    The clip-and-fill must match that function or reconstructed figures would
+    differ from the pipeline's on any matrix with negatives or NaNs.
+    """
+    adj = np.asarray(adj_m, dtype=float).copy()
+    adj[adj < 0] = 0.0
+    adj = np.nan_to_num(adj, nan=0.0)
+    idx = np.asarray(active_index, dtype=int)
+    return adj[np.ix_(idx, idx)]
+
+
+def _recordings_from_csv(root: Path) -> list[dict]:
+    """Recover the recordings table from the recording-level CSV."""
+    import pandas as pd
+
+    path = root / "4_NetworkActivity" / "NetworkActivity_RecordingLevel.csv"
+    if not path.exists():
+        return []
+    df = pd.read_csv(path).drop_duplicates("FileName")
+    return [{"filename": r.FileName, "group": r.Grp, "div": r.DIV}
+            for r in df.itertuples()]
+
+
+def available_figures(ctx: RenderContext, recording: str, lag: int) -> list[FigureSpec]:
+    """Which figures this recording/lag can actually produce."""
+    metrics = ctx.results.get(recording, {}).get(f"{lag}mslag", {})
+    if "adjMsub" not in metrics:
+        return []
+    out = []
+    for spec in FIGURES:
+        if spec.requires is not None and spec.requires not in metrics:
+            continue
+        if spec.name == "12_MeanImageAndNetwork" and _background_path(ctx, recording) is None:
+            continue
+        out.append(dataclasses.replace(spec, name=spec.name.format(lag=lag)))
+    return out
+
+
+def _background_path(ctx: RenderContext, recording: str) -> Path | None:
+    from meanap.catnap.store import BACKGROUND_SUFFIX
+
+    path = ctx.root / "ExperimentMatFiles" / f"{recording}{BACKGROUND_SUFFIX}"
+    return path if path.exists() else None
+
+
+def render_figure(
+    ctx: RenderContext,
+    recording: str,
+    lag: int,
+    figure: str,
+    out_dir: Path | str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> Path:
+    """Redraw one figure and return the file written.
+
+    ``fmt`` may be any format matplotlib writes; ``svg`` and ``pdf`` give
+    editable vector output. ``overrides`` is a mapping of ``Params`` field names
+    to values, applied to a *copy* — so a viewer can restyle a plot (node size,
+    edge threshold, colour map) without disturbing the bundle or any other
+    request.
+
+    Raises :class:`ValueError` when the figure isn't available for this
+    recording/lag, rather than silently writing nothing.
+    """
+    from meanap.catnap.store import load_background
+    from meanap.pipeline.figure_output import figure_dpi
+    from meanap.pipeline.step4 import _plot_recording_lag
+
+    lag_key = f"{lag}mslag"
+    metrics = ctx.results.get(recording, {}).get(lag_key)
+    if not metrics:
+        raise ValueError(f"No results for {recording} at {lag} ms lag")
+    if "adjMsub" not in metrics:
+        raise ValueError(
+            f"{recording} at {lag} ms lag has no adjacency subgraph — the run "
+            "excluded it (too few active nodes) or its state file is missing."
+        )
+
+    rec = ctx.recordings.get(recording) or RecordingInfo(
+        filename=recording, div=0.0, group="")
+
+    params, style = _apply_overrides(ctx.params, overrides)
+
+    channels, coords, markers = _recording_arrays(ctx, recording)
+    background = None
+    bg_path = _background_path(ctx, recording)
+    if bg_path is not None:
+        background = load_background(bg_path)
+
+    with figure_dpi(dpi):
+        written = _plot_recording_lag(
+            rec, lag, metrics, channels, params, Path(out_dir), lambda m: None,
+            ctx.batch_bounds, coords_all=coords, cell_types=markers,
+            background=background,
+            node_size_scale="auto" if params.twop_auto_node_size else 1.0,
+            fmt=fmt, only=figure, style=style,
+        )
+    if not written:
+        raise ValueError(
+            f"'{figure}' is not one of the figures available for {recording} at "
+            f"{lag} ms lag. Use available_figures() to list them."
+        )
+    return written[0]
+
+
+#: Styling knobs the viewer exposes, forwarded to
+#: :class:`~meanap.network_plot.NetworkStyle` rather than to ``Params``. These
+#: are the Network Viewer tab's controls; keeping them separate is what lets a
+#: request restyle a figure without pretending the run used those settings.
+STYLE_KEYS = frozenset({
+    "max_edges", "edge_threshold_method", "edge_threshold", "layout",
+    "node_size_scale", "node_scaling_method", "node_scaling_power",
+    "min_node_size", "min_edge_width", "max_edge_width", "colormap",
+})
+
+
+def style_from_overrides(overrides: dict | None):
+    """Split a request's overrides into the styling half.
+
+    Returns ``None`` when nothing styling-related was asked for, which keeps
+    the pipeline's own styling — and therefore pixel parity — in force.
+    """
+    from meanap.network_plot import NetworkStyle
+
+    picked = {k: v for k, v in (overrides or {}).items() if k in STYLE_KEYS}
+    return NetworkStyle(**picked) if picked else None
+
+
+def _apply_overrides(params: Params, overrides: dict | None):
+    """Split overrides into ``(Params, NetworkStyle | None)``.
+
+    Both are applied to copies, so a request never mutates the loaded context.
+    An unrecognised key is an error rather than a silent no-op: a viewer
+    control that quietly does nothing is worse than one that reports itself.
+    """
+    style = style_from_overrides(overrides)
+    param_names = {f.name for f in dataclasses.fields(Params)}
+    rest = {k: v for k, v in (overrides or {}).items() if k not in STYLE_KEYS}
+    unknown = set(rest) - param_names
+    if unknown:
+        raise ValueError(f"Unknown parameter override(s): {sorted(unknown)}")
+    return (dataclasses.replace(params, **rest) if rest else params), style
+
+
+# ── Batch (2B / 4B) comparison figures ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GroupFamily:
+    """One batch-comparison figure family and where it lands."""
+
+    key: str
+    label: str
+    #: Output subfolder, relative to the run root.
+    out_subdir: str
+
+
+GROUP_FAMILIES: tuple[GroupFamily, ...] = (
+    GroupFamily("network", "Network metrics by group and age", "4_NetworkActivity"),
+    GroupFamily("activity", "Two-photon activity by group and age", "2_NeuronalActivity"),
+    GroupFamily("cell_type", "Activity by cell type", "2_NeuronalActivity"),
+    GroupFamily("subnetwork", "Cell-type subnetworks by group and age", "4_NetworkActivity"),
+    GroupFamily("ephys_activity", "Neuronal activity by group and age",
+                "2_NeuronalActivity"),
+)
+
+
+def _ephys_stats(ctx: RenderContext) -> dict:
+    """Step-2 ``Ephys`` dicts, read back from ``ephys_results.json``.
+
+    The electrophysiology counterpart of the CAT-NAP activity stats; a
+    different file and a different plotter, but the same idea — the numbers the
+    2B comparison figures are drawn from.
+    """
+    path = ctx.root / "2_NeuronalActivity" / "ephys_results.json"
+    if not path.exists():
+        return {}
+    with open(path) as fh:
+        return _to_arrays(json.load(fh))
+
+
+def available_group_families(ctx: RenderContext) -> list[GroupFamily]:
+    """Which batch families this bundle has the inputs for.
+
+    Each depends on something optional — activity stats, a cell-type grouping,
+    the subnetwork analysis having been switched on — so a viewer should ask
+    rather than assume.
+    """
+    out = []
+    for fam in GROUP_FAMILIES:
+        if fam.key == "network" and ctx.results:
+            out.append(fam)
+        elif fam.key == "activity" and _all_stats(ctx):
+            out.append(fam)
+        elif fam.key == "cell_type" and _groups_by_rec(ctx):
+            out.append(fam)
+        elif fam.key == "subnetwork" and _subnetwork_rows(ctx)[0]:
+            out.append(fam)
+        elif fam.key == "ephys_activity" and _ephys_stats(ctx):
+            out.append(fam)
+    return out
+
+
+def _states(ctx: RenderContext) -> dict:
+    """Per-recording stored state, loaded once and cached on the context."""
+    cached = getattr(ctx, "_states_cache", None)
+    if cached is not None:
+        return cached
+    from meanap.catnap.store import load_recording_state
+
+    states: dict = {}
+    for name in ctx.recordings:
+        path = ctx.root / "ExperimentMatFiles" / f"{name}{CATNAP_SUFFIX}"
+        if path.exists():
+            states[name] = load_recording_state(path, Path("."))
+    object.__setattr__(ctx, "_states_cache", states)
+    return states
+
+
+def _all_stats(ctx: RenderContext) -> dict:
+    return {name: stats for name, (_, stats) in _states(ctx).items() if stats}
+
+
+def _channels_by_rec(ctx: RenderContext) -> dict:
+    return {name: state.channels for name, (state, _) in _states(ctx).items()}
+
+
+def _groups_by_rec(ctx: RenderContext) -> dict:
+    return {name: state.groups for name, (state, _) in _states(ctx).items()
+            if state.groups is not None and state.groups.n_groups}
+
+
+def _subnetwork_rows(ctx: RenderContext) -> tuple[list, list]:
+    """The cell-type subnetwork tables, read back from the bundle's CSVs."""
+    import pandas as pd
+
+    def read(name: str) -> list:
+        path = ctx.root / "4_NetworkActivity" / name
+        return (pd.read_csv(path).to_dict("records") if path.exists() else [])
+
+    return read("Subnetwork_RecordingLevel.csv"), read("Subnetwork_NodeLevel.csv")
+
+
+def render_group_family(
+    ctx: RenderContext,
+    family: str,
+    out_root: Path | str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> list[Path]:
+    """Redraw one batch-comparison family, returning the files written.
+
+    These are whole folders of small multiples rather than single figures, so
+    unlike :func:`render_figure` this renders a family at a time — which is
+    also how the pipeline produces them.
+
+    ``dpi`` overrides each plot's authored resolution; pass
+    :data:`~meanap.pipeline.figure_output.DEFAULT_THUMBNAIL_DPI` for a gallery.
+    Leave it ``None`` for figures meant to be looked at closely.
+    """
+    from meanap.catnap import group_plots as gp
+    from meanap.pipeline.figure_output import figure_dpi
+    from meanap.pipeline.plotting_step4 import plot_step4_group_comparisons
+
+    fam = next((f for f in GROUP_FAMILIES if f.key == family), None)
+    if fam is None:
+        raise ValueError(
+            f"Unknown figure family {family!r}; expected one of "
+            f"{[f.key for f in GROUP_FAMILIES]}")
+
+    params, _ = _apply_overrides(ctx.params, overrides)
+    order = params.custom_grp_order or None
+    out_root = Path(out_root)
+    out_dir = out_root / fam.out_subdir
+    recordings = list(ctx.recordings.values())
+    before = set(out_dir.rglob("*")) if out_dir.exists() else set()
+
+    with figure_dpi(dpi):
+        if fam.key == "network":
+            plot_step4_group_comparisons(recordings, ctx.results, out_dir, order, fmt=fmt)
+        elif fam.key == "activity":
+            gp.plot_twop_group_comparisons(
+                recordings, _all_stats(ctx), out_dir, custom_grp_order=order,
+                channels_by_rec=_channels_by_rec(ctx), fmt=fmt)
+        elif fam.key == "cell_type":
+            _, df_node = gp.twop_stats_frames(
+                recordings, _all_stats(ctx), _channels_by_rec(ctx))
+            groups_by_rec = _groups_by_rec(ctx)
+            by_type = gp.add_cell_type_column(
+                df_node, groups_by_rec, _channels_by_rec(ctx))
+            composition = gp.composition_frame(
+                recordings, groups_by_rec, _channels_by_rec(ctx))
+            gp.plot_activity_by_cell_type(
+                by_type, composition, out_dir, custom_grp_order=order, fmt=fmt)
+        elif fam.key == "ephys_activity":
+            from meanap.pipeline.plotting_step2 import plot_step2_group_comparisons
+            plot_step2_group_comparisons(
+                recordings, _ephys_stats(ctx), out_dir, order, fmt=fmt)
+        else:  # subnetwork
+            summary, node = _subnetwork_rows(ctx)
+            gp.plot_subnetwork_group_comparisons(summary, node, out_dir, order, fmt=fmt)
+
+    return sorted(p for p in out_dir.rglob(f"*.{fmt}")
+                  if p.is_file() and p not in before)
+
+
+def cached_figure(
+    ctx: RenderContext,
+    cache,
+    recording: str,
+    lag: int,
+    figure: str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> tuple[Path, bool]:
+    """One figure, rendered once per (figure, style, format) and cached.
+
+    Returns ``(path, was_cached)``. Single figures are ~0.1 s so the cache
+    matters less than it does for a family, but flicking back and forth between
+    two plots is the commonest thing a reader does, and it should be instant.
+    """
+    from meanap.pipeline.render_cache import bundle_identity, cache_key
+
+    key = cache_key(bundle_identity(ctx.root), f"fig:{recording}:{lag}:{figure}",
+                    fmt=fmt, dpi=dpi, overrides=overrides)
+    files, was_cached = cache.get_or_render(
+        key,
+        lambda dest: [render_figure(ctx, recording, lag, figure, dest,
+                                    fmt=fmt, dpi=dpi, overrides=overrides)],
+    )
+    return files[0], was_cached
+
+
+def gallery(
+    ctx: RenderContext,
+    family: str,
+    cache,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> tuple[list[Path], bool]:
+    """A family's figures, rendered once and served from *cache* thereafter.
+
+    Returns ``(files, was_cached)``. This is what a viewer should call to show
+    a family: the first request pays the render (about six seconds for the
+    109-figure network family at thumbnail resolution), every later one is a
+    directory listing.
+
+    ``dpi`` defaults to :data:`~meanap.pipeline.figure_output.DEFAULT_THUMBNAIL_DPI`
+    because the caller is a gallery; pass ``dpi=None`` explicitly via
+    :func:`render_group_family` when you want the authored resolution.
+    """
+    from meanap.pipeline.figure_output import DEFAULT_THUMBNAIL_DPI
+    from meanap.pipeline.render_cache import bundle_identity, cache_key
+
+    if dpi is None:
+        dpi = DEFAULT_THUMBNAIL_DPI
+    key = cache_key(bundle_identity(ctx.root), family,
+                    fmt=fmt, dpi=dpi, overrides=overrides)
+    return cache.get_or_render(
+        key,
+        lambda dest: render_group_family(
+            ctx, family, dest, fmt=fmt, dpi=dpi, overrides=overrides),
+    )
+
+
+def available_activity_figures(ctx: RenderContext, recording: str) -> list[FigureSpec]:
+    """Which step-2 activity figures this recording can produce.
+
+    Empty when the bundle has no spike times for it — the raster and the
+    burst-detection detail are drawn from spike times, not from the summary
+    metrics, so without them there is nothing to redraw.
+    """
+    ephys = _ephys_stats(ctx).get(recording)
+    if not ephys or _spike_file(ctx, recording) is None:
+        return []
+    return [spec for spec in ACTIVITY_FIGURES
+            if spec.requires is None or spec.requires in ephys]
+
+
+def _spike_file(ctx: RenderContext, recording: str) -> Path | None:
+    from meanap.pipeline.resume import SPIKE_SUBDIR
+
+    path = ctx.root / SPIKE_SUBDIR / f"{recording}_spikes.npz"
+    return path if path.exists() else None
+
+
+def _activity_batch_max(ctx: RenderContext) -> dict:
+    """Pooled per-channel maxima, recomputed exactly as step 2 does.
+
+    These set the shared colour ceiling for the batch-scaled heatmap panels, so
+    getting them from the whole batch rather than one recording is what keeps a
+    rebuilt heatmap identical to the pipeline's.
+    """
+    stats = _ephys_stats(ctx)
+    out: dict = {}
+    for metric in _ACTIVITY_BATCH_METRICS:
+        maxes = [
+            float(np.nanmax(e[metric]))
+            for e in stats.values()
+            if e.get(metric) is not None and np.size(e[metric]) > 0
+            and np.any(np.isfinite(e[metric]))
+        ]
+        out[metric] = max(maxes) if maxes else None
+    return out
+
+
+def render_activity_figure(
+    ctx: RenderContext,
+    recording: str,
+    figure: str,
+    out_dir: Path | str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> Path:
+    """Redraw one step-2 activity figure from the bundle.
+
+    Same contract as :func:`render_figure`, for the other per-recording family:
+    it calls ``plot_neuronal_activity_checks`` — the function the pipeline
+    calls — with the spike times and metrics reassembled from the bundle.
+    """
+    from meanap.pipeline.figure_output import figure_dpi
+    from meanap.pipeline.io import load_spike_times_npz
+    from meanap.pipeline.plotting_step2 import plot_neuronal_activity_checks
+    from meanap.pipeline.spreadsheet import ground_spike_times_dict, parse_ground_electrodes
+
+    ephys = _ephys_stats(ctx).get(recording)
+    spike_path = _spike_file(ctx, recording)
+    if not ephys or spike_path is None:
+        raise ValueError(
+            f"No step-2 activity data for {recording} in this bundle — it needs "
+            "both ephys_results.json and the spike times.")
+
+    params, _ = _apply_overrides(ctx.params, overrides)
+    rec = ctx.recordings.get(recording) or RecordingInfo(
+        filename=recording, div=0.0, group="")
+
+    data = np.load(spike_path)
+    fs = float(data["fs"][0])
+    channels = data["channels"]
+    n_channels = len(channels)
+    duration_s = float(data["duration_s"][0]) if "duration_s" in data else None
+    if duration_s is None:
+        raise ValueError(
+            f"{spike_path.name} has no stored duration; it predates express mode "
+            "and the raster cannot be scaled without it.")
+
+    # Same spike-time selection step 2 makes, including grounding — a grounded
+    # electrode must stay empty in the raster.
+    full = load_spike_times_npz(spike_path)
+    spike_times_dict = {
+        ch: full.get(ch, {}).get(params.spikes_method, np.array([]))
+        for ch in range(n_channels)
+    }
+    ground = parse_ground_electrodes(rec.ground)
+    if ground:
+        spike_times_dict = ground_spike_times_dict(spike_times_dict, channels, ground)
+
+    batch_max = _activity_batch_max(ctx)
+    with figure_dpi(dpi):
+        written = plot_neuronal_activity_checks(
+            rec=rec, params=params, spike_times_dict=spike_times_dict,
+            n_channels=n_channels, chs=channels, fs=fs, duration_s=duration_s,
+            ephys=ephys, output_root=Path(out_dir),
+            spike_freq_max=batch_max.get("FR"), batch_max=batch_max,
+            fmt=fmt, only=figure,
+        )
+    if not written:
+        raise ValueError(
+            f"'{figure}' is not one of the activity figures available for "
+            f"{recording}. Use available_activity_figures() to list them.")
+    return written[0]
+
+
+def _recording_arrays(ctx: RenderContext, recording: str):
+    """``(channels, coords, markers)`` for one recording, from its state file.
+
+    ``coords`` is ``None`` on the electrophysiology path: node positions there
+    come from the MEA channel layout, which the plotters derive from
+    ``params.channel_layout`` and the channel list, so storing them would be
+    redundant.
+    """
+    path = _state_file(ctx.root, recording)
+    if path is None:
+        raise ValueError(f"No stored state for {recording} in {ctx.root}")
+    with np.load(path) as data:
+        channels = np.asarray(data["channels"])
+        coords = np.asarray(data["coords"]) if "coords" in data.files else None
+        markers = None
+        if "marker_matrix" in data.files:
+            markers = (np.asarray(data["marker_matrix"]),
+                       [str(n) for n in data["marker_names"]])
+    return channels, coords, markers

--- a/src/meanap/pipeline/render_cache.py
+++ b/src/meanap/pipeline/render_cache.py
@@ -1,0 +1,149 @@
+"""Cache for figures rendered from a bundle.
+
+The batch comparison families are produced by plotters that emit a whole folder
+in one call — ``plot_step4_group_comparisons`` writes all 109 of its figures
+per invocation and cannot be asked for just one. So a gallery cannot render
+lazily as the reader scrolls; it renders the family, or it renders nothing.
+
+That is affordable if it happens once. At the thumbnail resolution
+(:data:`~meanap.pipeline.figure_output.DEFAULT_THUMBNAIL_DPI`) a 109-figure
+family takes about six seconds; every view after the first should be a file
+read. This module is that "after the first".
+
+Entries are keyed by everything that can change a pixel — the bundle's
+identity, the family, the image format, the resolution, and any styling
+overrides — so a restyled view is a different entry rather than a stale hit.
+The key deliberately does *not* include a timestamp: the same bundle rendered
+the same way must hit, or the cache is pointless.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["RenderCache", "cache_key"]
+
+
+def cache_key(
+    bundle_id: str,
+    family: str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> str:
+    """A stable digest of everything that affects the rendered output."""
+    payload = json.dumps(
+        {
+            "bundle": bundle_id,
+            "family": family,
+            "fmt": fmt,
+            "dpi": dpi,
+            # Sorted so two equivalent override dicts share one entry.
+            "overrides": sorted((overrides or {}).items(), key=lambda kv: kv[0]),
+        },
+        sort_keys=True, default=str,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:20]
+
+
+def bundle_identity(path: Path | str) -> str:
+    """Identify a bundle by content, not by name.
+
+    Two people can hold the same analysis under different filenames, and one
+    person can overwrite a bundle in place while keeping its name. Hashing the
+    bytes gets both cases right; for bundles of a megabyte or so it costs
+    milliseconds.
+    """
+    p = Path(path)
+    if not p.is_file():
+        # An unpacked output folder: fall back to its resolved path plus the
+        # metrics file's mtime, which is the thing a re-run would change.
+        metrics = p / "4_NetworkActivity" / "netmet_results.json"
+        stamp = metrics.stat().st_mtime_ns if metrics.exists() else 0
+        return hashlib.sha256(f"{p.resolve()}:{stamp}".encode()).hexdigest()[:20]
+
+    digest = hashlib.sha256()
+    with open(p, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()[:20]
+
+
+@dataclass
+class RenderCache:
+    """A directory of rendered figure sets, addressed by :func:`cache_key`.
+
+    Not thread-safe against concurrent *writes* of the same key: two requests
+    racing on a cold entry would both render. That is wasteful but harmless —
+    the render is deterministic, so whichever finishes last writes the same
+    bytes. Serialising it would mean holding a lock across a six-second render,
+    which is worse.
+    """
+
+    root: Path
+    _owned_tempdir: str | None = None
+
+    @classmethod
+    def in_temp(cls) -> "RenderCache":
+        """A cache in a temporary directory, cleaned up by :meth:`close`."""
+        tmp = tempfile.mkdtemp(prefix="meanap-render-cache-")
+        return cls(root=Path(tmp), _owned_tempdir=tmp)
+
+    def path_for(self, key: str) -> Path:
+        return self.root / key
+
+    def get(self, key: str) -> list[Path] | None:
+        """Cached files for *key*, or ``None`` on a miss.
+
+        A directory without its ``.complete`` marker counts as a miss: it means
+        a previous render died partway, and half a gallery is worse than none.
+        """
+        entry = self.path_for(key)
+        if not (entry / ".complete").exists():
+            return None
+        return sorted(p for p in entry.rglob("*")
+                      if p.is_file() and p.name != ".complete")
+
+    def put(self, key: str, render) -> list[Path]:
+        """Render into the entry for *key* and mark it complete.
+
+        ``render`` is called with the destination directory and should return
+        the files it wrote. A failed render leaves no marker, so the next
+        request retries rather than serving a partial set.
+        """
+        entry = self.path_for(key)
+        if entry.exists():
+            shutil.rmtree(entry, ignore_errors=True)
+        entry.mkdir(parents=True, exist_ok=True)
+        written = list(render(entry))
+        (entry / ".complete").write_text(str(len(written)))
+        return written
+
+    def get_or_render(self, key: str, render) -> tuple[list[Path], bool]:
+        """Return ``(files, was_cached)``."""
+        hit = self.get(key)
+        if hit is not None:
+            return hit, True
+        return self.put(key, render), False
+
+    def clear(self) -> None:
+        if self.root.exists():
+            shutil.rmtree(self.root, ignore_errors=True)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def close(self) -> None:
+        if self._owned_tempdir is not None:
+            shutil.rmtree(self._owned_tempdir, ignore_errors=True)
+            self._owned_tempdir = None
+
+    def __enter__(self) -> "RenderCache":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()

--- a/src/meanap/pipeline/resume.py
+++ b/src/meanap/pipeline/resume.py
@@ -7,13 +7,20 @@ from. Results still go to a *fresh* output folder — the prior run is only ever
 read — which is the behaviour mirrored here.
 
 Because this port writes discrete per-recording files rather than MATLAB's one
-chained ``.mat`` per recording, resuming reduces to a search path. Only two
+chained ``.mat`` per recording, resuming reduces to a search path. Only three
 artefacts cross step boundaries:
 
 ===========================  ================================================
 Step 1 → Steps 2, 3, 4       ``1_SpikeDetection/1A_SpikeDetectedData/<rec>_spikes.npz``
 Step 3 → Step 4              ``ExperimentMatFiles/<rec>_adjM.npz``
+CAT-NAP step 2 → step 4      ``ExperimentMatFiles/<rec>_catnap.npz``
 ===========================  ================================================
+
+The CAT-NAP (``suite2pMode``) path has no step 1 or 3 — adjacency is built in
+step 2, as it is in MATLAB — so step 4 is its only resumable boundary. Its file
+is deliberately named differently from the ephys ``_adjM.npz``: the two hold
+different things, and pointing a CAT-NAP resume at an ephys output folder (or
+the reverse) should report a missing input rather than fail deep inside a load.
 
 :class:`InputLocator` resolves those two lookups against, in order:
 
@@ -45,10 +52,17 @@ __all__ = [
     "missing_step_inputs",
     "SPIKE_SUBDIR",
     "ADJM_SUBDIR",
+    "CATNAP_SUFFIX",
+    "ADJM_SUFFIX",
 ]
 
 SPIKE_SUBDIR = Path("1_SpikeDetection") / "1A_SpikeDetectedData"
 ADJM_SUBDIR = Path("ExperimentMatFiles")
+#: Per-recording array files inside :data:`ADJM_SUBDIR`. Both suffixes are
+#: owned here rather than by the pipelines that write them, so this module
+#: stays the single place describing the output layout.
+ADJM_SUFFIX = "_adjM.npz"       # electrophysiology, step 3
+CATNAP_SUFFIX = "_catnap.npz"   # CAT-NAP, step 2
 
 
 @dataclass(frozen=True)
@@ -73,7 +87,19 @@ class InputLocator:
 
     def adjm_file(self, recording_name: str) -> Path | None:
         """Path to a recording's Step-3 adjacency file, or ``None`` if absent."""
-        name = f"{recording_name}_adjM.npz"
+        name = f"{recording_name}{ADJM_SUFFIX}"
+        candidates = [self.output_root / ADJM_SUBDIR / name]
+        if self.prior_root is not None:
+            candidates.append(self.prior_root / ADJM_SUBDIR / name)
+        return _first_existing(candidates)
+
+    def catnap_file(self, recording_name: str) -> Path | None:
+        """Path to a recording's CAT-NAP step-2 file, or ``None`` if absent.
+
+        ``spike_dir`` is not consulted: it holds externally *spike-detected*
+        MEA data, which has nothing to say about a suite2p recording.
+        """
+        name = f"{recording_name}{CATNAP_SUFFIX}"
         candidates = [self.output_root / ADJM_SUBDIR / name]
         if self.prior_root is not None:
             candidates.append(self.prior_root / ADJM_SUBDIR / name)
@@ -102,6 +128,33 @@ def _first_existing(candidates: list[Path]) -> Path | None:
     return None
 
 
+#: Bundles unpacked this process, keyed by source path. Held for the process
+#: lifetime because :class:`InputLocator` is a plain-paths dataclass that gets
+#: pickled into spawned workers — the extracted directory has to outlive the
+#: locator, and re-unpacking per worker would be both slower and a different
+#: path in each one.
+_UNPACKED_BUNDLES: dict[Path, Path] = {}
+
+
+def _unpack_prior_bundle(path: Path) -> Path:
+    """Resolve a ``.meanap`` prior-analysis path to the folder it unpacks to."""
+    from meanap.pipeline.bundle import BUNDLE_SUFFIX, open_bundle
+
+    resolved = path.resolve()
+    if resolved in _UNPACKED_BUNDLES:
+        return _UNPACKED_BUNDLES[resolved]
+    if resolved.suffix != BUNDLE_SUFFIX:
+        raise ValueError(
+            f"Previous analysis path is a file, not a folder: {resolved}. Point it "
+            f"at an OutputData… folder or a '{BUNDLE_SUFFIX}' bundle."
+        )
+    # Deliberately not closed: the run reads from it throughout, and the OS
+    # reclaims the temp directory. Bundles are ~1 MB.
+    bundle = open_bundle(resolved)
+    _UNPACKED_BUNDLES[resolved] = bundle.root
+    return bundle.root
+
+
 def build_input_locator(params: Params, output_root: Path) -> InputLocator:
     """Build the locator for a run, validating the configured paths up front.
 
@@ -118,6 +171,12 @@ def build_input_locator(params: Params, output_root: Path) -> InputLocator:
                 "disable prior analysis."
             )
         prior_root = Path(params.prior_analysis_path).expanduser()
+        # A ``.meanap`` bundle is an output folder in a zip, so resuming from
+        # one is just resuming from where it unpacks to — no lookup below needs
+        # to know the difference. This is what lets the file you share double as
+        # the file you re-run from.
+        if prior_root.is_file():
+            prior_root = _unpack_prior_bundle(prior_root)
         if not prior_root.is_dir():
             raise ValueError(f"Previous analysis folder does not exist: {prior_root}")
         if not (prior_root / SPIKE_SUBDIR).is_dir() and not (prior_root / ADJM_SUBDIR).is_dir():
@@ -142,6 +201,8 @@ def missing_step_inputs(
     locator: InputLocator,
     recordings: list[RecordingInfo],
     start_step: int,
+    *,
+    suite2p_mode: bool = False,
 ) -> dict[str, list[str]]:
     """Which recordings lack the inputs the *starting* step needs.
 
@@ -149,14 +210,21 @@ def missing_step_inputs(
     produce during this run. Returns ``{recording_name: [missing artefact, …]}``
     for recordings that would be skipped, so the caller can fail fast (nothing
     resolvable) or warn (only some missing).
+
+    ``suite2p_mode`` selects the CAT-NAP artefacts instead of the ephys ones —
+    a different file, and only one resumable boundary (step 4).
     """
     missing: dict[str, list[str]] = {}
     for rec in recordings:
         gaps: list[str] = []
-        if start_step >= 2 and locator.spike_file(rec.filename) is None:
-            gaps.append("spike times (step 1)")
-        if start_step >= 4 and locator.adjm_file(rec.filename) is None:
-            gaps.append("adjacency matrices (step 3)")
+        if suite2p_mode:
+            if start_step >= 4 and locator.catnap_file(rec.filename) is None:
+                gaps.append("adjacency matrices + activity stats (step 2)")
+        else:
+            if start_step >= 2 and locator.spike_file(rec.filename) is None:
+                gaps.append("spike times (step 1)")
+            if start_step >= 4 and locator.adjm_file(rec.filename) is None:
+                gaps.append("adjacency matrices (step 3)")
         if gaps:
             missing[rec.filename] = gaps
     return missing

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Callable
 
-from meanap.params import Params
+from meanap.params import PARAMS_FILENAME, Params, save_params
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
 from meanap.pipeline.io import (
     RAW_EXTENSIONS,
@@ -70,6 +70,14 @@ def run_pipeline(
     )
     log(f"Output folder ready: {output_root}")
 
+    # Snapshot the settings alongside the results. Until this, an output folder
+    # recorded nothing about how it was produced — and every plotting routine
+    # reads Params, so reconstructing a figure later needs it.
+    try:
+        save_params(params, output_root)
+    except Exception as e:
+        log(f"Warning: could not write {PARAMS_FILENAME}: {e}")
+
     # Raises on a misconfigured prior-analysis/spike-data path, before any work.
     locator = build_input_locator(params, output_root)
     if locator.is_resuming:
@@ -88,12 +96,27 @@ def run_pipeline(
     # the raw MEA .mat files those steps expect don't exist for 2P data.
     if params.suite2p_mode:
         log("\n=== CAT-NAP (suite2p) pipeline ===")
-        from meanap.catnap.pipeline import run_catnap_pipeline
-        from meanap.pipeline.rng import make_rng
+        from meanap.catnap.pipeline import RESUME_STEP, run_catnap_pipeline
+
+        # CAT-NAP has no step 1 or 3 — adjacency is built in step 2, as in
+        # MATLAB — so step 4 is the only boundary the step range can act on.
+        # Say so rather than silently ignoring a setting the Pipeline tab
+        # happily lets the user change.
+        if 1 < params.start_analysis_step < RESUME_STEP:
+            log(f"  Note: starting at step {params.start_analysis_step} is the same as "
+                "starting at step 1 in CAT-NAP mode — only step 4 can be resumed.")
+        if params.stop_analysis_step < RESUME_STEP:
+            log(f"  Note: stopping at step {params.stop_analysis_step} has no effect in "
+                "CAT-NAP mode — the calcium path runs as one step.")
+        if params.start_analysis_step >= RESUME_STEP:
+            _check_catnap_resume_inputs(locator, recordings, params, log)
+
         run_catnap_pipeline(
-            params, recordings, output_root, log, should_cancel,
-            rng=make_rng(params.random_seed, "catnap"),
+            params, recordings, output_root, log, should_cancel, locator=locator,
         )
+        if params.express_mode:
+            _write_run_bundle(params, recordings, output_root, log, mode="catnap",
+                              embedded_figures=["2p_traces"] if params.num_2p_traces else [])
         return output_root
 
     start = params.start_analysis_step
@@ -187,6 +210,15 @@ def run_pipeline(
     else:
         log("Skipping step 4 (network activity) — outside the selected step range.")
 
+    if params.express_mode:
+        # Spike-detection checks are the one family here that can't be rebuilt
+        # from the bundle — they need the raw voltage — so they are kept as
+        # images and named in the manifest.
+        _write_run_bundle(
+            params, recordings, output_root, log, mode="ephys",
+            embedded_figures=["spike_detection_checks"] if start <= 1 <= stop else [],
+        )
+
     if params.time_processes:
         total_duration = time.perf_counter() - pipeline_start
         for step_num in (1, 2, 3, 4, 5):
@@ -207,6 +239,55 @@ def run_pipeline(
             log(f"Warning: could not save step_durations.json: {e}")
 
     return output_root
+
+
+def _write_run_bundle(
+    params: Params, recordings, output_root: Path, log, *, mode: str,
+    embedded_figures: list[str] | None = None,
+) -> Path | None:
+    """Pack an express run into one shareable ``.meanap`` file.
+
+    Guarded: the output folder is already complete and usable by this point, so
+    a packing failure costs the run nothing but the convenience file.
+    """
+    from meanap.pipeline.bundle import build_manifest, write_bundle
+
+    try:
+        manifest = build_manifest(params, recordings, mode=mode,
+                                  embedded_figures=embedded_figures)
+        path = write_bundle(output_root, manifest)
+        size_mb = path.stat().st_size / 1e6
+        log(f"\nBundle written: {path}  ({size_mb:.1f} MB)")
+        log("  Open it in viewer mode, or pass it as the prior analysis folder "
+            "to re-run from it.")
+        return path
+    except Exception as e:
+        log(f"Warning: could not write the run bundle: {e}")
+        return None
+
+
+def _check_catnap_resume_inputs(locator, recordings, params: Params, log) -> None:
+    """Fail fast when a CAT-NAP step-4 resume has nothing to resume from.
+
+    Same reasoning as the ephys check in :func:`run_pipeline`: without it a
+    mis-set path just logs "SKIP" for every recording and the run "succeeds"
+    with empty CSVs.
+    """
+    missing = missing_step_inputs(
+        locator, recordings, params.start_analysis_step, suite2p_mode=True)
+    if len(missing) == len(recordings):
+        detail = "; ".join(f"{name}: {', '.join(gaps)}" for name, gaps in missing.items())
+        hint = (
+            "Enable 'Use prior analysis' and set the previous analysis folder"
+            if not locator.is_resuming
+            else "Check that the previous analysis folder holds these recordings"
+        )
+        raise ValueError(
+            f"Cannot start at step {params.start_analysis_step}: no recording has the "
+            f"inputs it needs ({detail}). {hint}, or start at step 1."
+        )
+    for name, gaps in missing.items():
+        log(f"  ! {name} will be skipped — missing {', '.join(gaps)}")
 
 
 def _run_step1_spike_detection(

--- a/src/meanap/pipeline/step2.py
+++ b/src/meanap/pipeline/step2.py
@@ -191,7 +191,10 @@ def _run_step2_neuronal_activity(
         batch_max[metric] = max(maxes) if maxes else None
     spike_freq_max = batch_max.get("FR")
 
-    for ctx in plot_contexts:
+    # Express mode keeps every number and drops every picture here: the step-2
+    # figures are all functions of `ephys`, which is written to JSON and CSV
+    # just below, so a viewer can redraw them from the bundle.
+    for ctx in [] if params.express_mode else plot_contexts:
         check_cancel(should_cancel)
         log(f"  [{ctx['rec'].filename}] generating neuronal activity plots...")
         plot_neuronal_activity_checks(
@@ -208,17 +211,18 @@ def _run_step2_neuronal_activity(
             batch_max=batch_max,
         )
 
-    log("  Generating group comparison plots...")
-    from meanap.pipeline.plotting_step2 import plot_step2_group_comparisons
-    try:
-        plot_step2_group_comparisons(
-            recordings,
-            all_ephys,
-            out_dir,
-            params.custom_grp_order
-        )
-    except Exception as e:
-        log(f"  Warning: failed to generate group comparison plots: {e}")
+    if not params.express_mode:
+        log("  Generating group comparison plots...")
+        from meanap.pipeline.plotting_step2 import plot_step2_group_comparisons
+        try:
+            plot_step2_group_comparisons(
+                recordings,
+                all_ephys,
+                out_dir,
+                params.custom_grp_order
+            )
+        except Exception as e:
+            log(f"  Warning: failed to generate group comparison plots: {e}")
         
     try:
         with open(out_dir / "ephys_results.json", "w") as f:

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from meanap.network_plot import NetworkStyle
 
 import numpy as np
 import pandas as pd
@@ -262,7 +265,10 @@ def _plot_recording_lag(
     sub_dir: str | None = None,
     background: tuple | None = None,
     node_size_scale: float | str = 1.0,
-) -> None:
+    fmt: str = "png",
+    only: str | None = None,
+    style: "NetworkStyle | None" = None,
+) -> list[Path]:
     """Draw every step-4A plot for one recording/lag.
 
     Produces both the individual-scaled plots (each colored/sized to this
@@ -295,20 +301,42 @@ def _plot_recording_lag(
     ``node_size_scale`` is forwarded to ``plot_network``; ``"auto"`` sizes nodes
     from how densely they are packed, which two-photon fields need and MEA
     layouts are unaffected by.
+    ``fmt`` is the image format — the suffix drives matplotlib, so ``"svg"`` (or
+    ``"pdf"``) yields editable vector output for figures headed to a paper.
+    ``only`` restricts the call to the single figure with that base name, which
+    is how the viewer renders one plot per request instead of the whole set.
+    Returns the paths actually written.
     """
     if "adjMsub" not in metrics:
-        return
+        return []
 
     rec_out_dir = out_dir / "4A_IndividualNetworkAnalysis" / rec.group / rec.filename
     lag_dir = rec_out_dir / f"{lag_ms}mslag"
     if sub_dir:
         lag_dir = lag_dir.joinpath(*str(sub_dir).split("/"))
 
-    plot_connectivity_stats(
-        metrics["adjMsub"], metrics["ND"], metrics["NS"], lag_ms,
-        rec.filename, lag_dir / f"1_adjM{lag_ms}msConnectivityStats.png",
-        exclude_edges_below_threshold=params.exclude_edges_below_threshold,
-    )
+    written: list[Path] = []
+
+    def want(name: str) -> Path | None:
+        """Path for one figure, or ``None`` when this render skips it.
+
+        Centralising the naming here is what lets the same call sites serve
+        both the pipeline (every figure, PNG) and the viewer (one figure, any
+        format) without a second copy of the figure list.
+        """
+        stem = Path(name).stem
+        if only is not None and stem != only:
+            return None
+        path = lag_dir / f"{stem}.{fmt}"
+        written.append(path)
+        return path
+
+    if (p := want(f"1_adjM{lag_ms}msConnectivityStats.png")) is not None:
+        plot_connectivity_stats(
+            metrics["adjMsub"], metrics["ND"], metrics["NS"], lag_ms,
+            rec.filename, p,
+            exclude_edges_below_threshold=params.exclude_edges_below_threshold,
+        )
 
     nd_max = batch_bounds["ND"][1] if batch_bounds.get("ND") else None
     ns_max = batch_bounds["NS"][1] if batch_bounds.get("NS") else None
@@ -351,29 +379,31 @@ def _plot_recording_lag(
             z2 = metrics[color_key] if color_key is not None else None
 
             # Individual-scaled (this recording's own range).
-            plot_spatial_network(
-                metrics["adjMsub"], channels_active, params.channel_layout,
-                z, z2, color_name, lag_ms, rec.filename,
-                lag_dir / fname, z_name=size_name,
-                coords_override=coords_active, cell_types=ct_active,
-                node_size_scale=node_size_scale,
-            )
+            if (p := want(fname)) is not None:
+                plot_spatial_network(
+                    metrics["adjMsub"], channels_active, params.channel_layout,
+                    z, z2, color_name, lag_ms, rec.filename,
+                    p, z_name=size_name,
+                    coords_override=coords_active, cell_types=ct_active,
+                    node_size_scale=node_size_scale, style=style,
+                )
 
             # Batch-scaled variant + side-by-side combined figure, if we have a
             # batch max for the size metric.
             if size_max is not None:
                 color_bounds = batch_bounds.get(color_key) if color_key is not None else None
                 scaled_name = fname.replace("_MEA_NetworkPlot", "_scaled_MEA_NetworkPlot", 1)
-                plot_spatial_network(
-                    metrics["adjMsub"], channels_active, params.channel_layout,
-                    z, z2, color_name, lag_ms, rec.filename,
-                    lag_dir / scaled_name, z_name=size_name,
-                    z_scale_override=size_max,
-                    z2_bounds_override=color_bounds,
-                    edge_bounds_override=_EDGE_BATCH_BOUNDS,
-                    coords_override=coords_active, cell_types=ct_active,
-                    node_size_scale=node_size_scale,
-                )
+                if (p := want(scaled_name)) is not None:
+                    plot_spatial_network(
+                        metrics["adjMsub"], channels_active, params.channel_layout,
+                        z, z2, color_name, lag_ms, rec.filename,
+                        p, z_name=size_name,
+                        z_scale_override=size_max,
+                        z2_bounds_override=color_bounds,
+                        edge_bounds_override=_EDGE_BATCH_BOUNDS,
+                        coords_override=coords_active, cell_types=ct_active,
+                        node_size_scale=node_size_scale, style=style,
+                    )
                 # MATLAB names the combined figure "<n>_combined_MEA_NetworkPlot"
                 # plus "_<color legend name>" when there's a colour metric (e.g.
                 # "10_combined_MEA_NetworkPlot_Average controllability"), rather
@@ -383,69 +413,81 @@ def _plot_recording_lag(
                 if color_key is not None:
                     combined_name += f"_{color_name}"
                 combined_name += ".png"
-                plot_spatial_network_combined(
-                    metrics["adjMsub"], channels_active, params.channel_layout,
-                    z, z2, color_name, lag_ms, rec.filename,
-                    lag_dir / combined_name, z_name=size_name,
-                    z_scale_override=size_max,
-                    z2_bounds_override=color_bounds,
-                    edge_bounds_override=_EDGE_BATCH_BOUNDS,
-                    coords_override=coords_active,
-                )
+                if (p := want(combined_name)) is not None:
+                    plot_spatial_network_combined(
+                        metrics["adjMsub"], channels_active, params.channel_layout,
+                        z, z2, color_name, lag_ms, rec.filename,
+                        p, z_name=size_name,
+                        z_scale_override=size_max,
+                        z2_bounds_override=color_bounds,
+                        edge_bounds_override=_EDGE_BATCH_BOUNDS,
+                        coords_override=coords_active,
+                    )
     except ValueError as e:
         log(f"  [{rec.filename}] skipped spatial network plot: {e}")
 
     if background is not None:
         try:
-            plot_network_beside_field(
-                metrics["adjMsub"], channels_active, params.channel_layout,
-                metrics["ND"], lag_ms, rec.filename,
-                lag_dir / "12_MeanImageAndNetwork.png",
-                background=background,
-                coords_override=coords_active,
-                node_size_scale=node_size_scale,
-            )
+            if (p := want("12_MeanImageAndNetwork.png")) is not None:
+                plot_network_beside_field(
+                    metrics["adjMsub"], channels_active, params.channel_layout,
+                    metrics["ND"], lag_ms, rec.filename, p,
+                    background=background,
+                    coords_override=coords_active,
+                    node_size_scale=node_size_scale,
+                )
         except Exception as e:
             log(f"  [{rec.filename}] skipped field-of-view figure: {e}")
 
     if "PC" in metrics:
-        plot_node_cartography(
-            metrics["PC"], metrics["Z"], params, lag_ms, rec.filename,
-            lag_dir / f"9_adjM{lag_ms}msNodeCartography.png",
-            boundaries=metrics.get("cartographyBoundaries"),
-            nd_cart_div=metrics.get("NdCartDiv"),
-        )
+        if (p := want(f"9_adjM{lag_ms}msNodeCartography.png")) is not None:
+            plot_node_cartography(
+                metrics["PC"], metrics["Z"], params, lag_ms, rec.filename, p,
+                boundaries=metrics.get("cartographyBoundaries"),
+                nd_cart_div=metrics.get("NdCartDiv"),
+            )
 
     if "NdCartDiv" in metrics:
-        plot_circular_cartography_network(
-            metrics["adjMsub"], metrics["NdCartDiv"],
-            lag_ms, rec.filename,
-            lag_dir / "9_circular_NetworkPlotNodeCartography.png",
-            edge_thresh=params.exclude_edges_below_threshold * 0.0001,
-        )
+        if (p := want("9_circular_NetworkPlotNodeCartography.png")) is not None:
+            plot_circular_cartography_network(
+                metrics["adjMsub"], metrics["NdCartDiv"],
+                lag_ms, rec.filename, p,
+                edge_thresh=params.exclude_edges_below_threshold * 0.0001,
+            )
 
     if "Ci" in metrics:
-        plot_circular_module_network(
-            metrics["adjMsub"], metrics["Ci"], metrics["ND"],
-            lag_ms, rec.filename,
-            lag_dir / "6_circular_NetworkPlotNodedegreeModule.png",
-        )
+        if (p := want("6_circular_NetworkPlotNodedegreeModule.png")) is not None:
+            plot_circular_module_network(
+                metrics["adjMsub"], metrics["Ci"], metrics["ND"],
+                lag_ms, rec.filename, p,
+            )
 
     try:
-        plot_graph_metrics_by_node(
-            nd=metrics["ND"],
-            mew=metrics["MEW"],
-            ns=metrics["NS"],
-            z=metrics.get("Z"),
-            eloc=metrics.get("Eloc"),
-            pc=metrics.get("PC"),
-            bc=metrics.get("BC"),
-            lag_ms=lag_ms,
-            recording_name=rec.filename,
-            out_path=lag_dir / f"7_adjM{lag_ms}msGraphMetricsByNode.png",
-        )
+        if (p := want(f"7_adjM{lag_ms}msGraphMetricsByNode.png")) is not None:
+            plot_graph_metrics_by_node(
+                nd=metrics["ND"],
+                mew=metrics["MEW"],
+                ns=metrics["NS"],
+                z=metrics.get("Z"),
+                eloc=metrics.get("Eloc"),
+                pc=metrics.get("PC"),
+                bc=metrics.get("BC"),
+                lag_ms=lag_ms,
+                recording_name=rec.filename,
+                out_path=p,
+                # The half-violin jitter is the only randomness in the 4A set.
+                # Left unseeded it made this one figure differ between two
+                # otherwise-identical seeded runs — and between the pipeline's
+                # copy and a viewer's. Derived per recording+lag like every
+                # other stochastic stage (see pipeline/rng.py).
+                rng=make_rng(params.random_seed, "step4-plots", rec.filename, lag_ms),
+            )
     except Exception as e:
         log(f"  [{rec.filename}] skipped graph-metrics-by-node plot: {e}")
+
+    # ``want`` records intent; a plot guarded by a try/except may not have
+    # produced its file, so report what is actually on disk.
+    return [p for p in written if p.exists()]
 
 
 # Peak per-worker RAM for Step 4: NMF's downsampled spike matrix + sklearn NMF
@@ -563,6 +605,12 @@ def _step4_plot_one(
 
     def _log(msg: str) -> None:
         logs.append(msg)
+
+    # Every 4A figure is a function of `metrics` + the stored adjacency, both of
+    # which the bundle carries, so express mode skips them and the viewer
+    # redraws on demand.
+    if params.express_mode:
+        return rec.filename, logs
 
     for lag_key, metrics in rec_results.items():
         lag_ms = int(lag_key.replace("mslag", ""))
@@ -710,7 +758,11 @@ def _run_step4_network_metrics(
     # re-classify every node. Mirrors MEApipeline.m's autoSetCartographyBoundaries
     # barrier between per-recording ExtractNetMet and calNodeCartography.
     if params.auto_set_cartography_boundaries:
-        _apply_cartography_boundaries(params, all_results, log, out_dir=out_dir)
+        # out_dir=None suppresses the pooled PC/Z landscape scatter — a figure,
+        # and one the bundle's metrics can redraw.
+        _apply_cartography_boundaries(
+            params, all_results, log,
+            out_dir=None if params.express_mode else out_dir)
 
     # Pool node-level metrics across every recording for the batch-scaled plot
     # bounds.
@@ -809,16 +861,17 @@ def _run_step4_network_metrics(
     except Exception as e:
         log(f"  Warning: could not save network metrics results: {e}")
 
-    log("  Generating group comparison plots...")
-    from meanap.pipeline.plotting_step4 import plot_step4_group_comparisons
-    try:
-        plot_step4_group_comparisons(
-            recordings,
-            all_results,
-            out_dir,
-            params.custom_grp_order
-        )
-    except Exception as e:
-        log(f"  Warning: failed to generate group comparison plots: {e}")
+    if not params.express_mode:
+        log("  Generating group comparison plots...")
+        from meanap.pipeline.plotting_step4 import plot_step4_group_comparisons
+        try:
+            plot_step4_group_comparisons(
+                recordings,
+                all_results,
+                out_dir,
+                params.custom_grp_order
+            )
+        except Exception as e:
+            log(f"  Warning: failed to generate group comparison plots: {e}")
 
     log("  Step 4 complete.")

--- a/src/meanap/viewer/__init__.py
+++ b/src/meanap/viewer/__init__.py
@@ -1,0 +1,5 @@
+"""Local web viewer for MEA-NAP run bundles."""
+
+from meanap.viewer.server import ViewerService, serve
+
+__all__ = ["ViewerService", "serve"]

--- a/src/meanap/viewer/__main__.py
+++ b/src/meanap/viewer/__main__.py
@@ -1,0 +1,3 @@
+from meanap.viewer.server import main
+
+raise SystemExit(main())

--- a/src/meanap/viewer/controls.py
+++ b/src/meanap/viewer/controls.py
@@ -1,0 +1,133 @@
+"""The styling controls a viewer exposes, and how a request maps onto them.
+
+One declaration, used three ways: the page builds its form from it, the server
+coerces and validates query parameters against it, and the tests check that
+every knob is reachable. Keeping those in one place is what stops a control
+from existing in the UI but doing nothing on the backend — the failure mode
+that makes an interactive viewer untrustworthy.
+
+The values map onto :class:`~meanap.network_plot.NetworkStyle`, so they apply
+to the spatial network plots only. Violin plots and cartography scatters don't
+read them, which is why the family gallery hides this panel outright rather
+than showing controls that quietly do nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from meanap.network_plot import (
+    EDGE_THRESHOLD_METHODS, LAYOUT_OPTIONS, NetworkStyle,
+)
+
+__all__ = ["CONTROLS", "Control", "control_schema", "parse_overrides"]
+
+#: Colormaps offered for the node-colour metric. Perceptually uniform ones
+#: first — they are the defensible choice for a continuous metric — with the
+#: common diverging and legacy options after.
+COLORMAPS = [
+    "viridis", "plasma", "inferno", "magma", "cividis",
+    "coolwarm", "RdBu_r", "Spectral_r", "turbo", "jet",
+]
+
+NODE_SCALING_METHODS = ["Linear", "Log2", "Log10", "Square", "Cube", "Power"]
+
+
+@dataclass(frozen=True)
+class Control:
+    """One control: how to render it, and how to coerce what comes back."""
+
+    key: str
+    label: str
+    kind: str                      # "number" | "select"
+    default: object
+    options: list = field(default_factory=list)
+    minimum: float | None = None
+    maximum: float | None = None
+    step: float | None = None
+    #: Shown under the control in the page.
+    help: str = ""
+
+    def coerce(self, raw: str):
+        """Turn a query-string value into the type the style expects."""
+        if self.kind == "select":
+            if raw not in self.options:
+                raise ValueError(
+                    f"{self.key}: {raw!r} is not one of {self.options}")
+            return raw
+        value = float(raw)
+        if self.minimum is not None and value < self.minimum:
+            raise ValueError(f"{self.key}: {value} is below {self.minimum}")
+        if self.maximum is not None and value > self.maximum:
+            raise ValueError(f"{self.key}: {value} is above {self.maximum}")
+        return int(value) if isinstance(self.default, int) else value
+
+
+_defaults = NetworkStyle()
+
+CONTROLS: tuple[Control, ...] = (
+    Control("layout", "Node layout", "select", _defaults.layout,
+            options=list(LAYOUT_OPTIONS),
+            help="Electrode/cell positions, or a layout derived from topology."),
+    Control("colormap", "Node colour map", "select", _defaults.colormap,
+            options=list(COLORMAPS),
+            help="Applied to the node-colour metric."),
+    Control("edge_threshold_method", "Edge threshold by", "select",
+            _defaults.edge_threshold_method, options=list(EDGE_THRESHOLD_METHODS),
+            help="How the threshold below is interpreted."),
+    Control("edge_threshold", "Edge threshold", "number", 0.0,
+            minimum=0.0, maximum=100.0, step=0.01,
+            help="A weight for 'Absolute value', otherwise a percentile."),
+    Control("max_edges", "Max edges drawn", "number", 0,
+            minimum=0, maximum=100000, step=25,
+            help="Keeps only the strongest N edges. 0 draws all of them."),
+    Control("node_size_scale", "Node size scale", "number", 1.0,
+            minimum=0.05, maximum=20.0, step=0.05),
+    Control("node_scaling_method", "Node scaling", "select",
+            _defaults.node_scaling_method, options=NODE_SCALING_METHODS,
+            help="How the size metric maps onto node radius."),
+    Control("node_scaling_power", "Scaling power", "number",
+            _defaults.node_scaling_power, minimum=0.1, maximum=6.0, step=0.1,
+            help="Exponent used when scaling is 'Power'."),
+    Control("min_node_size", "Min node size", "number", _defaults.min_node_size,
+            minimum=0.0, maximum=10.0, step=0.01),
+    Control("min_edge_width", "Min edge width", "number", _defaults.min_edge_width,
+            minimum=0.0, maximum=10.0, step=0.001),
+    Control("max_edge_width", "Max edge width", "number", _defaults.max_edge_width,
+            minimum=0.1, maximum=30.0, step=0.1),
+)
+
+
+def control_schema() -> list[dict]:
+    """The controls as plain data, for the page to build its form from."""
+    return [
+        {
+            "key": c.key, "label": c.label, "kind": c.kind, "default": c.default,
+            "options": c.options, "min": c.minimum, "max": c.maximum,
+            "step": c.step, "help": c.help,
+        }
+        for c in CONTROLS
+    ]
+
+
+def parse_overrides(query: dict[str, list[str]]) -> dict:
+    """Extract and coerce styling overrides from a parsed query string.
+
+    Only values that differ from the default are returned. That matters for
+    more than tidiness: an empty override dict means *no* ``NetworkStyle`` is
+    built, which is what keeps the viewer's default view byte-identical to the
+    figure the pipeline drew.
+    """
+    overrides: dict = {}
+    for control in CONTROLS:
+        raw = query.get(control.key, [None])[0]
+        if raw is None or raw == "":
+            continue
+        value = control.coerce(raw)
+        if value == control.default:
+            continue
+        # 0 means "unlimited" in the UI; NetworkStyle spells that None.
+        if control.key == "max_edges" and not value:
+            continue
+        overrides[control.key] = value
+    return overrides

--- a/src/meanap/viewer/page.py
+++ b/src/meanap/viewer/page.py
@@ -1,0 +1,406 @@
+"""The viewer's single HTML page.
+
+Kept as one self-contained string — no build step, no external assets, no CDN.
+A bundle gets shared with people who will run one command and expect a page;
+anything that needs npm or a network fetch fails that test.
+
+Two views, and the difference between them is the point:
+
+* **A recording's figure** — one spatial network plot at a time, with the full
+  Network Viewer control set live beside it. Every change re-requests the
+  figure from Python, so what is on screen is always something the pipeline
+  could have drawn.
+* **A comparison family** — a gallery of small multiples. The controls are
+  *hidden* here, not disabled: they style spatial network plots, and none of
+  the violin plots in these families read them. A greyed-out panel would still
+  imply the knobs mean something for this view.
+"""
+
+PAGE_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MEA-NAP viewer</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #16181d; --muted: #6b7280; --line: #e3e6ea;
+    --panel: #f7f8fa; --accent: #2563eb; --accent-soft: #eaf0fe;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #14161a; --fg: #e7e9ee; --muted: #9aa1ac; --line: #2a2e35;
+      --panel: #1b1e24; --accent: #6ea8fe; --accent-soft: #1e2836;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    display: grid; grid-template-columns: 260px 1fr 280px; height: 100vh;
+  }
+  @media (max-width: 900px) { body { grid-template-columns: 1fr; height: auto; } }
+
+  aside { border-right: 1px solid var(--line); overflow-y: auto; padding: 16px; }
+  aside.right { border-right: none; border-left: 1px solid var(--line); }
+  main { overflow-y: auto; padding: 20px 24px; min-width: 0; }
+
+  h1 { font-size: 15px; margin: 0 0 2px; letter-spacing: -0.01em; }
+  .sub { color: var(--muted); font-size: 12px; margin-bottom: 18px;
+         overflow-wrap: anywhere; }
+  h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
+       color: var(--muted); margin: 18px 0 8px; font-weight: 600; }
+
+  select, input, button { font: inherit; color: inherit; background: var(--bg);
+    border: 1px solid var(--line); border-radius: 6px; padding: 5px 7px; width: 100%; }
+  button { cursor: pointer; }
+  button:hover { border-color: var(--accent); }
+  label { display: block; margin-bottom: 10px; font-size: 12px; color: var(--muted); }
+  label span.l { display: block; margin-bottom: 3px; color: var(--fg); }
+  label small { display: block; margin-top: 3px; color: var(--muted); font-size: 11px; }
+
+  .list { display: flex; flex-direction: column; gap: 2px; }
+  .list button { text-align: left; border: 1px solid transparent;
+    background: transparent; border-radius: 6px; padding: 6px 8px; }
+  .list button:hover { background: var(--panel); }
+  .list button[aria-current="true"] {
+    background: var(--accent-soft); border-color: var(--accent); font-weight: 600; }
+
+  figure { margin: 0; }
+  figure img { max-width: 100%; height: auto; display: block;
+    border: 1px solid var(--line); border-radius: 8px; background: #fff; }
+  .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+         margin-bottom: 14px; }
+  .row button { width: auto; }
+  .status { color: var(--muted); font-size: 12px; min-height: 18px; }
+  .err { color: #b42318; white-space: pre-wrap; font-size: 12px; }
+
+  .gallery { display: grid; gap: 14px;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); }
+  .gallery figure { border: 1px solid var(--line); border-radius: 8px;
+    padding: 8px; background: var(--panel); }
+  .gallery img { border: none; border-radius: 4px; }
+  .gallery figcaption { font-size: 11px; color: var(--muted); margin-top: 6px;
+    overflow-wrap: anywhere; }
+  .group-head { grid-column: 1 / -1; font-size: 11px; text-transform: uppercase;
+    letter-spacing: .08em; color: var(--muted); margin-top: 8px; }
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+
+<aside>
+  <h1>MEA-NAP viewer</h1>
+  <div class="sub" id="source">loading…</div>
+
+  <h2>Recording</h2>
+  <select id="recording"></select>
+  <h2>Lag</h2>
+  <select id="lag"></select>
+
+  <h2>Network figures</h2>
+  <div class="list" id="figures"></div>
+
+  <h2>Activity figures</h2>
+  <div class="list" id="activity"></div>
+
+  <h2>Comparisons</h2>
+  <div class="list" id="families"></div>
+</aside>
+
+<main>
+  <div class="row" id="toolbar">
+    <span class="status" id="status"></span>
+    <span style="flex:1"></span>
+    <button id="dl-png">Download PNG</button>
+    <button id="dl-svg">Download SVG</button>
+    <button id="dl-pdf">Download PDF</button>
+  </div>
+  <div class="err" id="error"></div>
+  <figure id="single"><img id="figure-img" alt=""></figure>
+  <div class="gallery hidden" id="gallery"></div>
+</main>
+
+<aside class="right" id="controls-panel">
+  <h2>Network styling</h2>
+  <div id="controls"></div>
+  <button id="reset">Reset to pipeline defaults</button>
+  <p class="sub" style="margin-top:12px">
+    Defaults reproduce the figure the pipeline drew, pixel for pixel.
+  </p>
+</aside>
+
+<script>
+const $ = (id) => document.getElementById(id);
+let MANIFEST = null;
+let VIEW = { kind: "figure", rec: null, lag: null, name: null, family: null };
+// "figure"   — a network plot, per recording + lag, restylable
+// "activity" — a step-2 plot, per recording only; the network controls don't
+//              apply to a raster or a heatmap, so they are hidden for it
+// "family"   — a gallery of small multiples
+
+async function getJSON(url) {
+  const r = await fetch(url);
+  const j = await r.json();
+  if (!r.ok) throw new Error(j.error || r.statusText);
+  return j;
+}
+
+function overrideParams() {
+  const p = new URLSearchParams();
+  for (const c of MANIFEST.controls) {
+    const el = $("ctl-" + c.key);
+    if (!el) continue;
+    if (String(el.value) !== String(c.default)) p.set(c.key, el.value);
+  }
+  return p;
+}
+
+function figureURL(extra = {}) {
+  if (VIEW.kind === "activity") {
+    const p = new URLSearchParams({rec: VIEW.rec, name: VIEW.name});
+    for (const [k, v] of Object.entries(extra)) p.set(k, v);
+    return "/api/activity?" + p.toString();
+  }
+  const p = overrideParams();
+  p.set("rec", VIEW.rec); p.set("lag", VIEW.lag); p.set("name", VIEW.name);
+  for (const [k, v] of Object.entries(extra)) p.set(k, v);
+  return "/api/figure?" + p.toString();
+}
+
+function buildControls() {
+  const box = $("controls");
+  box.innerHTML = "";
+  for (const c of MANIFEST.controls) {
+    const label = document.createElement("label");
+    const name = document.createElement("span");
+    name.className = "l"; name.textContent = c.label;
+    label.appendChild(name);
+
+    let el;
+    if (c.kind === "select") {
+      el = document.createElement("select");
+      for (const opt of c.options) {
+        const o = document.createElement("option");
+        o.value = opt; o.textContent = opt; el.appendChild(o);
+      }
+    } else {
+      el = document.createElement("input");
+      el.type = "number";
+      if (c.min !== null) el.min = c.min;
+      if (c.max !== null) el.max = c.max;
+      if (c.step !== null) el.step = c.step;
+    }
+    el.id = "ctl-" + c.key;
+    el.value = c.default;
+    el.addEventListener("change", () => { if (VIEW.kind === "figure") showFigure(); });
+    label.appendChild(el);
+    if (c.help) { const s = document.createElement("small"); s.textContent = c.help;
+                  label.appendChild(s); }
+    box.appendChild(label);
+  }
+}
+
+function resetControls() {
+  for (const c of MANIFEST.controls) {
+    const el = $("ctl-" + c.key);
+    if (el) el.value = c.default;
+  }
+  if (VIEW.kind === "figure") showFigure();
+}
+
+function currentRecording() {
+  return MANIFEST.recordings.find((r) => r.name === $("recording").value);
+}
+
+function fillRecordings() {
+  const sel = $("recording");
+  sel.innerHTML = "";
+  for (const r of MANIFEST.recordings) {
+    const o = document.createElement("option");
+    o.value = r.name;
+    o.textContent = r.group ? `${r.name}  (${r.group})` : r.name;
+    sel.appendChild(o);
+  }
+  fillLags();
+}
+
+function fillLags() {
+  fillActivity();
+  const rec = currentRecording();
+  const sel = $("lag");
+  sel.innerHTML = "";
+  for (const lag of (rec ? rec.lags : [])) {
+    const o = document.createElement("option");
+    o.value = lag; o.textContent = lag + " ms";
+    sel.appendChild(o);
+  }
+  fillFigures();
+}
+
+function fillActivity() {
+  const rec = currentRecording();
+  const box = $("activity");
+  box.innerHTML = "";
+  const figs = (rec && rec.activity) || [];
+  if (!figs.length) {
+    box.innerHTML = '<div class="sub">None in this bundle.</div>';
+    return;
+  }
+  for (const f of figs) {
+    const b = document.createElement("button");
+    b.textContent = f.label;
+    b.dataset.activity = f.name;
+    b.addEventListener("click", () => {
+      VIEW = { kind: "activity", rec: rec.name, lag: null, name: f.name, family: null };
+      showFigure();
+    });
+    box.appendChild(b);
+  }
+}
+
+function fillFigures() {
+  const rec = currentRecording();
+  const lag = $("lag").value;
+  const box = $("figures");
+  box.innerHTML = "";
+  const figs = (rec && rec.figures[lag]) || [];
+  if (!figs.length) {
+    box.innerHTML = '<div class="sub">No figures for this lag.</div>';
+    return;
+  }
+  for (const f of figs) {
+    const b = document.createElement("button");
+    b.textContent = f.label;
+    b.dataset.name = f.name;
+    b.addEventListener("click", () => {
+      VIEW = { kind: "figure", rec: rec.name, lag: lag, name: f.name, family: null };
+      showFigure();
+    });
+    box.appendChild(b);
+  }
+  // Open the first figure so the page is never blank.
+  if (!VIEW.name || VIEW.kind !== "figure" ||
+      !figs.some((f) => f.name === VIEW.name)) {
+    VIEW = { kind: "figure", rec: rec.name, lag: lag, name: figs[0].name, family: null };
+  } else {
+    VIEW.rec = rec.name; VIEW.lag = lag;
+  }
+  showFigure();
+}
+
+function fillFamilies() {
+  const box = $("families");
+  box.innerHTML = "";
+  if (!MANIFEST.families.length) {
+    box.innerHTML = '<div class="sub">None in this bundle.</div>';
+    return;
+  }
+  for (const fam of MANIFEST.families) {
+    const b = document.createElement("button");
+    b.textContent = fam.label;
+    b.dataset.family = fam.key;
+    b.addEventListener("click", () => showFamily(fam));
+    box.appendChild(b);
+  }
+}
+
+function markCurrent() {
+  for (const b of document.querySelectorAll("#figures button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "figure" && b.dataset.name === VIEW.name));
+  for (const b of document.querySelectorAll("#activity button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "activity" && b.dataset.activity === VIEW.name));
+  for (const b of document.querySelectorAll("#families button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "family" && b.dataset.family === VIEW.family));
+}
+
+function setMode(kind) {
+  const single = kind === "figure" || kind === "activity";
+  // Hidden, not disabled: the controls style spatial network plots. A raster,
+  // a heatmap and a violin gallery read none of them, so offering the knobs
+  // there would imply they do something.
+  $("controls-panel").classList.toggle("hidden", kind !== "figure");
+  $("single").classList.toggle("hidden", !single);
+  $("gallery").classList.toggle("hidden", single);
+  for (const id of ["dl-png", "dl-svg", "dl-pdf"])
+    $(id).classList.toggle("hidden", !single);
+}
+
+function showFigure() {
+  if (VIEW.kind !== "activity") VIEW.kind = "figure";
+  setMode(VIEW.kind); markCurrent();
+  $("error").textContent = "";
+  $("status").textContent = "rendering…";
+  const img = $("figure-img");
+  img.onload = () => { $("status").textContent = VIEW.name; };
+  img.onerror = () => {
+    $("status").textContent = "";
+    $("error").textContent = "Could not render this figure.";
+  };
+  img.src = figureURL();
+  img.alt = VIEW.name;
+}
+
+async function showFamily(fam) {
+  VIEW = { kind: "family", rec: null, lag: null, name: null, family: fam.key };
+  setMode("family"); markCurrent();
+  $("error").textContent = "";
+  $("status").textContent = "rendering gallery — this can take a few seconds the first time…";
+  const box = $("gallery");
+  box.innerHTML = "";
+  try {
+    const data = await getJSON("/api/family?key=" + encodeURIComponent(fam.key));
+    $("status").textContent =
+      `${fam.label} — ${data.count} figures${data.cached ? " (cached)" : ""}`;
+    let lastGroup = null;
+    for (const item of data.items) {
+      if (item.group !== lastGroup) {
+        const h = document.createElement("div");
+        h.className = "group-head"; h.textContent = item.group;
+        box.appendChild(h); lastGroup = item.group;
+      }
+      const fig = document.createElement("figure");
+      const img = document.createElement("img");
+      img.loading = "lazy";
+      img.src = "/api/asset?path=" + encodeURIComponent(item.asset);
+      img.alt = item.name;
+      const cap = document.createElement("figcaption");
+      cap.textContent = item.name;
+      fig.appendChild(img); fig.appendChild(cap);
+      box.appendChild(fig);
+    }
+  } catch (e) {
+    $("status").textContent = "";
+    $("error").textContent = String(e.message || e);
+  }
+}
+
+function download(fmt) {
+  if (VIEW.kind === "family") return;
+  window.location = figureURL({ fmt: fmt, download: "1" });
+}
+
+(async function init() {
+  try {
+    MANIFEST = await getJSON("/api/manifest");
+  } catch (e) {
+    document.body.innerHTML =
+      '<p class="err" style="padding:24px">Could not load this bundle: ' +
+      String(e.message || e) + "</p>";
+    return;
+  }
+  $("source").textContent = `${MANIFEST.source} · ${MANIFEST.mode}`;
+  buildControls();
+  fillRecordings();
+  fillFamilies();
+  $("recording").addEventListener("change", fillLags);
+  $("lag").addEventListener("change", fillFigures);
+  $("reset").addEventListener("click", resetControls);
+  $("dl-png").addEventListener("click", () => download("png"));
+  $("dl-svg").addEventListener("click", () => download("svg"));
+  $("dl-pdf").addEventListener("click", () => download("pdf"));
+})();
+</script>
+</body>
+</html>
+"""

--- a/src/meanap/viewer/server.py
+++ b/src/meanap/viewer/server.py
@@ -1,0 +1,337 @@
+"""A local web viewer for a ``.meanap`` bundle.
+
+Express mode ships data instead of pictures; this serves the pictures back on
+demand. The front end is HTML so the figures live where people already read
+things, and so vector output is a click away rather than a file dialog; the
+back end is the same Python that drew them in the pipeline, so what you see is
+what the pipeline would have produced — the pixel-parity tests cover exactly
+that path.
+
+Deliberately stdlib-only (``http.server``): a viewer that needs a web framework
+installed is a viewer a collaborator won't run. Bound to loopback by default,
+because the bundle is unpublished research data and nothing here authenticates
+anyone.
+
+Endpoints
+---------
+``GET /``                     the page
+``GET /api/manifest``         recordings, lags, figures, families, controls
+``GET /api/figure``           one network figure, restyled per the query string
+``GET /api/activity``         one step-2 activity figure (raster, heatmap, …)
+``GET /api/family``           a family's thumbnails (renders once, then cached)
+``GET /api/asset``            a file from the render cache
+
+The styling controls apply to the spatial network plots only, so ``/api/family``
+ignores them and the page hides the panel for gallery views rather than
+offering knobs that do nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+import threading
+import traceback
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from meanap.pipeline.bundle import is_bundle, open_bundle
+from meanap.pipeline.figure_output import DEFAULT_THUMBNAIL_DPI
+from meanap.pipeline.render import (
+    available_activity_figures, available_figures, available_group_families,
+    cached_figure, gallery, load_context, render_activity_figure,
+)
+from meanap.pipeline.render_cache import RenderCache
+from meanap.viewer.controls import control_schema, parse_overrides
+from meanap.viewer.page import PAGE_HTML
+
+__all__ = ["ViewerService", "serve"]
+
+#: Formats a client may request. Anything else is rejected rather than passed
+#: to matplotlib, whose error for an unknown suffix is not user-facing.
+ALLOWED_FORMATS = ("png", "svg", "pdf")
+
+
+class ViewerService:
+    """Bundle + render cache + the queries the HTTP layer needs.
+
+    Separated from the request handler so it can be driven directly in tests
+    without a socket, and so a GUI could embed the same logic behind a
+    ``QWebEngineView`` without going through HTTP at all.
+    """
+
+    def __init__(self, source: Path | str):
+        source = Path(source)
+        self._bundle = open_bundle(source) if is_bundle(source) else None
+        root = self._bundle.root if self._bundle is not None else source
+        self.ctx = load_context(self._bundle if self._bundle is not None else root)
+        self.cache = RenderCache.in_temp()
+        self.source = source
+
+    def close(self) -> None:
+        self.cache.close()
+        if self._bundle is not None:
+            self._bundle.close()
+
+    # ── queries ──────────────────────────────────────────────────────────────
+
+    def manifest(self) -> dict:
+        recordings = []
+        for name, rec in self.ctx.recordings.items():
+            lags = self.ctx.lags(name)
+            recordings.append({
+                "name": name, "group": rec.group, "div": rec.div, "lags": lags,
+                "figures": {
+                    str(lag): [{"name": f.name, "label": f.label}
+                               for f in available_figures(self.ctx, name, lag)]
+                    for lag in lags
+                },
+                # Step-2 figures are per recording, not per lag — a separate
+                # list rather than a lag key, so the page can show them once.
+                "activity": [{"name": f.name, "label": f.label}
+                             for f in available_activity_figures(self.ctx, name)],
+            })
+        return {
+            "source": self.source.name,
+            "mode": self.ctx.mode,
+            "recordings": recordings,
+            "families": [{"key": f.key, "label": f.label}
+                         for f in available_group_families(self.ctx)],
+            "controls": control_schema(),
+            "formats": list(ALLOWED_FORMATS),
+        }
+
+    def figure(self, recording: str, lag: int, name: str, *,
+               fmt: str, overrides: dict, thumbnail: bool) -> Path:
+        path, _ = cached_figure(
+            self.ctx, self.cache, recording, lag, name, fmt=fmt,
+            dpi=DEFAULT_THUMBNAIL_DPI if thumbnail else None,
+            overrides=overrides or None,
+        )
+        return path
+
+    def activity_figure(self, recording: str, name: str, *,
+                        fmt: str, overrides: dict) -> Path:
+        """One step-2 activity figure. Cached like the network ones."""
+        from meanap.pipeline.render_cache import bundle_identity, cache_key
+
+        key = cache_key(bundle_identity(self.ctx.root), f"act:{recording}:{name}",
+                        fmt=fmt, dpi=None, overrides=overrides)
+        files, _ = self.cache.get_or_render(
+            key,
+            lambda dest: [render_activity_figure(
+                self.ctx, recording, name, dest, fmt=fmt,
+                overrides=overrides or None)],
+        )
+        return files[0]
+
+    def family(self, key: str, *, fmt: str = "png") -> dict:
+        """Render (or serve cached) a family, as asset references.
+
+        Paths are returned relative to the cache root and resolved back through
+        :meth:`asset`, so the client never sees or supplies a filesystem path.
+        """
+        files, was_cached = gallery(self.ctx, key, self.cache, fmt=fmt)
+        items = []
+        for path in files:
+            rel = path.relative_to(self.cache.root)
+            # The folder tree is how the pipeline groups these (by lag, by
+            # comparison axis); keep it as the caption so a gallery of 109
+            # small multiples is navigable rather than a wall of names.
+            items.append({
+                "asset": rel.as_posix(),
+                "name": path.stem,
+                "group": rel.parent.as_posix(),
+            })
+        return {"cached": was_cached, "count": len(items), "items": items}
+
+    def asset(self, relative: str) -> Path:
+        """Resolve a cache-relative path, refusing anything that escapes it."""
+        root = self.cache.root.resolve()
+        target = (root / relative).resolve()
+        if not target.is_relative_to(root) or not target.is_file():
+            raise FileNotFoundError(relative)
+        return target
+
+
+class _Handler(BaseHTTPRequestHandler):
+    service: ViewerService = None  # set by serve()
+    server_version = "MEA-NAP-viewer"
+
+    def log_message(self, *args) -> None:  # noqa: D102 - quieten stderr spam
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        try:
+            if parsed.path == "/":
+                self._send(200, "text/html; charset=utf-8", PAGE_HTML.encode())
+            elif parsed.path == "/api/manifest":
+                self._json(self.service.manifest())
+            elif parsed.path == "/api/figure":
+                self._figure(query)
+            elif parsed.path == "/api/activity":
+                self._activity(query)
+            elif parsed.path == "/api/family":
+                self._json(self.service.family(
+                    _one(query, "key"), fmt=_fmt(query)))
+            elif parsed.path == "/api/asset":
+                self._file(self.service.asset(_one(query, "path")))
+            else:
+                self._json({"error": "not found"}, status=404)
+        except FileNotFoundError as e:
+            self._json({"error": f"not found: {e}"}, status=404)
+        except ValueError as e:
+            # Bad input from the page: report it verbatim, it is actionable.
+            self._json({"error": str(e)}, status=400)
+        except Exception as e:
+            self._json({"error": f"{type(e).__name__}: {e}",
+                        "traceback": traceback.format_exc()}, status=500)
+
+    # ── handlers ─────────────────────────────────────────────────────────────
+
+    def _figure(self, query) -> None:
+        fmt = _fmt(query)
+        path = self.service.figure(
+            _one(query, "rec"), int(_one(query, "lag")), _one(query, "name"),
+            fmt=fmt, overrides=parse_overrides(query),
+            thumbnail=query.get("thumb", ["0"])[0] == "1",
+        )
+        download = query.get("download", ["0"])[0] == "1"
+        self._file(path, download_as=path.name if download else None)
+
+    def _activity(self, query) -> None:
+        fmt = _fmt(query)
+        path = self.service.activity_figure(
+            _one(query, "rec"), _one(query, "name"),
+            fmt=fmt, overrides=parse_overrides(query))
+        download = query.get("download", ["0"])[0] == "1"
+        self._file(path, download_as=path.name if download else None)
+
+    # ── plumbing ─────────────────────────────────────────────────────────────
+
+    def _send(self, status: int, content_type: str, body: bytes,
+              extra: dict | None = None) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (extra or {}).items():
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, payload: dict, status: int = 200) -> None:
+        self._send(status, "application/json", json.dumps(payload).encode())
+
+    def _file(self, path: Path, download_as: str | None = None) -> None:
+        ctype = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        extra = ({"Content-Disposition": f'attachment; filename="{download_as}"'}
+                 if download_as else {})
+        self._send(200, ctype, path.read_bytes(), extra)
+
+
+def _one(query: dict, key: str) -> str:
+    value = query.get(key, [None])[0]
+    if not value:
+        raise ValueError(f"missing required parameter '{key}'")
+    return value
+
+
+def _fmt(query: dict) -> str:
+    fmt = query.get("fmt", ["png"])[0]
+    if fmt not in ALLOWED_FORMATS:
+        raise ValueError(f"unsupported format {fmt!r}; expected one of "
+                         f"{list(ALLOWED_FORMATS)}")
+    return fmt
+
+
+#: Default port. Not 8765 — that is AnkiConnect's, and a collision there is
+#: nastier than it sounds: ``HTTPServer`` sets ``SO_REUSEADDR``, so binding can
+#: succeed while the browser reaches the *other* application. Hence
+#: :func:`_port_in_use` below, which probes before binding rather than trusting
+#: bind() to fail.
+DEFAULT_PORT = 8912
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    """Whether something is already answering on ``host:port``."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.3)
+        return probe.connect_ex((host, port)) == 0
+
+
+def serve(
+    source: Path | str,
+    host: str = "127.0.0.1",
+    port: int = DEFAULT_PORT,
+    *,
+    open_browser: bool = False,
+    background: bool = False,
+):
+    """Serve *source* (a ``.meanap`` bundle or an output folder).
+
+    Returns ``(httpd, service)``. With ``background=True`` the server runs on a
+    daemon thread and the call returns immediately — how the tests drive it;
+    otherwise it blocks until interrupted.
+
+    ``host`` defaults to loopback deliberately. The bundle is unpublished data
+    and there is no authentication here, so binding to a routable address would
+    expose it to the network; do that only on a machine where that is intended.
+    """
+    if port and _port_in_use(host, port):
+        raise OSError(
+            f"Port {port} on {host} is already in use by another application, so "
+            f"the viewer would be unreachable there (a browser would get that "
+            f"application instead). Pass --port with a free port, or 0 to let the "
+            f"system choose one."
+        )
+
+    service = ViewerService(source)
+    handler = type("_BoundHandler", (_Handler,), {"service": service})
+    httpd = ThreadingHTTPServer((host, port), handler)
+    httpd.daemon_threads = True
+    url = f"http://{host}:{httpd.server_address[1]}/"
+
+    if open_browser:
+        import webbrowser
+        webbrowser.open(url)
+
+    if background:
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        return httpd, service
+
+    print(f"MEA-NAP viewer: {url}   (Ctrl-C to stop)")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping…")
+    finally:
+        httpd.shutdown()
+        service.close()
+    return httpd, service
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="meanap-viewer",
+        description="Browse a .meanap bundle (or an output folder) in a browser.")
+    ap.add_argument("source", help="a .meanap bundle or an OutputData… folder")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=DEFAULT_PORT,
+                    help="0 lets the system choose a free port")
+    ap.add_argument("--no-browser", action="store_true",
+                    help="don't open a browser window")
+    args = ap.parse_args(argv)
+
+    serve(args.source, args.host, args.port, open_browser=not args.no_browser)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Four related pieces, each verified against the pipeline's own output rather than assumed correct.

**CAT-NAP resume.** The calcium path ignored startAnalysisStep/prior_analysis entirely and wrote nothing to resume from. Now saves each recording's step-2 products (catnap/store.py) and reads them back at step 4, mirroring MATLAB's priorAnalysis == 1 && startAnalysisStep == 4 branch. Verified end to end: same seed reproduces the original run's CSVs byte-for-byte.

**Express mode** (Params.express_mode). Skips every figure that can be rebuilt from the run's own data, keeping only the quality-control plots that cannot — spike-detection checks and 2P traces, which need raw data far too large to carry. On the documented benchmark dataset (ExampleData, two Axion64 recordings, lags 10/25/50): 483 figures and 56.4 MB become 6 figures and 3.2 MB, and the run drops from 251.1s to 198.0s (21%). The CSVs are byte-identical either way — express changes what is drawn, never what is computed.

**Run bundles** (.meanap). One shareable zip per run, 2.2 MB against a 56.4 MB folder, mirroring the output-folder layout so any zip tool finds plain CSVs inside. It absorbs the resume file: step 4 re-runs from the bundle alone with no raw data present, reproducing the original metrics. Cell types travel inside it, so a recipient with no spreadsheet still gets marker rings and by-cell-type comparisons.

**Viewer** (meanap-viewer). Local stdlib HTTP server plus a self-contained page: per-recording network and activity figures, batch comparison galleries, PNG/SVG/PDF export, and the full Network Viewer control set extracted into a shared NetworkStyle so the viewer tab, the pipeline and the renderer drive one implementation. Every figure redrawn from a bundle is pixel-identical to the pipeline's — 66 network and 18 activity figures verified on real data.

Bugs found and fixed on the way:

- The CAT-NAP metric loop iterated Params.funcConLagval, but suite2pToAdjm derives a single lag round(1000/fs) for the F/spks/denoised F activity types — so those three produced no network metrics at all.
- Four stochastic plot stages drew from unseeded RNGs, so figures differed between two identically-seeded runs: CAT-NAP's batch-wide stream, step-4 graph-metrics violins, and step-2's firing-rate strip plot.
- load_recording_state refused older formats, telling the user to "re-run from step 1" — advice a bundle recipient cannot take. Now reads older files and refuses only newer ones.
- The default viewer port (8765) collides with AnkiConnect; SO_REUSEADDR let the bind succeed while the browser reached the other application.

Also: params.json is now written into every output folder (nothing recorded the settings that produced a run before), and figure resolution is controllable via a ContextVar so galleries can render thumbnails.

Docs: new docs/python/express-mode.md, wired into the Python docs index, with cross-references from output-report and catnap.

Known gap, recorded in each bundle's manifest: CAT-NAP's per-recording cell-type subnetwork figures are dropped and not yet reconstructable.


Claude-Session: https://claude.ai/code/session_01U2GsZ8XZ7kfTvMNq2XDPvs