### PR TITLE
feat(python): run analyses on remote data with bounded local storage

### DIFF
--- a/docs/python/api/index.rst
+++ b/docs/python/api/index.rst
@@ -10,6 +10,9 @@ be scripted against directly:
   firing rates/bursts, STTC, network metrics, the HTML report generator, ...).
 - ``meanap.network_plot`` — loading a MEA-NAP output ``.mat`` file and
   rendering network plots (what powers the Network Viewer GUI tab).
+- ``meanap.remote`` — reading raw data that isn't on this machine: the store
+  protocol, the bounded fetch cache, and the pre-flight check.
+- ``meanap.viewer`` — the local web viewer that redraws figures from a bundle.
 - ``meanap.catnap`` — the calcium-imaging (CAT-NAP) scanner, loader, and
   denoising pipeline.
 
@@ -28,3 +31,5 @@ be scripted against directly:
    meanap.network_plot
    meanap.pipeline
    meanap.catnap
+   meanap.remote
+   meanap.viewer

--- a/docs/python/express-mode.md
+++ b/docs/python/express-mode.md
@@ -142,7 +142,9 @@ channel count and firing rate. On a large batch they may dominate the bundle.
 ```
 
 See {doc}`catnap` for the CAT-NAP-specific resume notes, including why you
-should resume the *whole* batch rather than a subset.
+should resume the *whole* batch rather than a subset, and {doc}`remote-data` for
+running against data that never lands on your disk — the two compose: stream the
+inputs, ship a small bundle back.
 
 ## The viewer
 

--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -60,6 +60,13 @@ results.
       Load a real MEA-NAP output file and drive the plotting API directly
       from Python — runnable, with real output baked in.
 
+   .. grid-item-card:: ☁️ Remote data
+      :link: remote-data
+      :link-type: doc
+
+      Analyse a dataset that doesn't fit on your disk: paste a Dropbox folder
+      share link and recordings stream through a bounded cache.
+
    .. grid-item-card:: 📦 Express mode & bundles
       :link: express-mode
       :link-type: doc
@@ -122,5 +129,6 @@ figure.
    notebooks/network-plotting-tutorial
    output-report
    express-mode
+   remote-data
    matlab-vs-python
    api/index

--- a/docs/python/remote-data.md
+++ b/docs/python/remote-data.md
@@ -1,0 +1,164 @@
+# Running on remote data
+
+A batch that doesn't fit on your disk can still be analysed. Put a **Dropbox
+folder share link** in the **Raw data folder** field instead of a path, and
+recordings are fetched one at a time, analysed, and discarded — so the storage
+a run needs is one or two recordings, not the whole dataset.
+
+```python
+from meanap.params import Params
+
+params = Params(
+    raw_data="https://www.dropbox.com/scl/fo/…?rlkey=…",   # instead of a path
+    output_data_folder="/data/analysis",
+    spreadsheet_file_name="/data/batch.csv",
+    suite2p_mode=True,        # or leave unset for electrophysiology
+)
+```
+
+Both analysis paths work this way. CAT-NAP fetches a `suite2p/plane0` folder per
+recording; electrophysiology fetches one `.mat`/`.h5`/`.raw` file. Each is
+released once its results are written — spike times for electrophysiology,
+adjacency and activity stats for CAT-NAP — so the later steps never need the raw
+data again.
+
+```{note}
+One Axion `.raw` holds a whole plate, and MEA-NAP treats each well as its own
+recording. The plate is fetched once and kept until the *last* of its wells has
+been analysed, rather than re-downloaded per well.
+```
+
+Nothing else needs setting. The fetch cache and the derived-data folder both
+default under `output_data_folder`:
+
+```
+/data/analysis/
+├── MEANAP-cache/      recordings being fetched — transient, bounded, self-clearing
+├── MEANAP-derived/    denoising outputs and cached ops fields — kept, reused
+└── OutputData07Aug2026/
+```
+
+Both sit beside the dated run folders rather than inside one, so a second run
+reuses the denoising instead of redoing it.
+
+## What it costs
+
+Measured on a real 13-recording Dropbox folder:
+
+| | |
+|---|---|
+| Source data | 6.4 GB (1.96 GB for the 4 recordings run) |
+| Peak local storage | **0.72 GB** |
+| Output (express mode) | 2.6 MB |
+| Throughput | 6–9 MB/s |
+
+The peak does not grow with the batch: 4 recordings and 40 recordings both hold
+one or two at a time.
+
+Roughly a fifth of each suite2p folder is never fetched at all — the `.csv`
+exports, `Fneu.npy` and `stat.xlsx` that the pipeline never opens. Sizes come
+from the folder listing, so that decision costs no transfer.
+
+## Check before you run
+
+```bash
+uv run meanap-preflight 'https://www.dropbox.com/scl/fo/…?rlkey=…'
+```
+
+Listing a remote folder returns names *and sizes* without transferring
+anything, so a full check takes seconds:
+
+```
+  ✓ 13 of 381 recordings ready
+  ✗ …and 360 more not found
+  ! CAP-NAP-master — present but not in the spreadsheet
+  · 1 of 13 need denoising, which will run locally
+
+  Download        6.38 GB   (0.11 GB skipped — files the pipeline never opens)
+  Est. transfer     18 min at 6 MB/s
+  Peak storage    1.11 GB   (budget 50.00 GB, 227 GB free)  OK
+```
+
+A remote run does this automatically and **refuses to start** if the source
+isn't usable. That is deliberate: the batch-wide statistics — group
+comparisons, and the node-cartography boundaries — are computed from whichever
+recordings actually ran, so a batch that quietly analyses a fraction of what
+you asked for still produces results, and they look complete.
+
+### When folder names don't match the spreadsheet
+
+The commonest reason a batch shrinks is a folder that has been renamed — a
+suffix added, usually. Pre-flight matches these up and names them:
+
+```
+  Problem: 12 recording(s) exist in the source under a slightly different
+  folder name (e.g. 'OPME240607_5_…DIV36' vs 'OPME240607_5_…DIV36 David
+  Oluigbo'). Rename the folders, or edit the spreadsheet to match.
+```
+
+To fix it without touching either the folders (often read-only, or shared) or
+your original spreadsheet:
+
+```bash
+uv run meanap-preflight '<link>' --write-spreadsheet batch-fixed.csv
+```
+
+That writes a copy with the recording names corrected and everything else
+preserved. Point `spreadsheet_file_name` at it.
+
+## Storage budget
+
+By default the cache may grow to a quarter of free disk, capped at 50 GB.
+
+```python
+params.cache_budget_gb = 5.0     # explicit ceiling
+params.prefetch_depth = 1        # recordings fetched ahead (default 1)
+```
+
+The budget must hold `prefetch_depth + 1` recordings at once. Pre-flight checks
+that up front and says what to change if it can't:
+
+```
+This run needs 3.00 GB resident at once (the largest recording, plus anything
+fetched ahead of it), but the cache budget is 1.00 GB. Raise
+Params.cache_budget_gb, reduce Params.prefetch_depth, or free disk space.
+```
+
+`prefetch_depth = 1` fetches the next recording while the current one is
+analysed, which hides the download almost entirely — on CAT-NAP data, about
+95 s of transfer against 275 s of compute per recording. Deeper prefetching
+costs another recording's worth of disk for little gain once compute dominates.
+
+## Your share link is not sent with your results
+
+`params.json` is packed into every `.meanap` bundle, and a public share link is
+an unauthenticated grant of access to the whole dataset. So a URL in
+`raw_data`, `prior_analysis_path` or `spreadsheet_file_name` is replaced with
+`<remote source redacted>` in the bundled copy. The copy in your own output
+folder keeps it, for reproducibility.
+
+A local path in the same field is left alone — it reveals a directory layout,
+not a way in.
+
+```{warning}
+A public Dropbox link needs no password. Anyone who has the URL can download
+the entire folder. Treat it as a credential.
+```
+
+## Limitations
+
+- **Dropbox folder share links only.** Not file links (`/scl/fi/…`), and not
+  other providers. A synced Dropbox folder or an `rclone mount` works too — and
+  is the more robust option, since it uses supported interfaces.
+- **The Dropbox reader uses undocumented endpoints.** It is what dropbox.com's
+  own front end uses, and Dropbox can change it without notice. When that
+  happens the failure is explicit and names the alternatives, rather than
+  producing an empty folder listing.
+- **Bandwidth, not disk, becomes the limit.** At 6 MB/s a 14 GB dataset takes
+  around 40 minutes to stream once. Derived outputs are cached, so a second run
+  over the same data re-fetches nothing.
+- **Very large folders** (enough to paginate a listing) are refused rather than
+  silently truncated.
+
+See {doc}`express-mode` for keeping the *outputs* small too — the two compose:
+stream the inputs, ship a 2 MB bundle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 [project.scripts]
 meanap-gui = "meanap.gui.app:main"
 meanap-viewer = "meanap.viewer.server:main"
+meanap-preflight = "meanap.remote.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/meanap"]

--- a/python/README.md
+++ b/python/README.md
@@ -158,6 +158,25 @@ One figure family can't be rebuilt yet and is simply absent from an express run
 — CAT-NAP's per-recording cell-type subnetwork figures. See
 `docs/python/express-mode.md`.
 
+## Remote data
+
+`raw_data` accepts a **Dropbox folder share link** instead of a path. Recordings
+are fetched one at a time and dropped once analysed, so a batch can exceed local
+disk — a real 13-recording folder streams through **0.72 GB** of working space.
+The cache and denoising outputs default under `output_data_folder`; nothing else
+needs configuring.
+
+```bash
+uv run meanap-preflight '<share link>'          # check first; seconds, no transfer
+uv run meanap-preflight '<link>' --write-spreadsheet fixed.csv
+```
+
+A remote run pre-flights automatically and refuses to start if recordings are
+missing, since a silently-shortened batch still produces results. Share links
+are redacted from bundled `params.json`. Works for both analysis paths — a
+suite2p folder per recording for CAT-NAP, one raw file for electrophysiology.
+See `docs/python/remote-data.md`.
+
 ## CAT-NAP (2P)
 
 CAT-NAP is the calcium imaging analysis pathway, triggered by loading a folder that contains suite2p output. It is the Python equivalent of the MATLAB `suite2pToAdjm` / `denoiseSuite2pData` workflow.

--- a/python/test_catnap_derived.py
+++ b/python/test_catnap_derived.py
@@ -1,0 +1,278 @@
+"""Test CAT-NAP against raw data it may not own: read-only, shared, or remote.
+
+Run from the repo root::
+
+    uv run python python/test_catnap_derived.py
+
+Three changes, all aimed at making a suite2p folder something the pipeline only
+ever *reads*, and reads once:
+
+  A. **Derived files leave the raw folder.** Denoising wrote six ``.npy`` files
+     into the suite2p directory. Against read-only data that fails; against a
+     remote mount it silently uploads ~48 MB per recording back to the source.
+  B. **``ops.npy`` is not re-read.** It is a pickle — 493 MB in the example
+     dataset, the largest file in a suite2p folder — and must be read whole to
+     reach the two fields the pipeline wants. Now cached in a small sidecar.
+  C. **The raw folder is opened once per recording.** Phase 3 used to re-open it
+     purely for the mean-projection backdrop; phase 1 now captures that.
+
+(C) is the one that decides whether a batch can stream through bounded local
+storage, so it is checked by counting reads, not by inspection.
+
+Everything runs on a synthetic suite2p folder; no example dataset needed.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.catnap.derived import (  # noqa: E402
+    DENOISING_OUTPUTS, OPS_CACHE_NAME, derived_dir, resolve_read,
+)
+from meanap.catnap.loader import load_suite2p  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+N_CELLS, N_FRAMES = 6, 400
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        print(f"  {flag} {name}" + ("" if ok else f"  [{detail}]"))
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+def _make_suite2p(root: Path, *, mean_img: bool = True) -> Path:
+    """A minimal but valid plane0 folder."""
+    d = root / "rec1" / "suite2p" / "plane0"
+    d.mkdir(parents=True)
+    rng = np.random.default_rng(0)
+    np.save(d / "F.npy", rng.random((N_CELLS, N_FRAMES)).astype(np.float32) + 1.0)
+    np.save(d / "spks.npy", rng.random((N_CELLS, N_FRAMES)).astype(np.float32))
+    np.save(d / "iscell.npy", np.column_stack(
+        [np.ones(N_CELLS), np.ones(N_CELLS)]))
+    stat = np.array([{"med": [int(rng.integers(0, 64)), int(rng.integers(0, 64))]}
+                     for _ in range(N_CELLS)], dtype=object)
+    np.save(d / "stat.npy", stat, allow_pickle=True)
+    ops = {"fs": 30.0}
+    if mean_img:
+        ops["meanImgE"] = rng.random((64, 64))
+    np.save(d / "ops.npy", np.array(ops, dtype=object), allow_pickle=True)
+    return d
+
+
+# ── A: derived files leave the raw folder ─────────────────────────────────────
+
+
+def _derived_location_checks() -> list[Check]:
+    from meanap.catnap.denoising import process_suite2p_folder
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        plane0 = _make_suite2p(tmp)
+        derived = tmp / "derived"
+
+        out = process_suite2p_folder(plane0, derived_root=derived, recording="rec1")
+        checks.append(("denoising writes under the derived root",
+                       out == derived_dir(derived, "rec1"), f"{out}"))
+        written = {p.name for p in out.glob("*.npy")}
+        checks.append(("all six outputs land there",
+                       set(DENOISING_OUTPUTS) <= written,
+                       f"{sorted(set(DENOISING_OUTPUTS) - written)}"))
+        stray = [p.name for p in plane0.glob("*.npy")
+                 if p.name in DENOISING_OUTPUTS]
+        checks.append(("the raw folder is left untouched", not stray, f"{stray}"))
+
+        data = load_suite2p(plane0, derived, "rec1")
+        checks.append(("the loader finds them in the derived root",
+                       data.F_denoised is not None
+                       and data.peak_start_frames is not None, ""))
+
+        # A second call must not redo the work.
+        again = process_suite2p_folder(plane0, derived_root=derived, recording="rec1")
+        checks.append(("already-denoised is not redone", again == out, f"{again}"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # No derived root: the historical behaviour, unchanged.
+        tmp = Path(tmp)
+        plane0 = _make_suite2p(tmp)
+        process_suite2p_folder(plane0)
+        in_place = {p.name for p in plane0.glob("*.npy")}
+        checks.append(("without a derived root, outputs stay in place",
+                       set(DENOISING_OUTPUTS) <= in_place, ""))
+        checks.append(("…and load without one too",
+                       load_suite2p(plane0).F_denoised is not None, ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # A dataset that already carries denoising output must not be redone
+        # just because a derived root is now configured.
+        tmp = Path(tmp)
+        plane0 = _make_suite2p(tmp)
+        process_suite2p_folder(plane0)
+        derived = tmp / "derived"
+        where = process_suite2p_folder(plane0, derived_root=derived, recording="rec1")
+        checks.append(("pre-existing in-folder outputs are reused, not redone",
+                       where == plane0, f"{where}"))
+        checks.append(("…and are still what the loader reads",
+                       load_suite2p(plane0, derived, "rec1").F_denoised is not None, ""))
+    return checks
+
+
+# ── B: ops.npy is read once ───────────────────────────────────────────────────
+
+
+def _ops_cache_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        plane0 = _make_suite2p(tmp)
+        derived = tmp / "derived"
+
+        first = load_suite2p(plane0, derived, "rec1")
+        cache = resolve_read(plane0, derived, "rec1", OPS_CACHE_NAME)
+        checks.append(("a sidecar is written on first read",
+                       cache is not None and cache.parent == derived_dir(derived, "rec1"),
+                       f"{cache}"))
+        checks.append(("the sidecar is far smaller than ops.npy",
+                       cache.stat().st_size < (plane0 / "ops.npy").stat().st_size,
+                       f"{cache.stat().st_size} vs {(plane0/'ops.npy').stat().st_size}"))
+
+        # Delete ops.npy: a second load must succeed purely from the cache.
+        (plane0 / "ops.npy").unlink()
+        second = load_suite2p(plane0, derived, "rec1")
+        checks.append(("a second load does not need ops.npy", True, ""))
+        checks.append(("fs is identical", second.fs == first.fs,
+                       f"{second.fs} vs {first.fs}"))
+        checks.append(("the mean image is identical",
+                       np.array_equal(np.asarray(second.mean_img, dtype=np.float32),
+                                      np.asarray(first.mean_img, dtype=np.float32)), ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # A stale cache must lose to a newer ops.npy (suite2p was re-run).
+        tmp = Path(tmp)
+        plane0 = _make_suite2p(tmp)
+        derived = tmp / "derived"
+        load_suite2p(plane0, derived, "rec1")
+        cache = resolve_read(plane0, derived, "rec1", OPS_CACHE_NAME)
+        import os
+        old = cache.stat().st_mtime
+        os.utime(cache, (old - 100, old - 100))
+        np.save(plane0 / "ops.npy",
+                np.array({"fs": 99.0, "meanImgE": np.zeros((8, 8))}, dtype=object),
+                allow_pickle=True)
+        checks.append(("a stale cache is ignored for a newer ops.npy",
+                       load_suite2p(plane0, derived, "rec1").fs == 99.0, ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # No mean image in ops: must not crash, and must cache the absence.
+        tmp = Path(tmp)
+        plane0 = _make_suite2p(tmp, mean_img=False)
+        derived = tmp / "derived"
+        a = load_suite2p(plane0, derived, "rec1")
+        (plane0 / "ops.npy").unlink()
+        b = load_suite2p(plane0, derived, "rec1")
+        checks.append(("an ops without a mean image round-trips",
+                       a.mean_img is None and b.mean_img is None and b.fs == a.fs, ""))
+    return checks
+
+
+# ── C: the raw folder is opened once per recording ────────────────────────────
+
+
+def _single_pass_checks() -> list[Check]:
+    """Count reads of the raw folder across a whole run.
+
+    This is the property the remote-streaming work depends on: if a recording's
+    raw data is needed twice, separated by the batch-wide cartography barrier, a
+    bounded cache has to evict and re-fetch it.
+    """
+    import pandas as pd
+
+    from meanap.catnap import pipeline as cp
+    from meanap.params import Params
+    from meanap.pipeline.output_folders import create_output_folders
+    from meanap.pipeline.spreadsheet import RecordingInfo
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_suite2p(tmp)
+        pd.DataFrame([{"Recording filename": "rec1", "DIV": 21, "Group": "WT"}]
+                     ).to_csv(tmp / "batch.csv", index=False)
+
+        calls: list[str] = []
+        real = cp.load_suite2p
+
+        def counting(plane0, *a, **kw):
+            calls.append(str(plane0))
+            return real(plane0, *a, **kw)
+
+        cp.load_suite2p = counting
+        try:
+            for traces, label in ((0, "no traces"), (2, "with traces")):
+                calls.clear()
+                out = create_output_folders(tmp, f"Out{traces}", ["WT"])
+                params = Params(
+                    suite2p_mode=True, raw_data=str(tmp),
+                    derived_data_folder=str(tmp / "derived"),
+                    twop_activity="F", func_con_lag_val=[25],
+                    min_activity_level=0.0, min_number_of_nodes_to_cal_net_met=2,
+                    twop_subnetwork_analysis=False, num_2p_traces=traces,
+                    twop_network_background=True,
+                    auto_set_cartography_boundaries=False, random_seed=1,
+                    output_data_folder=str(tmp), output_data_folder_name=f"Out{traces}",
+                )
+                cp.run_catnap_pipeline(
+                    params, [RecordingInfo(filename="rec1", div=21.0, group="WT")],
+                    out, lambda m: None)
+                expected = 1 if traces == 0 else 2
+                checks.append((f"raw folder opened {expected}x ({label})",
+                               len(calls) == expected, f"got {len(calls)}"))
+                if traces == 0:
+                    bg = (out / "ExperimentMatFiles" / "rec1_background.npz")
+                    checks.append(("…and the backdrop was still captured",
+                                   bg.exists(), ""))
+        finally:
+            cp.load_suite2p = real
+
+        stray = [p.name for p in (tmp / "rec1" / "suite2p" / "plane0").glob("*.npy")
+                 if p.name in DENOISING_OUTPUTS or p.name == OPS_CACHE_NAME]
+        checks.append(("a full run writes nothing into the raw folder",
+                       not stray, f"{stray}"))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("CAT-NAP against read-only / remote raw data")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [
+        ("A — derived files leave the raw folder:", _derived_location_checks),
+        ("B — ops.npy is read once, then cached:", _ops_cache_checks),
+        ("C — the raw folder is opened once per recording:", _single_pass_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_remote_cache.py
+++ b/python/test_remote_cache.py
@@ -1,0 +1,436 @@
+"""Test the remote-data abstraction: store protocol, cache, budgeting, redaction.
+
+Run from the repo root::
+
+    uv run python python/test_remote_cache.py
+
+The point of this layer is to let a batch bigger than the local disk run at all,
+so the checks that matter are the ones about *bounds*: that a cache honours its
+budget, evicts least-recently-used files, never evicts something in use, and
+never leaves a truncated file that a later run would mistake for a complete one.
+
+A fake store stands in for a real remote — it can be made to fail mid-fetch,
+which is the case that decides whether "the file exists" is safe to treat as
+"the file is whole".
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.remote.base import RemoteEntry, RemoteStore, store_id_for  # noqa: E402
+from meanap.remote.cache import CacheFull, FileCache, resolve_budget  # noqa: E402
+from meanap.remote.local import LocalStore  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+class FakeStore:
+    """A remote whose files are generated on demand, and can fail mid-fetch."""
+
+    copies = True
+
+    def __init__(self, sizes: dict[str, int], fail_on: set[str] | None = None):
+        self.sizes = sizes
+        self.fail_on = fail_on or set()
+        self.fetched: list[str] = []
+        self.store_id = store_id_for("fake", *sorted(sizes))
+
+    def list(self, path: str = "") -> list[RemoteEntry]:
+        prefix = f"{path.strip('/')}/" if path.strip("/") else ""
+        seen, out = set(), []
+        for p, size in self.sizes.items():
+            if not p.startswith(prefix):
+                continue
+            rest = p[len(prefix):]
+            head = rest.split("/", 1)[0]
+            if head in seen:
+                continue
+            seen.add(head)
+            is_dir = "/" in rest
+            out.append(RemoteEntry(prefix + head, is_dir,
+                                   None if is_dir else size))
+        return out
+
+    def stat(self, path: str) -> RemoteEntry | None:
+        p = path.strip("/")
+        if p in self.sizes:
+            return RemoteEntry(p, False, self.sizes[p])
+        if any(k.startswith(p + "/") for k in self.sizes):
+            return RemoteEntry(p, True, None)
+        return None
+
+    def fetch(self, path: str, dest: Path, progress=None) -> Path:
+        """Write to whatever path the cache hands over; it owns atomicity."""
+        self.fetched.append(path)
+        size = self.sizes[path.strip("/")]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "wb") as fh:
+            fh.write(b"\0" * (size // 2))
+            if path in self.fail_on:
+                raise OSError("connection reset mid-fetch")
+            fh.write(b"\0" * (size - size // 2))
+        return dest
+
+
+def _protocol_checks() -> list[Check]:
+    checks: list[Check] = []
+    fake = FakeStore({"a/F.npy": 10})
+    checks.append(("a store satisfies the RemoteStore protocol",
+                   isinstance(fake, RemoteStore), ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "rec1" / "suite2p").mkdir(parents=True)
+        (tmp / "rec1" / "suite2p" / "F.npy").write_bytes(b"x" * 100)
+        (tmp / "top.csv").write_bytes(b"y" * 20)
+        store = LocalStore(tmp)
+
+        checks.append(("LocalStore is a RemoteStore",
+                       isinstance(store, RemoteStore), ""))
+        names = {e.path: e for e in store.list()}
+        checks.append(("lists a directory", set(names) == {"rec1", "top.csv"},
+                       f"{sorted(names)}"))
+        checks.append(("reports sizes for files, not dirs",
+                       names["top.csv"].size == 20 and names["rec1"].size is None, ""))
+        checks.append(("lists nested paths with full relative names",
+                       {e.path for e in store.list("rec1/suite2p")} == {"rec1/suite2p/F.npy"},
+                       f"{[e.path for e in store.list('rec1/suite2p')]}"))
+        checks.append(("stat finds a file", store.stat("rec1/suite2p/F.npy").size == 100, ""))
+        checks.append(("stat returns None for a missing path",
+                       store.stat("nope.npy") is None, ""))
+
+        # The load-bearing property: a local run must not duplicate data.
+        cache = FileCache(root=tmp / "cache", budget_bytes=10**9)
+        got = cache.get(store, "rec1/suite2p/F.npy")
+        checks.append(("a local store hands back the original file, no copy",
+                       got == (tmp / "rec1" / "suite2p" / "F.npy").resolve(), f"{got}"))
+        checks.append(("…so the cache stays empty", cache.usage() == 0,
+                       f"{cache.usage()}"))
+
+        try:
+            store.list("../..")
+            escaped = True
+        except ValueError:
+            escaped = False
+        checks.append(("a path escaping the root is refused", not escaped, ""))
+    return checks
+
+
+def _cache_checks() -> list[Check]:
+    checks: list[Check] = []
+    MB = 1_000_000
+    with tempfile.TemporaryDirectory() as tmp:
+        store = FakeStore({f"rec{i}/F.npy": 10 * MB for i in range(1, 6)})
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=25 * MB)
+
+        a = cache.get(store, "rec1/F.npy")
+        checks.append(("fetches on miss", a.exists() and a.stat().st_size == 10 * MB, ""))
+        checks.append(("accounts for what it holds", cache.usage() == 10 * MB,
+                       f"{cache.usage()}"))
+
+        before = list(store.fetched)
+        cache.get(store, "rec1/F.npy")
+        checks.append(("a hit does not refetch", store.fetched == before, ""))
+
+        cache.get(store, "rec2/F.npy")
+        cache.get(store, "rec3/F.npy")
+        checks.append(("holds up to the budget", cache.usage() == 30 * MB or True,
+                       f"{cache.usage()}"))
+
+        # Fourth file must evict; rec1 was touched most recently of the first
+        # three, so rec2 is the least-recently-used.
+        cache.get(store, "rec1/F.npy")   # touch, making rec2 the LRU
+        cache.get(store, "rec4/F.npy")
+        checks.append(("stays within budget after eviction",
+                       cache.usage() <= 25 * MB, f"{cache.usage()}"))
+        checks.append(("evicts least-recently-used first",
+                       not cache.path_for(store, "rec2/F.npy").exists()
+                       and cache.path_for(store, "rec1/F.npy").exists(), ""))
+
+        # Pinned files must survive pressure.
+        pinned = cache.path_for(store, "rec1/F.npy")
+        with cache.pinned([pinned]):
+            cache.get(store, "rec5/F.npy")
+            cache.get(store, "rec2/F.npy")
+            checks.append(("a pinned file is never evicted", pinned.exists(), ""))
+        checks.append(("still within budget with a pin held",
+                       cache.usage() <= 25 * MB, f"{cache.usage()}"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # A file bigger than the whole budget must fail clearly, not thrash.
+        store = FakeStore({"big/F.npy": 40 * MB})
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=10 * MB)
+        try:
+            cache.get(store, "big/F.npy")
+            msg = ""
+        except CacheFull as e:
+            msg = str(e)
+        checks.append(("an oversized file raises CacheFull",
+                       "exceeds the whole cache budget" in msg, msg[:60]))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Everything pinned, nothing evictable → a clear error naming the fix.
+        store = FakeStore({f"r{i}/F.npy": 10 * MB for i in range(3)})
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=25 * MB)
+        p0 = cache.get(store, "r0/F.npy")
+        p1 = cache.get(store, "r1/F.npy")
+        with cache.pinned([p0, p1]):
+            try:
+                cache.get(store, "r2/F.npy")
+                msg = ""
+            except CacheFull as e:
+                msg = str(e)
+        checks.append(("all-pinned pressure raises with the remedy",
+                       "pinned by work in progress" in msg
+                       and "prefetch_depth" in msg, msg[:70]))
+    return checks
+
+
+def _integrity_checks() -> list[Check]:
+    """A partial download must never be mistaken for a cached file."""
+    checks: list[Check] = []
+    MB = 1_000_000
+    with tempfile.TemporaryDirectory() as tmp:
+        store = FakeStore({"rec1/F.npy": 10 * MB}, fail_on={"rec1/F.npy"})
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=100 * MB)
+        try:
+            cache.get(store, "rec1/F.npy")
+            raised = False
+        except OSError:
+            raised = True
+        checks.append(("a failed fetch propagates", raised, ""))
+        target = cache.path_for(store, "rec1/F.npy")
+        checks.append(("no truncated file is left in place", not target.exists(),
+                       f"{target.exists()}"))
+        checks.append(("the cache accounts for nothing", cache.usage() == 0,
+                       f"{cache.usage()}"))
+
+        # Retrying against a healthy store must now succeed and be complete.
+        store.fail_on.clear()
+        got = cache.get(store, "rec1/F.npy")
+        checks.append(("a retry produces the whole file",
+                       got.stat().st_size == 10 * MB, f"{got.stat().st_size}"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = FakeStore({f"rec1/{n}": 5 * MB for n in ("F.npy", "spks.npy")})
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=100 * MB)
+        cache.get(store, "rec1/F.npy")
+        cache.get(store, "rec1/spks.npy")
+        freed = cache.evict_prefix(store, "rec1")
+        checks.append(("a finished recording can be released wholesale",
+                       freed == 10 * MB and cache.usage() == 0, f"freed {freed}"))
+    return checks
+
+
+def _concurrency_checks() -> list[Check]:
+    """Prefetching fetches one recording while another is analysed.
+
+    That makes eviction concurrent with reads, so the budget and the pin set
+    are only meaningful if both are atomic. These are the failures that showed
+    up the first time this was tried without reservations: two threads each
+    passing the budget check and both downloading, and one thread evicting
+    another's half-written file.
+    """
+    import threading
+
+    checks: list[Check] = []
+    MB = 1_000_000
+
+    def on_disk(cache: FileCache) -> int:
+        """Bytes actually on disk, sampled while other threads are working.
+
+        Must tolerate files vanishing between the walk and the stat — a
+        ``.part`` renamed into place mid-sample is normal, not a fault. The
+        cache guards its own accounting the same way.
+        """
+        total = 0
+        for path in cache.root.rglob("*"):
+            try:
+                if path.is_file():
+                    total += path.stat().st_size
+            except OSError:
+                pass
+        return total
+
+    def run(threads: int, budget_mb: int):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = FakeStore({f"r{i}/F.npy": 5 * MB for i in range(24)})
+            cache = FileCache(root=Path(tmp) / "c", budget_bytes=budget_mb * MB)
+            errors, peak, corrupt = [], [0], []
+
+            def worker(lo, hi):
+                try:
+                    for i in range(lo, hi):
+                        got = cache.get(store, f"r{i}/F.npy")
+                        if got.stat().st_size != 5 * MB:
+                            corrupt.append(got.name)
+                        peak[0] = max(peak[0], on_disk(cache))
+                except CacheFull:
+                    errors.append("CacheFull")
+                except Exception as e:  # anything else is a real defect
+                    errors.append(f"{type(e).__name__}: {e}")
+
+            n = 24 // threads
+            ts = [threading.Thread(target=worker, args=(i * n, (i + 1) * n))
+                  for i in range(threads)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join()
+            return errors, peak[0], corrupt
+
+    # Depth-1 prefetching: one fetch ahead of one analysis.
+    errors, peak, corrupt = run(threads=2, budget_mb=30)
+    checks.append(("concurrent fetch + eviction completes without error",
+                   not errors, f"{errors[:2]}"))
+    checks.append(("no file is corrupted by a concurrent eviction",
+                   not corrupt, f"{corrupt[:2]}"))
+    checks.append(("on-disk bytes never exceed the budget",
+                   peak <= 30 * MB, f"peak {peak / 1e6:.0f} MB"))
+
+    # Oversubscribed: must refuse cleanly, never overshoot.
+    errors, peak, corrupt = run(threads=4, budget_mb=30)
+    checks.append(("oversubscription refuses rather than overshooting",
+                   peak <= 30 * MB and not corrupt
+                   and all(e == "CacheFull" for e in errors),
+                   f"peak {peak / 1e6:.0f} MB, errors {set(errors)}"))
+    return checks
+
+
+def _budget_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        free = shutil.disk_usage(tmp).free
+
+        auto = resolve_budget(tmp)
+        checks.append(("an auto budget is a fraction of free disk, capped",
+                       0 < auto <= min(free * 0.25, 50 * 1000**3) + 1,
+                       f"{auto / 1e9:.1f} GB of {free / 1e9:.1f} GB free"))
+
+        checks.append(("an explicit budget is honoured",
+                       resolve_budget(tmp, configured_gb=2.0) == 2 * 1000**3, ""))
+
+        try:
+            resolve_budget(tmp, configured_gb=free / 1000**3 + 100)
+            msg = ""
+        except CacheFull as e:
+            msg = str(e)
+        checks.append(("a budget beyond free disk is refused",
+                       "exceeds the" in msg and "free" in msg, msg[:60]))
+
+        # The pre-flight case: peak requirement known before the run starts.
+        try:
+            resolve_budget(tmp, configured_gb=1.0, required_bytes=3 * 1000**3)
+            msg2 = ""
+        except CacheFull as e:
+            msg2 = str(e)
+        checks.append(("too small for the largest recording is caught up front",
+                       "needs" in msg2 and "cache_budget_gb" in msg2, msg2[:70]))
+        checks.append(("…and the message says how much is actually free",
+                       "free on" in msg2, msg2[-60:]))
+
+        checks.append(("budgeting works for a directory that doesn't exist yet",
+                       resolve_budget(tmp / "not" / "made" / "yet") > 0, ""))
+    return checks
+
+
+def _redaction_checks() -> list[Check]:
+    """A share link must not travel inside a results bundle."""
+    from meanap.params import (
+        PARAMS_FILENAME, REDACTED, SECRET_URL_FIELDS, Params, redact,
+    )
+
+    checks: list[Check] = []
+    URL = "https://www.dropbox.com/scl/fo/abc/XYZ?rlkey=supersecret"
+
+    # Redaction is by value, not by field name: the same field holds a local
+    # path on most runs and a share link on a remote one.
+    out = redact({"raw_data": URL, "output_data_folder": "/home/me/out"})
+    checks.append(("a url in raw_data is redacted",
+                   out["raw_data"] == REDACTED, out["raw_data"][:40]))
+    checks.append(("…with a placeholder, so its absence is visible",
+                   "redacted" in out["raw_data"], ""))
+    local = redact({"raw_data": "/home/me/data"})
+    checks.append(("a local path in the same field is left alone",
+                   local["raw_data"] == "/home/me/data", ""))
+    checks.append(("every path field that could hold a url is covered",
+                   {"raw_data", "prior_analysis_path"} <= set(SECRET_URL_FIELDS),
+                   f"{SECRET_URL_FIELDS}"))
+
+    # End to end: through a real bundle.
+    sys.path.insert(0, str(REPO_ROOT / "python"))
+    from test_bundle_render import BUNDLE_SUFFIX, _run  # noqa: E402
+    from meanap.pipeline.bundle import open_bundle
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        root = _run(tmp, "Express", express=True)
+        # Stamp a link into the run's own params, as a remote run would.
+        pfile = root / PARAMS_FILENAME
+        raw = json.loads(pfile.read_text())
+        raw["raw_data"] = URL
+        pfile.write_text(json.dumps(raw))
+
+        from meanap.pipeline.bundle import build_manifest, write_bundle
+        from meanap.pipeline.spreadsheet import RecordingInfo
+        write_bundle(root, build_manifest(
+            Params(), [RecordingInfo(filename="recA", div=21.0, group="WT")],
+            mode="catnap", lags=[25]), root.with_suffix(BUNDLE_SUFFIX))
+
+        with open_bundle(root.with_suffix(BUNDLE_SUFFIX)) as b:
+            shipped = json.loads((b.root / PARAMS_FILENAME).read_text())
+            checks.append(("the bundled params carry no url",
+                           shipped["raw_data"] == REDACTED,
+                           shipped["raw_data"][:40]))
+            checks.append(("the secret does not appear anywhere in the bundle",
+                           not any("supersecret" in p.read_bytes().decode(
+                               "utf-8", "ignore")
+                               for p in b.root.rglob("*") if p.is_file()), ""))
+        checks.append(("the local copy keeps it, for reproducibility",
+                       json.loads(pfile.read_text())["raw_data"] == URL, ""))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Remote data: store protocol, cache, budgeting, redaction")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [
+        ("A — the store protocol and local passthrough:", _protocol_checks),
+        ("B — cache bounds, eviction and pinning:", _cache_checks),
+        ("C — partial fetches never become cache hits:", _integrity_checks),
+        ("D — concurrent fetch, eviction and pinning:", _concurrency_checks),
+        ("E — disk budgeting:", _budget_checks),
+        ("F — share links don't travel in bundles:", _redaction_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_remote_dropbox.py
+++ b/python/test_remote_dropbox.py
@@ -1,0 +1,389 @@
+"""Test the Dropbox share-link store.
+
+Run from the repo root::
+
+    uv run python python/test_remote_dropbox.py           # offline
+    MEANAP_DROPBOX_URL='https://…' uv run python python/test_remote_dropbox.py
+
+The default run uses a fake HTTP layer and needs no network. That is not a
+convenience: the interesting cases here are the ones a live connection only
+produces by luck — a session expiring, a server ignoring ``Range``, a truncated
+response, an interstitial page served instead of file bytes. Each of those is
+provoked deliberately below.
+
+The adapter depends on undocumented endpoints, so there is also a live section.
+It runs only when ``MEANAP_DROPBOX_URL`` is set, and its job is to fail loudly
+the day Dropbox changes something — with a message pointing at the supported
+alternatives rather than a stack trace.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.remote.dropbox_link import (  # noqa: E402
+    DropboxInterfaceChanged, DropboxLinkStore, parse_share_url,
+)
+from meanap.remote.http import HttpResponse  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+LINK = ("https://www.dropbox.com/scl/fo/LINKKEY/ROOTHASH"
+        "?rlkey=RLKEY&dl=0")
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+# ── a fake Dropbox ────────────────────────────────────────────────────────────
+
+TREE = {
+    "": [("rec1", True, None), ("batch.csv", False, 1200)],
+    "/rec1": [("suite2p", True, None)],
+    "/rec1/suite2p": [("plane0", True, None)],
+    "/rec1/suite2p/plane0": [("F.npy", False, 40), ("ops.npy", False, 100)],
+}
+
+
+def _fake_hash(sub_path: str) -> str:
+    """Stand-in for Dropbox's per-entry secure_hash: opaque and slash-free."""
+    return "HASH" + sub_path.strip("/").replace("/", "_")
+
+
+class FakeHttp:
+    """Enough of :class:`HttpClient` to drive the adapter, with failure switches."""
+
+    def __init__(self, **flags):
+        self.flags = flags
+        self.posts: list[dict] = []
+        self.streams: list[tuple[str, int]] = []
+        self._token = "TOKEN1"
+        self.token_reads = 0
+
+    # session
+    def get(self, url, headers=None):
+        self.token_reads += 1
+        return HttpResponse(200, {}, b"<html></html>")
+
+    def cookie(self, name):
+        if self.flags.get("no_csrf"):
+            return None
+        return self._token
+
+    # listing
+    def post_form(self, url, fields, headers=None):
+        self.posts.append(dict(fields))
+        if self.flags.get("html_listing"):
+            return HttpResponse(200, {}, b"<!DOCTYPE html><html>...")
+        if self.flags.get("expired") and fields["t"] == "TOKEN1":
+            from meanap.remote.http import HttpError
+            self._token = "TOKEN2"
+            raise HttpError("POST listing: HTTP 403", 403)
+
+        sub = fields["sub_path"]
+        # The real endpoint 404s when the hash doesn't match the sub_path; the
+        # fake enforces the same rule so a regression in the walk is caught.
+        # Real hashes are opaque and slash-free, so the fake's must be too —
+        # otherwise the link regex would stop at the first slash.
+        expected = "ROOTHASH" if sub == "" else _fake_hash(sub)
+        if fields["secure_hash"] != expected:
+            from meanap.remote.http import HttpError
+            raise HttpError("POST listing: HTTP 404", 404)
+        if sub not in TREE:
+            from meanap.remote.http import HttpError
+            raise HttpError("POST listing: HTTP 404", 404)
+
+        entries = []
+        for name, is_dir, size in TREE[sub]:
+            child = f"{sub}/{name}"
+            entries.append({
+                "filename": name, "is_dir": is_dir, "bytes": size,
+                "href": (f"https://www.dropbox.com/scl/fo/LINKKEY/"
+                         f"{_fake_hash(child)}{child}?rlkey=RLKEY&dl=0"),
+            })
+        body = {"entries": entries, "total_num_entries": len(entries)}
+        if self.flags.get("no_entries_key"):
+            body = {"unexpected": True}
+        if self.flags.get("paginated"):
+            body["has_more_entries"] = True
+        return HttpResponse(200, {}, json.dumps(body).encode())
+
+    # download
+    def stream(self, url, start=0, chunk_size=1 << 20):
+        self.streams.append((url, start))
+        if self.flags.get("html_body"):
+            return 200, {"Content-Type": "text/html"}, iter([b"<!DOCTYPE html>"])
+        payload = bytes(range(40))
+        if self.flags.get("ignores_range"):
+            return 200, {"Content-Type": "application/octet-stream"}, iter([payload])
+        if self.flags.get("truncated"):
+            return 200, {"Content-Type": "application/octet-stream"}, iter([payload[:10]])
+        if start:
+            return 206, {"Content-Type": "application/octet-stream"}, iter([payload[start:]])
+        return 200, {"Content-Type": "application/octet-stream"}, iter([payload])
+
+
+def _store(**flags) -> tuple[DropboxLinkStore, FakeHttp]:
+    http = FakeHttp(**flags)
+    return DropboxLinkStore(LINK, client=http), http
+
+
+# ── sections ──────────────────────────────────────────────────────────────────
+
+
+def _url_checks() -> list[Check]:
+    checks: list[Check] = []
+    key, h, rl = parse_share_url(LINK)
+    checks.append(("a folder link parses", (key, h, rl) == ("LINKKEY", "ROOTHASH", "RLKEY"),
+                   f"{(key, h, rl)}"))
+    checks.append(("extra query parameters are tolerated",
+                   parse_share_url(LINK + "&st=abc&e=1")[2] == "RLKEY", ""))
+
+    for bad, expect in [
+        ("https://example.com/x", "Not a Dropbox share link"),
+        ("https://www.dropbox.com/scl/fi/K/H?rlkey=R", "link to a single file"),
+        ("https://www.dropbox.com/scl/fo/K/H", "no 'rlkey'"),
+    ]:
+        try:
+            parse_share_url(bad)
+            msg = ""
+        except ValueError as e:
+            msg = str(e)
+        checks.append((f"rejected with a reason: {expect}", expect in msg, msg[:60]))
+    return checks
+
+
+def _walk_checks() -> list[Check]:
+    checks: list[Check] = []
+    store, http = _store()
+
+    root = {e.name: e for e in store.list()}
+    checks.append(("lists the root", set(root) == {"rec1", "batch.csv"}, f"{sorted(root)}"))
+    checks.append(("file sizes come from the listing", root["batch.csv"].size == 1200, ""))
+    checks.append(("directories report no size", root["rec1"].size is None, ""))
+
+    deep = {e.name: e for e in store.list("rec1/suite2p/plane0")}
+    checks.append(("descends three levels", set(deep) == {"F.npy", "ops.npy"},
+                   f"{sorted(deep)}"))
+    checks.append(("nested entries carry full relative paths",
+                   deep["F.npy"].path == "rec1/suite2p/plane0/F.npy",
+                   deep["F.npy"].path))
+
+    # The walk must reuse cached ancestors rather than re-listing them.
+    posts_before = len(http.posts)
+    store.list("rec1/suite2p/plane0")
+    checks.append(("a repeated listing costs no requests",
+                   len(http.posts) == posts_before, f"{len(http.posts) - posts_before}"))
+
+    checks.append(("stat finds a nested file",
+                   store.stat("rec1/suite2p/plane0/F.npy").size == 40, ""))
+    checks.append(("stat returns None for a missing name",
+                   store.stat("rec1/suite2p/plane0/nope.npy") is None, ""))
+    checks.append(("listing a non-existent folder is empty, not an error",
+                   store.list("rec1/nope") == [], ""))
+
+    # The download URL must use raw=1 — dl=1 returns an interstitial page.
+    url = store._download_url("rec1/suite2p/plane0/F.npy")
+    checks.append(("download url uses raw=1", "raw=1" in url, url[-40:]))
+    checks.append(("…and drops dl=", "dl=" not in url, url[-40:]))
+    checks.append(("…and keeps the access key", "rlkey=RLKEY" in url, ""))
+    return checks
+
+
+def _session_checks() -> list[Check]:
+    checks: list[Check] = []
+
+    store, http = _store(expired=True)
+    entries = store.list()
+    checks.append(("an expired session is refreshed and retried",
+                   len(entries) == 2, f"{len(entries)}"))
+    checks.append(("…using a new token",
+                   http.posts[-1]["t"] == "TOKEN2", f"{http.posts[-1]['t']}"))
+
+    store, _ = _store(no_csrf=True)
+    try:
+        store.list()
+        msg = ""
+    except DropboxInterfaceChanged as e:
+        msg = str(e)
+    checks.append(("a missing CSRF cookie is reported as an interface change",
+                   "CSRF cookie" in msg, msg[:50]))
+    checks.append(("…with the supported alternatives named",
+                   "rclone" in msg and "synced Dropbox folder" in msg, ""))
+    return checks
+
+
+def _interface_change_checks() -> list[Check]:
+    """Every way this can rot must fail loudly, never as "the folder is empty"."""
+    checks: list[Check] = []
+
+    for flags, label, expect in [
+        (dict(html_listing=True), "HTML instead of JSON", "HTML instead of JSON"),
+        (dict(no_entries_key=True), "no 'entries' key", "no 'entries' key"),
+        (dict(paginated=True), "a paginated listing", "paginated listings"),
+    ]:
+        store, _ = _store(**flags)
+        try:
+            store.list()
+            msg = ""
+        except DropboxInterfaceChanged as e:
+            msg = str(e)
+        checks.append((f"{label} raises DropboxInterfaceChanged", expect in msg, msg[:60]))
+
+    store, _ = _store(html_body=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            store.fetch("rec1/suite2p/plane0/F.npy", Path(tmp) / "F.npy")
+            msg = ""
+        except DropboxInterfaceChanged as e:
+            msg = str(e)
+    checks.append(("a web page served instead of file bytes is caught",
+                   "web page instead of file data" in msg, msg[:60]))
+    return checks
+
+
+def _download_checks() -> list[Check]:
+    checks: list[Check] = []
+    rel = "rec1/suite2p/plane0/F.npy"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store, http = _store()
+        dest = Path(tmp) / "F.npy"
+        store.fetch(rel, dest)
+        checks.append(("a fresh download is complete",
+                       dest.read_bytes() == bytes(range(40)), ""))
+
+        # Resume: half the bytes already present.
+        dest.write_bytes(bytes(range(40))[:15])
+        http.streams.clear()
+        store.fetch(rel, dest)
+        checks.append(("a partial file is resumed, not restarted",
+                       http.streams[-1][1] == 15, f"{http.streams[-1][1]}"))
+        checks.append(("…and the result is byte-identical",
+                       dest.read_bytes() == bytes(range(40)), ""))
+
+        # Already complete: no request at all.
+        http.streams.clear()
+        store.fetch(rel, dest)
+        checks.append(("a complete file triggers no download",
+                       not http.streams, f"{len(http.streams)}"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # A server that ignores Range must not have its bytes appended.
+        store, _ = _store(ignores_range=True)
+        dest = Path(tmp) / "F.npy"
+        dest.write_bytes(bytes(range(40))[:15])
+        store.fetch(rel, dest)
+        checks.append(("a server ignoring Range restarts cleanly",
+                       dest.read_bytes() == bytes(range(40)),
+                       f"{len(dest.read_bytes())} bytes"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store, _ = _store(truncated=True)
+        try:
+            store.fetch(rel, Path(tmp) / "F.npy")
+            msg = ""
+        except Exception as e:
+            msg = str(e)
+        checks.append(("a truncated response is detected against the listed size",
+                       "expected 40" in msg, msg[:60]))
+    return checks
+
+
+def _live_checks(url: str) -> list[Check]:
+    """Against the real Dropbox. Fails the day the undocumented endpoints change."""
+    import numpy as np
+
+    from meanap.remote.cache import FileCache
+
+    checks: list[Check] = []
+    store = DropboxLinkStore(url)
+    root = store.list()
+    checks.append(("the live root lists", len(root) > 0, f"{len(root)}"))
+    checks.append(("entries carry sizes without downloading",
+                   any(e.size for e in root if not e.is_dir)
+                   or all(e.is_dir for e in root), ""))
+
+    folders = [e for e in root if e.is_dir]
+    if not folders:
+        checks.append(("a recording folder exists", False, "none found"))
+        return checks
+
+    plane0 = None
+    for folder in folders:
+        candidate = f"{folder.path}/suite2p/plane0"
+        if store.list(candidate):
+            plane0 = candidate
+            break
+    checks.append(("a suite2p/plane0 is reachable", plane0 is not None, ""))
+    if plane0 is None:
+        return checks
+
+    files = {e.name: e for e in store.list(plane0)}
+    checks.append(("plane0 lists .npy files",
+                   any(n.endswith(".npy") for n in files), f"{sorted(files)[:4]}"))
+
+    name = "F.npy" if "F.npy" in files else next(iter(files))
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=2_000_000_000)
+        got = cache.get(store, f"{plane0}/{name}")
+        checks.append(("a file downloads to the listed size",
+                       got.stat().st_size == files[name].size,
+                       f"{got.stat().st_size} vs {files[name].size}"))
+        if name.endswith(".npy"):
+            try:
+                arr = np.load(got, mmap_mode="r", allow_pickle=True)
+                ok = getattr(arr, "shape", None) is not None or True
+            except Exception as e:
+                ok, arr = False, e
+            checks.append(("…and is a readable .npy, not an HTML page", ok, f"{arr}"))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Dropbox share-link store")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [
+        ("A — share-link URLs:", _url_checks),
+        ("B — listing and the folder walk:", _walk_checks),
+        ("C — session and CSRF handling:", _session_checks),
+        ("D — every way the interface can rot:", _interface_change_checks),
+        ("E — downloads, resume and truncation:", _download_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+
+    live = os.environ.get("MEANAP_DROPBOX_URL")
+    if live:
+        p, n = _report("F — against the live Dropbox link:", _live_checks(live))
+        total_pass += p
+        total += n
+    else:
+        print("\nF — live Dropbox check SKIPPED "
+              "(set MEANAP_DROPBOX_URL to run it)")
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_remote_pipeline.py
+++ b/python/test_remote_pipeline.py
@@ -1,0 +1,450 @@
+"""Test running a CAT-NAP batch from a remote source with bounded local disk.
+
+Run from the repo root::
+
+    uv run python python/test_remote_pipeline.py
+
+The claim phase 7 makes is a bound, not a speed-up: *peak local storage is one
+or two recordings, whatever the size of the batch*. So the load-bearing check
+samples disk usage throughout a run over a dataset several times larger than
+the cache budget, and asserts the budget was never exceeded — and that the run
+still produced the same results a fully-local run does.
+
+The remote is a fake store backed by a directory, so this needs no network but
+exercises the real fetch/pin/evict path (``copies = True``).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.remote.source import RecordingSource  # noqa: E402
+from meanap.params import Params  # noqa: E402
+from meanap.remote.cache import FileCache  # noqa: E402
+from meanap.remote.local import LocalStore  # noqa: E402
+from meanap.remote.prefetch import stream_ahead  # noqa: E402
+from meanap.pipeline.spreadsheet import RecordingInfo  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+N_CELLS, N_FRAMES = 8, 300
+#: Big enough that a few recordings cannot all be resident at once.
+PAD_BYTES = 4_000_000
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+class CopyingStore(LocalStore):
+    """A directory pretending to be remote: reads cost a real copy."""
+
+    copies = True
+
+    def fetch(self, path: str, dest: Path, progress=None) -> Path:
+        src = self._resolve(path)
+        if not src.is_file():
+            raise FileNotFoundError(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(src.read_bytes())
+        return dest
+
+
+def _make_dataset(root: Path, names: list[str]) -> None:
+    rng = np.random.default_rng(0)
+    for i, name in enumerate(names):
+        d = root / name / "suite2p" / "plane0"
+        d.mkdir(parents=True)
+        np.save(d / "F.npy", rng.random((N_CELLS, N_FRAMES)).astype(np.float32) + 1)
+        np.save(d / "spks.npy", rng.random((N_CELLS, N_FRAMES)).astype(np.float32))
+        np.save(d / "iscell.npy", np.ones((N_CELLS, 2)))
+        np.save(d / "stat.npy",
+                np.array([{"med": [int(rng.integers(0, 64)), int(rng.integers(0, 64))]}
+                          for _ in range(N_CELLS)], dtype=object), allow_pickle=True)
+        # ops carries the bulk, as it does in real suite2p output.
+        np.save(d / "ops.npy", np.array(
+            {"fs": 30.0, "meanImgE": rng.random((64, 64)),
+             "pad": np.zeros(PAD_BYTES // 8)}, dtype=object), allow_pickle=True)
+        # Files the pipeline never opens — must not be fetched.
+        (d / "F.csv").write_bytes(b"x" * 2_000_000)
+        (d / "Fneu.npy").write_bytes(b"x" * 1_000_000)
+
+
+def _params(tmp: Path, out_name: str, **kw) -> Params:
+    p = Params(
+        suite2p_mode=True, twop_activity="F", func_con_lag_val=[33],
+        min_activity_level=0.0, min_number_of_nodes_to_cal_net_met=2,
+        twop_subnetwork_analysis=False, num_2p_traces=0,
+        twop_network_background=True, auto_set_cartography_boundaries=False,
+        random_seed=3, express_mode=True,
+        output_data_folder=str(tmp), output_data_folder_name=out_name,
+        derived_data_folder=str(tmp / "derived"),
+    )
+    for k, v in kw.items():
+        setattr(p, k, v)
+    return p
+
+
+def _prefetch_checks() -> list[Check]:
+    """Ordering, lookahead bound, and failures that don't end the batch."""
+    checks: list[Check] = []
+
+    order, in_flight, peak = [], [0], [0]
+    lock = threading.Lock()
+
+    def fetch(i: int) -> int:
+        with lock:
+            in_flight[0] += 1
+            peak[0] = max(peak[0], in_flight[0])
+        time.sleep(0.01)
+        with lock:
+            in_flight[0] -= 1
+        return i * 10
+
+    for item, value in stream_ahead(range(6), fetch, depth=1):
+        order.append((item, value))
+        time.sleep(0.02)
+
+    checks.append(("results arrive in the original order",
+                   [i for i, _ in order] == list(range(6)), f"{[i for i, _ in order]}"))
+    checks.append(("each result matches its item",
+                   all(v == i * 10 for i, v in order), ""))
+    checks.append(("at most one fetch runs at a time", peak[0] <= 1, f"{peak[0]}"))
+
+    # depth=0 must still work — that is simply "no prefetching".
+    serial = list(stream_ahead(range(3), lambda i: i, depth=0))
+    checks.append(("depth 0 degrades to serial", [i for i, _ in serial] == [0, 1, 2], ""))
+
+    def flaky(i: int) -> int:
+        if i == 1:
+            raise OSError("connection reset")
+        return i
+
+    got = list(stream_ahead(range(4), flaky, depth=1))
+    checks.append(("a failed fetch is handed over, not raised",
+                   isinstance(got[1][1], OSError), f"{got[1][1]!r}"))
+    checks.append(("…and the rest of the batch still runs",
+                   [i for i, _ in got] == [0, 1, 2, 3], ""))
+    return checks
+
+
+def _selective_fetch_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_dataset(tmp / "remote", ["rec0"])
+        store = CopyingStore(tmp / "remote")
+        cache = FileCache(root=tmp / "cache", budget_bytes=200_000_000)
+        source = RecordingSource(store=store, cache=cache, log=lambda m: None)
+
+        plane0 = source.plane0("rec0")
+        fetched = {p.name for p in plane0.iterdir()}
+        checks.append(("the required files are fetched",
+                       {"F.npy", "iscell.npy", "stat.npy", "ops.npy"} <= fetched,
+                       f"{sorted(fetched)}"))
+        checks.append(("files the pipeline never opens are not fetched",
+                       "F.csv" not in fetched and "Fneu.npy" not in fetched,
+                       f"{sorted(fetched)}"))
+
+        from meanap.catnap.loader import load_suite2p
+        data = load_suite2p(plane0, tmp / "derived", "rec0")
+        checks.append(("the fetched folder loads as a real recording",
+                       data.F.shape == (N_CELLS, N_FRAMES) and data.fs == 30.0,
+                       f"{data.F.shape}"))
+
+        before = cache.usage()
+        source.release("rec0")
+        checks.append(("releasing frees the cache",
+                       cache.usage() == 0 and before > 0,
+                       f"{before} -> {cache.usage()}"))
+
+        missing = None
+        try:
+            source.plane0("nope")
+        except FileNotFoundError as e:
+            missing = str(e)
+        checks.append(("a recording with no suite2p output is reported",
+                       missing is not None, f"{missing}"))
+    return checks
+
+
+def _bounded_run_checks() -> list[Check]:
+    """The claim: a batch far larger than the cache still runs, within budget."""
+    from meanap.catnap import pipeline as cp
+    from meanap.pipeline.output_folders import create_output_folders
+
+    checks: list[Check] = []
+    names = [f"rec{i}" for i in range(6)]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_dataset(tmp / "remote", names)
+        dataset_bytes = sum(p.stat().st_size
+                            for p in (tmp / "remote").rglob("*") if p.is_file())
+
+        store = CopyingStore(tmp / "remote")
+        # Room for ~2 recordings, against a dataset of six.
+        budget = 12_000_000
+        cache = FileCache(root=tmp / "cache", budget_bytes=budget)
+
+        samples = [0]
+        stop = threading.Event()
+
+        def sample() -> None:
+            while not stop.is_set():
+                total = 0
+                for p in (tmp / "cache").rglob("*"):
+                    try:
+                        if p.is_file():
+                            total += p.stat().st_size
+                    except OSError:
+                        pass
+                samples[0] = max(samples[0], total)
+                time.sleep(0.005)
+
+        watcher = threading.Thread(target=sample, daemon=True)
+        watcher.start()
+        try:
+            out = create_output_folders(tmp, "Remote", ["WT"])
+            source = RecordingSource(store=store, cache=cache, log=lambda m: None)
+            cp.run_catnap_pipeline(
+                _params(tmp, "Remote"),
+                [RecordingInfo(filename=n, div=21.0, group="WT") for n in names],
+                out, lambda m: None, source=source)
+        finally:
+            stop.set()
+            watcher.join(timeout=2)
+
+        checks.append((f"the dataset is far larger than the budget "
+                       f"({dataset_bytes / 1e6:.0f} MB vs {budget / 1e6:.0f} MB)",
+                       dataset_bytes > budget * 3, f"{dataset_bytes / 1e6:.0f} MB"))
+        checks.append((f"peak cache never exceeded the budget "
+                       f"({samples[0] / 1e6:.1f} MB)",
+                       samples[0] <= budget, f"{samples[0]} > {budget}"))
+
+        import pandas as pd
+        csv = out / "4_NetworkActivity" / "NetworkActivity_RecordingLevel.csv"
+        checks.append(("the run produced results", csv.exists(), ""))
+        if csv.exists():
+            df = pd.read_csv(csv)
+            checks.append((f"every recording was analysed ({len(df)}/6)",
+                           set(df["FileName"]) == set(names), f"{sorted(set(df['FileName']))}"))
+
+        checks.append(("the cache is empty when the run ends",
+                       cache.usage() == 0, f"{cache.usage()}"))
+        checks.append(("nothing was written into the source data",
+                       not list((tmp / "remote").rglob("Fdenoised.npy")), ""))
+
+        # The same batch, run locally, must give identical numbers.
+        out2 = create_output_folders(tmp, "Local", ["WT"])
+        local_source = RecordingSource(
+            store=LocalStore(tmp / "remote"), cache=None, log=lambda m: None)
+        cp.run_catnap_pipeline(
+            _params(tmp, "Local"),
+            [RecordingInfo(filename=n, div=21.0, group="WT") for n in names],
+            out2, lambda m: None, source=local_source)
+        a = pd.read_csv(csv)
+        b = pd.read_csv(out2 / "4_NetworkActivity" / "NetworkActivity_RecordingLevel.csv")
+        checks.append(("remote and local runs agree exactly",
+                       a.equals(b), "CSVs differ"))
+    return checks
+
+
+def _ephys_source_checks() -> list[Check]:
+    """The electrophysiology path: one file per recording, sometimes shared.
+
+    An Axion ``.raw`` holds a whole plate and MEA-NAP treats each well as its
+    own recording, so several recordings map to one file. Releasing it when the
+    first well finishes would re-download it for the next — which is what the
+    reference counting exists to prevent.
+    """
+    checks: list[Check] = []
+    MB = 1_000_000
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        remote = tmp / "remote"
+        remote.mkdir()
+        (remote / "recA.mat").write_bytes(b"m" * 8 * MB)
+        (remote / "recB.h5").write_bytes(b"h" * 6 * MB)
+
+        store = CopyingStore(remote)
+        cache = FileCache(root=tmp / "cache", budget_bytes=100 * MB)
+        source = RecordingSource(store=store, cache=cache, log=lambda m: None)
+
+        got = source.raw_file("recA")
+        checks.append((".mat is found and fetched",
+                       got.path.exists() and got.path.stat().st_size == 8 * MB,
+                       f"{got.path}"))
+        checks.append(("no well is set for a single-recording file",
+                       got.well is None, f"{got.well}"))
+        checks.append((".h5 is found too",
+                       source.raw_file("recB").path.stat().st_size == 6 * MB, ""))
+
+        source.release("recA")
+        checks.append(("releasing frees just that recording",
+                       not cache.path_for(store, "recA.mat").exists()
+                       and cache.path_for(store, "recB.h5").exists(), ""))
+
+        missing = None
+        try:
+            source.raw_file("ghost")
+        except FileNotFoundError as e:
+            missing = str(e)
+        checks.append(("a missing recording names the extensions tried",
+                       missing and ".mat" in missing, f"{missing}"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # One plate, three wells: fetched once, kept until the last well is done.
+        tmp = Path(tmp)
+        remote = tmp / "remote"
+        remote.mkdir()
+        (remote / "plate1.raw").write_bytes(b"r" * 20 * MB)
+        store = CopyingStore(remote)
+        cache = FileCache(root=tmp / "cache", budget_bytes=100 * MB)
+        source = RecordingSource(store=store, cache=cache, log=lambda m: None)
+
+        wells = ["plate1_A1", "plate1_A2", "plate1_A3"]
+        sources = [source.raw_file(w) for w in wells]
+        checks.append(("every well resolves to the one plate file",
+                       len({s.path for s in sources}) == 1, ""))
+        checks.append(("each well knows which one it is",
+                       [s.well for s in sources] == ["A1", "A2", "A3"],
+                       f"{[s.well for s in sources]}"))
+        checks.append(("the plate is fetched once, not per well",
+                       cache.usage() == 20 * MB, f"{cache.usage()}"))
+
+        source.release("plate1_A1")
+        checks.append(("the plate survives the first well finishing",
+                       cache.path_for(store, "plate1.raw").exists(), ""))
+        source.release("plate1_A2")
+        checks.append(("…and the second", cache.path_for(store, "plate1.raw").exists(), ""))
+        source.release("plate1_A3")
+        checks.append(("…and is dropped when the last one is done",
+                       not cache.path_for(store, "plate1.raw").exists()
+                       and cache.usage() == 0, f"{cache.usage()}"))
+    return checks
+
+
+def _ephys_run_checks() -> list[Check]:
+    """A remote electrophysiology run, end to end, within a small budget."""
+    import pandas as pd
+
+    from meanap.pipeline.runner import run_pipeline
+
+    checks: list[Check] = []
+    REPO = Path("/home/timsit/MEA-NAP")
+    dataset = REPO / "local" / "testBurstDetection"
+    if not (dataset / "HCNT26_DIV58_E2.mat").exists():
+        checks.append(("SKIPPED — example ephys dataset not present", True, ""))
+        return checks
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        params = Params(
+            raw_data=str(dataset),
+            spreadsheet_file_name=str(dataset / "testBurstDetection.csv"),
+            spreadsheet_range="2:1000", output_data_folder=str(tmp),
+            output_data_folder_name="Local", start_analysis_step=1,
+            stop_analysis_step=4, func_con_lag_val=[25], random_seed=1,
+            express_mode=True,
+        )
+        local_out = run_pipeline(params, log=lambda m: None)
+
+        # Now the same data through a store that copies, with a tight budget.
+        import meanap.pipeline.runner as runner
+
+        def copying_open_store(p):
+            return CopyingStore(p.raw_data)
+
+        runner_open = runner._build_raw_source
+        def build(p, log):
+            store = CopyingStore(p.raw_data)
+            return RecordingSource(
+                store=store,
+                cache=FileCache(root=Path(p.output_data_folder) / "c",
+                                budget_bytes=400_000_000),
+                log=log)
+        runner._build_raw_source = build
+        try:
+            params.output_data_folder_name = "Remote"
+            remote_out = run_pipeline(params, log=lambda m: None)
+        finally:
+            runner._build_raw_source = runner_open
+
+        a = pd.read_csv(local_out / "4_NetworkActivity" / "NetworkActivity_RecordingLevel.csv")
+        b = pd.read_csv(remote_out / "4_NetworkActivity" / "NetworkActivity_RecordingLevel.csv")
+        checks.append(("a remote ephys run produces results", len(b) > 0, f"{len(b)}"))
+        checks.append(("…identical to the local run", a.equals(b), "CSVs differ"))
+        cache = Path(params.output_data_folder) / "c"
+        left = sum(p.stat().st_size for p in cache.rglob("*") if p.is_file()) if cache.exists() else 0
+        checks.append(("the raw recording is released after step 1",
+                       left == 0, f"{left / 1e6:.0f} MB left"))
+    return checks
+
+
+def _name_map_checks() -> list[Check]:
+    """Folders renamed away from the spreadsheet resolve without editing either."""
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        _make_dataset(tmp / "remote", ["rec0 Some Person"])
+        store = CopyingStore(tmp / "remote")
+        cache = FileCache(root=tmp / "cache", budget_bytes=200_000_000)
+
+        plain = RecordingSource(store=store, cache=cache, log=lambda m: None)
+        failed = False
+        try:
+            plain.plane0("rec0")
+        except FileNotFoundError:
+            failed = True
+        checks.append(("without a map, a renamed folder is not found", failed, ""))
+
+        mapped = RecordingSource(store=store, cache=cache, log=lambda m: None,
+                                 name_map={"rec0": "rec0 Some Person"})
+        got = mapped.plane0("rec0")
+        checks.append(("with a map, it resolves to the real folder",
+                       got.exists() and "Some Person" in str(got), f"{got}"))
+        freed = mapped.cache.evict_prefix(store, mapped.folder("rec0"))
+        checks.append(("release uses the mapped name too", freed > 0, f"{freed}"))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Remote batch: prefetch, eviction, bounded storage")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [
+        ("A — prefetch ordering and failures:", _prefetch_checks),
+        ("B — fetching only what the pipeline opens:", _selective_fetch_checks),
+        ("C — a batch larger than the cache:", _bounded_run_checks),
+        ("D — electrophysiology: files, plates and refcounts:", _ephys_source_checks),
+        ("E — a remote electrophysiology run:", _ephys_run_checks),
+        ("F — renamed folders resolve via the name map:", _name_map_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_remote_preflight.py
+++ b/python/test_remote_preflight.py
@@ -1,0 +1,280 @@
+"""Test the pre-flight check.
+
+Run from the repo root::
+
+    uv run python python/test_remote_preflight.py
+
+Pre-flight exists to stop one specific failure: a batch that runs, finishes, and
+reports results computed from a fraction of the recordings you asked for.
+Because the node-cartography boundaries and every group comparison are derived
+from whichever recordings actually ran, a silently-shortened batch produces
+numbers that look complete and aren't.
+
+So the checks here are mostly about *refusing*: an empty match set is a problem
+rather than a warning, and a folder that exists under a slightly different name
+is called out by name rather than counted as absent.
+
+Runs against a synthetic tree through :class:`LocalStore`; no network.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.remote.local import LocalStore  # noqa: E402
+from meanap.remote.preflight import (  # noqa: E402
+    CATNAP_REQUIRED, MAX_LISTED, find_spreadsheet, run_preflight,
+)
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+def _plane0(root: Path, name: str, *, files=CATNAP_REQUIRED,
+            denoised=False, junk=True) -> None:
+    d = root / name / "suite2p" / "plane0"
+    d.mkdir(parents=True)
+    for f in files:
+        (d / f).write_bytes(b"x" * 1_000_000)
+    if denoised:
+        (d / "Fdenoised.npy").write_bytes(b"x" * 500_000)
+    if junk:
+        # The files the pipeline never opens — must be counted as skipped, not
+        # fetched, since not fetching them is a fifth of the transfer.
+        (d / "F.csv").write_bytes(b"x" * 2_000_000)
+        (d / "Fneu.npy").write_bytes(b"x" * 1_000_000)
+
+
+def _catnap_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _plane0(root, "recA", denoised=True)
+        _plane0(root, "recB")                                  # needs denoising
+        _plane0(root, "recC", files=("stat.npy", "F.npy"))     # incomplete
+        (root / "recD").mkdir()                                # no suite2p
+        (root / "extra").mkdir()                               # unreferenced
+        (root / "batch.csv").write_bytes(b"x" * 100)
+
+        store = LocalStore(root)
+        rep = run_preflight(store, ["recA", "recB", "recC", "recD", "recE"],
+                            mode="catnap")
+
+        by = {r.name: r for r in rep.recordings}
+        checks.append(("a complete recording is ready", by["recA"].ok, ""))
+        checks.append(("a recording without denoising is still ready",
+                       by["recB"].ok and by["recB"].needs_denoising, ""))
+        checks.append(("an incomplete plane0 names the missing files",
+                       not by["recC"].ok
+                       and set(by["recC"].missing) == {"iscell.npy", "ops.npy"},
+                       f"{by['recC'].missing}"))
+        checks.append(("a folder without suite2p/plane0 is not found",
+                       not by["recD"].found and by["recD"].missing == ["suite2p/plane0"],
+                       f"{by['recD'].missing}"))
+        checks.append(("a recording absent entirely is not found",
+                       not by["recE"].found, ""))
+        checks.append(("folders not in the spreadsheet are reported",
+                       "extra" in rep.unreferenced, f"{rep.unreferenced}"))
+
+        checks.append(("only files the pipeline opens are counted for download",
+                       by["recA"].fetch_bytes == 4_500_000,
+                       f"{by['recA'].fetch_bytes}"))
+        checks.append(("the rest is counted as skipped",
+                       by["recA"].skipped_bytes == 3_000_000,
+                       f"{by['recA'].skipped_bytes}"))
+
+        checks.append(("usable counts only fully-ready recordings",
+                       {r.name for r in rep.usable} == {"recA", "recB"},
+                       f"{[r.name for r in rep.usable]}"))
+        checks.append(("a partial batch warns about batch-wide statistics",
+                       any("node-cartography" in w for w in rep.warnings), ""))
+    return checks
+
+
+def _ephys_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "recA.mat").write_bytes(b"x" * 3_000_000)
+        (root / "recB.h5").write_bytes(b"x" * 2_000_000)
+        (root / "recC.txt").write_bytes(b"x" * 10)
+
+        rep = run_preflight(LocalStore(root), ["recA", "recB", "recC"],
+                            mode="ephys")
+        by = {r.name: r for r in rep.recordings}
+        checks.append((".mat is found", by["recA"].ok
+                       and by["recA"].fetch_bytes == 3_000_000, ""))
+        checks.append((".h5 is found", by["recB"].ok, ""))
+        checks.append(("an unsupported extension is not a recording",
+                       not by["recC"].found, ""))
+        checks.append(("the expected extensions are named in the failure",
+                       ".mat" in by["recC"].missing[0], f"{by['recC'].missing}"))
+    return checks
+
+
+def _rename_checks() -> list[Check]:
+    """The failure that motivated this: folders renamed away from the spreadsheet."""
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _plane0(root, "rec_DIV21 Some Person", denoised=True)
+        _plane0(root, "rec_DIV28 Some Person", denoised=True)
+        _plane0(root, "rec_DIV35", denoised=True)
+
+        rep = run_preflight(LocalStore(root),
+                            ["rec_DIV21", "rec_DIV28", "rec_DIV35"],
+                            mode="catnap")
+        by = {r.name: r for r in rep.recordings}
+        checks.append(("an exactly-named folder is ready", by["rec_DIV35"].ok, ""))
+        checks.append(("a renamed folder is matched to its spreadsheet row",
+                       by["rec_DIV21"].suggestion == "rec_DIV21 Some Person",
+                       f"{by['rec_DIV21'].suggestion}"))
+        checks.append(("each rename is matched once, not shared",
+                       by["rec_DIV28"].suggestion == "rec_DIV28 Some Person",
+                       f"{by['rec_DIV28'].suggestion}"))
+        checks.append(("renames are a problem, not a warning",
+                       any("different folder name" in p for p in rep.problems), ""))
+        checks.append(("…so the run is refused", not rep.ok, ""))
+        checks.append(("the message shows both names",
+                       "rec_DIV21" in rep.problems[0]
+                       and "Some Person" in rep.problems[0], rep.problems[0][:60]))
+
+        rendered = rep.render()
+        checks.append(("the report points at the renamed folder",
+                       "under a different name" in rendered, ""))
+        # It may appear in the hint and in the problem text; what must not
+        # happen is it *also* being listed as an unrelated stray folder, which
+        # would read as two separate issues instead of one.
+        stray = [ln for ln in rendered.splitlines()
+                 if ln.startswith("  ! ") and "Some Person" in ln]
+        checks.append(("a matched rename is not also listed as unreferenced",
+                       not stray, f"{stray}"))
+    return checks
+
+
+def _report_shape_checks() -> list[Check]:
+    """A 381-row spreadsheet must not produce a 381-line report."""
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _plane0(root, "good", denoised=True)
+        names = ["good"] + [f"missing{i}" for i in range(50)]
+        rep = run_preflight(LocalStore(root), names, mode="catnap")
+        text = rep.render()
+
+        checks.append(("the summary line counts the whole batch",
+                       "1 of 51 recordings ready" in text, text.splitlines()[4]))
+        listed = sum(1 for line in text.splitlines() if line.startswith("  ✗ missing"))
+        checks.append((f"at most {MAX_LISTED} failures are spelled out",
+                       listed <= MAX_LISTED, f"{listed}"))
+        checks.append(("the rest are summarised",
+                       "and 42 more not found" in text, ""))
+        checks.append(("the report stays short",
+                       len(text.splitlines()) < 30, f"{len(text.splitlines())} lines"))
+    return checks
+
+
+def _budget_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _plane0(root, "recA", denoised=True)
+        store = LocalStore(root)
+
+        # A local store copies nothing, so budgeting doesn't apply to it.
+        rep = run_preflight(store, ["recA"], mode="catnap",
+                            cache_dir=root / "cache")
+        checks.append(("a local source needs no cache budget",
+                       rep.budget_bytes == 0 and rep.ok, ""))
+
+        # A copying store does. Fake one by flipping the flag.
+        class Copying(LocalStore):
+            copies = True
+
+        store2 = Copying(root)
+        rep2 = run_preflight(store2, ["recA"], mode="catnap",
+                             cache_dir=root / "cache", prefetch_depth=1)
+        checks.append(("peak storage is the largest recording times depth+1",
+                       rep2.peak_bytes == 4_500_000 * 2, f"{rep2.peak_bytes}"))
+        checks.append(("a budget is resolved", rep2.budget_bytes > 0, ""))
+        checks.append(("free disk is reported", rep2.free_bytes > 0, ""))
+
+        rep3 = run_preflight(store2, ["recA"], mode="catnap",
+                             cache_dir=root / "cache", cache_budget_gb=0.000001)
+        checks.append(("a budget too small for one recording is a problem",
+                       any("resident at once" in p for p in rep3.problems),
+                       f"{rep3.problems[:1]}"))
+        checks.append(("…so the run is refused", not rep3.ok, ""))
+    return checks
+
+
+def _spreadsheet_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "only.csv").write_bytes(b"x")
+        store = LocalStore(root)
+        checks.append(("a lone csv at the top level is found",
+                       find_spreadsheet(store) == "only.csv",
+                       f"{find_spreadsheet(store)}"))
+        checks.append(("a configured name is preferred",
+                       find_spreadsheet(store, "only.csv") == "only.csv", ""))
+        checks.append(("a configured name that isn't there returns None",
+                       find_spreadsheet(store, "nope.csv") is None, ""))
+
+        (root / "second.csv").write_bytes(b"x")
+        checks.append(("two candidates is ambiguous, not a guess",
+                       find_spreadsheet(store) is None, ""))
+    return checks
+
+
+def _empty_source_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        rep = run_preflight(LocalStore(Path(tmp)), ["recA", "recB"], mode="catnap")
+        checks.append(("nothing usable is a problem, not a warning",
+                       rep.problems and not rep.ok, ""))
+        checks.append(("the message suggests the likely cause",
+                       "same dataset" in rep.problems[0], rep.problems[0][:60]))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Pre-flight: can this dataset actually be analysed?")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [
+        ("A — CAT-NAP requirements and byte accounting:", _catnap_checks),
+        ("B — electrophysiology recordings:", _ephys_checks),
+        ("C — folders renamed away from the spreadsheet:", _rename_checks),
+        ("D — report stays readable at batch scale:", _report_shape_checks),
+        ("E — storage budget:", _budget_checks),
+        ("F — locating the spreadsheet:", _spreadsheet_checks),
+        ("G — an empty or mismatched source:", _empty_source_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meanap/catnap/denoising.py
+++ b/src/meanap/catnap/denoising.py
@@ -100,21 +100,35 @@ def process_suite2p_folder(
     time_after_peak_s: float = 2.05,
     denoising_width_sec: float = 1.13,
     denoising_wlen_sec: float = 12.0,
-) -> None:
+    derived_root: str | Path | None = None,
+    recording: str | None = None,
+) -> Path:
     """
-    Run the full denoising pipeline on one suite2p/plane0 directory and
-    save outputs as .npy files alongside the inputs.
+    Run the full denoising pipeline on one suite2p/plane0 directory.
 
     Outputs written:
       Fdenoised.npy, timePoints.npy,
       peakStartFrames.npy, peakEndFrames.npy,
       peakHeights.npy, eventAreas.npy
-    """
-    d = Path(suite2p_dir)
-    out_path = d / "Fdenoised.npy"
 
-    if out_path.exists() and not overwrite:
-        return
+    They land beside the suite2p inputs by default — the historical behaviour —
+    or under ``derived_root`` when one is given, which is what makes the raw
+    data usable read-only or remote (see :mod:`meanap.catnap.derived`).
+    Returns the directory written to.
+    """
+    from meanap.catnap.derived import resolve_read, resolve_write_dir
+
+    d = Path(suite2p_dir)
+    out_dir = resolve_write_dir(d, derived_root, recording) if recording else d
+    out_path = out_dir / "Fdenoised.npy"
+
+    # Honour outputs found anywhere we would read them from, not just where we
+    # would write them: a dataset shipped with denoising already done must not
+    # be redone just because a derived root is now configured.
+    existing = (resolve_read(d, derived_root, recording, "Fdenoised.npy")
+                if recording else (out_path if out_path.exists() else None))
+    if existing is not None and not overwrite:
+        return existing.parent
 
     F = np.load(d / "F.npy")          # (n_rois, n_frames)
     ops = np.load(d / "ops.npy", allow_pickle=True).item()
@@ -181,12 +195,13 @@ def process_suite2p_folder(
             mat[i, : len(arr)] = arr
         return mat
 
-    np.save(d / "Fdenoised.npy", F_denoised_out)
-    np.save(d / "timePoints.npy", time_points)
-    np.save(d / "peakStartFrames.npy", _to_matrix(peak_lists))
-    np.save(d / "peakEndFrames.npy", _to_matrix(end_lists))
-    np.save(d / "peakHeights.npy", _to_matrix(height_lists))
-    np.save(d / "eventAreas.npy", _to_matrix(area_lists))
+    np.save(out_dir / "Fdenoised.npy", F_denoised_out)
+    np.save(out_dir / "timePoints.npy", time_points)
+    np.save(out_dir / "peakStartFrames.npy", _to_matrix(peak_lists))
+    np.save(out_dir / "peakEndFrames.npy", _to_matrix(end_lists))
+    np.save(out_dir / "peakHeights.npy", _to_matrix(height_lists))
+    np.save(out_dir / "eventAreas.npy", _to_matrix(area_lists))
+    return out_dir
 
 
 def oasis_available() -> bool:

--- a/src/meanap/catnap/derived.py
+++ b/src/meanap/catnap/derived.py
@@ -1,0 +1,93 @@
+"""Where CAT-NAP's *derived* per-recording files live.
+
+suite2p's own outputs (``F.npy``, ``ops.npy``, …) are inputs: read-only, and
+often not ours to modify. But denoising produces six more ``.npy`` files that
+have always been written *into the same folder*, and :func:`load_suite2p` reads
+them back from there. That is fine on a local copy and wrong everywhere else:
+
+- a shared or archived dataset may be genuinely read-only;
+- a remote source (a mounted or fetched Dropbox folder) either rejects the
+  write or silently uploads ~48 MB per recording back to the remote;
+- two runs with different denoising thresholds overwrite each other's outputs
+  inside the *raw data*, which is the last place a re-runnable artefact should
+  be.
+
+So derived files get their own root, configured by
+``Params.derived_data_folder``. Reads look in the derived location first and
+fall back to the suite2p folder, so datasets that already carry in-folder
+denoising outputs — every dataset produced before this change — keep working
+untouched. Leaving the setting empty preserves the old behaviour exactly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = [
+    "DENOISING_OUTPUTS",
+    "OPS_CACHE_NAME",
+    "derived_dir",
+    "resolve_read",
+    "resolve_write_dir",
+]
+
+#: The files denoising produces. Named here rather than in ``denoising.py`` so
+#: the loader and the writer agree on the set without importing each other.
+DENOISING_OUTPUTS = (
+    "Fdenoised.npy",
+    "timePoints.npy",
+    "peakStartFrames.npy",
+    "peakEndFrames.npy",
+    "peakHeights.npy",
+    "eventAreas.npy",
+)
+
+#: Sidecar holding the two fields the pipeline needs out of ``ops.npy``.
+OPS_CACHE_NAME = "ops_fields.npz"
+
+
+def derived_dir(derived_root: str | Path | None, recording: str) -> Path | None:
+    """Where this recording's derived files go, or ``None`` for "beside the inputs".
+
+    One folder per recording under the root, mirroring how the raw data is
+    organised, so a derived tree can be read alongside a raw one without a name
+    map.
+    """
+    if not derived_root:
+        return None
+    return Path(derived_root) / recording / "plane0"
+
+
+def resolve_write_dir(
+    plane0: Path, derived_root: str | Path | None, recording: str,
+) -> Path:
+    """Directory to write derived files into, created if needed.
+
+    Falls back to the suite2p folder when no derived root is configured — the
+    behaviour every existing run has.
+    """
+    target = derived_dir(derived_root, recording)
+    if target is None:
+        return Path(plane0)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def resolve_read(
+    plane0: Path, derived_root: str | Path | None, recording: str, name: str,
+) -> Path | None:
+    """Locate one derived file: derived root first, then the suite2p folder.
+
+    Derived-first matters when both exist — a dataset shipped with denoising
+    outputs baked in, re-denoised locally at a different threshold, should use
+    the local ones. Returns ``None`` when neither has it.
+    """
+    candidates = []
+    target = derived_dir(derived_root, recording)
+    if target is not None:
+        candidates.append(target / name)
+    candidates.append(Path(plane0) / name)
+    for path in candidates:
+        if path.exists():
+            return path
+    return None

--- a/src/meanap/catnap/loader.py
+++ b/src/meanap/catnap/loader.py
@@ -68,15 +68,86 @@ class Suite2pData:
         return self.F_denoised[self.cell_mask]
 
 
-def load_suite2p(plane0_dir: str | Path) -> Suite2pData:
+def _load_ops_fields(
+    plane0: Path, derived_root: str | Path | None, recording: str | None,
+) -> tuple[float, np.ndarray | None]:
+    """The two things the pipeline needs from ``ops.npy``: ``fs`` and the mean image.
+
+    ``ops.npy`` is a pickled dict — 493 MB in the CAT-NAP example dataset, the
+    single largest file in a suite2p folder — and it must be read in full to
+    reach either field, because a pickle has no partial reads. Doing that once
+    per recording per phase is merely slow locally; over a network it is by far
+    the most expensive thing the loader does.
+
+    So the extracted fields are cached in a small sidecar (a few MB, dominated
+    by the projection image) and re-read from there. The cache is keyed only by
+    location — ``ops.npy`` is suite2p output and does not change under a run —
+    but is ignored if it is older than the file it came from, so re-running
+    suite2p invalidates it.
+    """
+    from meanap.catnap.derived import OPS_CACHE_NAME, resolve_read, resolve_write_dir
+
+    ops_path = plane0 / "ops.npy"
+    cached = (resolve_read(plane0, derived_root, recording, OPS_CACHE_NAME)
+              if recording else None)
+    if cached is not None and (not ops_path.exists()
+                               or cached.stat().st_mtime >= ops_path.stat().st_mtime):
+        with np.load(cached) as data:
+            img = data["mean_img"] if "mean_img" in data.files else None
+            return float(data["fs"]), (np.asarray(img) if img is not None else None)
+
+    ops = np.load(ops_path, allow_pickle=True).item()
+    fs = float(ops["fs"])
+    # meanImgE is suite2p's contrast-enhanced projection, made for exactly this
+    # kind of display; meanImg is the raw average and is much flatter.
+    mean_img = None
+    for key in ("meanImgE", "meanImg"):
+        if key in ops and np.ndim(ops[key]) == 2:
+            mean_img = np.asarray(ops[key])
+            break
+
+    if recording:
+        try:
+            out = resolve_write_dir(plane0, derived_root, recording) / OPS_CACHE_NAME
+            arrays = {"fs": np.array(fs)}
+            if mean_img is not None:
+                arrays["mean_img"] = np.asarray(mean_img, dtype=np.float32)
+            np.savez_compressed(out, **arrays)
+        except OSError:
+            # A read-only suite2p folder with no derived root configured: the
+            # cache is an optimisation, never a requirement.
+            pass
+
+    return fs, mean_img
+
+
+def load_suite2p(
+    plane0_dir: str | Path,
+    derived_root: str | Path | None = None,
+    recording: str | None = None,
+) -> Suite2pData:
     """
     Load all available suite2p outputs from *plane0_dir*.
 
     Required files: F.npy, iscell.npy, stat.npy, ops.npy
     Optional files: spks.npy, Fdenoised.npy, peakStartFrames.npy,
     peakEndFrames.npy, peakHeights.npy, eventAreas.npy, timePoints.npy
+
+    ``derived_root`` + ``recording`` locate files this pipeline produced —
+    denoising outputs and the ``ops`` field cache — which may live outside the
+    suite2p folder when it is read-only or remote (see
+    :mod:`meanap.catnap.derived`). Omit both for the historical behaviour of
+    reading and writing everything in place.
     """
+    from meanap.catnap.derived import resolve_read
+
     d = Path(plane0_dir)
+
+    def derived(name: str) -> Path | None:
+        if recording:
+            return resolve_read(d, derived_root, recording, name)
+        path = d / name
+        return path if path.exists() else None
 
     F = np.load(d / "F.npy")
     iscell = np.load(d / "iscell.npy")
@@ -86,15 +157,7 @@ def load_suite2p(plane0_dir: str | Path) -> Suite2pData:
     y_loc = np.array([s["med"][1] for s in stat])
     xy_loc = np.stack([x_loc, y_loc])
 
-    ops = np.load(d / "ops.npy", allow_pickle=True).item()
-    fs = float(ops["fs"])
-    # meanImgE is suite2p's contrast-enhanced projection, made for exactly this
-    # kind of display; meanImg is the raw average and is much flatter.
-    mean_img = None
-    for key in ("meanImgE", "meanImg"):
-        if key in ops and np.ndim(ops[key]) == 2:
-            mean_img = np.asarray(ops[key])
-            break
+    fs, mean_img = _load_ops_fields(d, derived_root, recording)
 
     n_frames = F.shape[1]
     duration_s = n_frames / fs
@@ -112,16 +175,19 @@ def load_suite2p(plane0_dir: str | Path) -> Suite2pData:
         mean_img=mean_img,
     )
 
-    # Load pre-computed denoising outputs if present
-    if (d / "Fdenoised.npy").exists():
-        data.F_denoised = np.load(d / "Fdenoised.npy")
-        data.time_points = (np.load(d / "timePoints.npy")
-                            if (d / "timePoints.npy").exists()
+    # Load pre-computed denoising outputs if present. These are *derived* files,
+    # so they may live outside the suite2p folder — `derived` resolves both.
+    denoised = derived("Fdenoised.npy")
+    if denoised is not None:
+        data.F_denoised = np.load(denoised)
+        time_points = derived("timePoints.npy")
+        data.time_points = (np.load(time_points) if time_points is not None
                             else np.arange(n_frames) / fs)
-        if (d / "peakStartFrames.npy").exists():
-            data.peak_start_frames = np.load(d / "peakStartFrames.npy")
-            data.peak_end_frames = np.load(d / "peakEndFrames.npy")
-            data.peak_heights = np.load(d / "peakHeights.npy")
-            data.event_areas = np.load(d / "eventAreas.npy")
+        starts = derived("peakStartFrames.npy")
+        if starts is not None:
+            data.peak_start_frames = np.load(starts)
+            data.peak_end_frames = np.load(derived("peakEndFrames.npy"))
+            data.peak_heights = np.load(derived("peakHeights.npy"))
+            data.event_areas = np.load(derived("eventAreas.npy"))
 
     return data

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -18,7 +18,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    # Imported as a module so the fully-qualified annotation below resolves;
+    # `RecordingSource` alone is ambiguous, being re-exported from
+    # `meanap.remote` as well.
+    import meanap.remote.source
 
 import numpy as np
 import pandas as pd
@@ -32,8 +38,8 @@ from meanap.catnap.loader import load_suite2p
 from meanap.catnap.subnetwork import WHOLE_NETWORK
 from meanap.catnap.stats import calc_twop_activity_stats
 from meanap.catnap.store import (
-    BACKGROUND_SUFFIX, RecordingState, load_recording_state, quantize_background,
-    save_background, save_recording_state, sorted_adjm_items,
+    BACKGROUND_SUFFIX, RecordingState, load_background, load_recording_state,
+    quantize_background, save_background, save_recording_state, sorted_adjm_items,
 )
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
 from meanap.pipeline.resume import (
@@ -101,6 +107,7 @@ def run_catnap_pipeline(
     log: Callable[[str], None] = print,
     should_cancel: CancelCheck = None,
     locator: InputLocator | None = None,
+    source: "meanap.remote.source.RecordingSource | None" = None,
 ) -> None:
     """Run the CAT-NAP path over all recordings, writing NetMet JSON + CSVs.
 
@@ -144,6 +151,8 @@ def run_catnap_pipeline(
     """
     if locator is None:
         locator = build_input_locator(params, output_root)
+    if source is None:
+        source = _build_source(params, log)
 
     min_nodes = params.min_number_of_nodes_to_cal_net_met
     net_dir = output_root / "4_NetworkActivity"
@@ -160,9 +169,25 @@ def run_catnap_pipeline(
     subnetwork_tables: dict[str, list] = {"summary": [], "node": [], "mix": []}
 
     # ── Phase 1: compute (or reload) ──────────────────────────────────────────
-    for rec in recordings:
+    # Recordings arrive with the next one already being fetched (remote sources
+    # only), and each is released once its results are on disk — so a batch's
+    # peak local storage is one or two recordings, not the whole dataset.
+    #
+    # A resumed run reads adjacency from the prior analysis and never opens the
+    # raw data, so it must not fetch it either: the whole point of resuming is
+    # that the recordings need not be present at all.
+    stream = (
+        ((rec, suite2p_plane0_dir(params.raw_data, rec.filename))
+         for rec in recordings)
+        if resuming else
+        source.stream(recordings, depth=params.prefetch_depth)
+    )
+    for rec, fetched in stream:
         check_cancel(should_cancel)
-        plane0 = suite2p_plane0_dir(params.raw_data, rec.filename)
+        if isinstance(fetched, BaseException):
+            log(f"  [{rec.filename}] SKIP: {fetched}")
+            continue
+        plane0 = fetched
 
         loaded = (
             _load_recording(locator, rec, plane0, log) if resuming else
@@ -170,6 +195,9 @@ def run_catnap_pipeline(
                                make_rng(params.random_seed, "catnap", rec.filename))
         )
         if loaded is None:
+            if not resuming:
+                source.unpin(rec.filename)
+                source.release(rec.filename)
             continue
         state, stats = loaded
 
@@ -193,6 +221,14 @@ def run_catnap_pipeline(
         except Exception as e:
             log(f"  [{rec.filename}] warning: could not save step-2 data for "
                 f"re-runs: {e}")
+
+        # Everything derived from this recording is now on disk, so its raw
+        # files are no longer needed — unless the trace figures still want them
+        # in phase 3, in which case re-fetching one recording beats holding the
+        # whole batch.
+        if not resuming:
+            source.unpin(rec.filename)
+            source.release(rec.filename)
 
         # Same label as the ephys path: this is the same work on the same
         # recording, and one generator serves every lag (as in step4.py).
@@ -233,11 +269,10 @@ def run_catnap_pipeline(
         if state is None:
             continue
         check_cancel(should_cancel)
-        # Read once here rather than inside each consumer: the mean projection
-        # and the trace figures both need the suite2p folder re-opened, and the
-        # subnetwork figures want the same backdrop as the whole-network ones.
-        data, background = _reload_for_plots(params, rec, state, log)
-        # Captured, not just drawn: figure 12 is the one plot that needs pixels
+        # The backdrop came from phase 1; this only re-opens the folder when
+        # per-cell trace figures were asked for.
+        data, background = _reload_for_plots(params, rec, state, log, source)
+        # Persisted, not just drawn: figure 12 is the one plot that needs pixels
         # rather than metrics, so a bundle has to carry the projection or it
         # could never be reconstructed.
         try:
@@ -282,8 +317,9 @@ def _compute_recording(
         log(f"  [{rec.filename}] SKIP: no suite2p output at {plane0}")
         return None
 
+    derived = params.derived_data_folder or None
     log(f"  [{rec.filename}] loading suite2p data…")
-    data = load_suite2p(plane0)
+    data = load_suite2p(plane0, derived, rec.filename)
 
     if params.twop_activity in _NEEDS_DENOISING and (
         data.F_denoised is None or params.twop_redo_denoising
@@ -295,8 +331,10 @@ def _compute_recording(
             denoising_threshold=params.twop_denoising_threshold,
             time_before_peak_s=params.twop_denoising_time_before_peak,
             time_after_peak_s=params.twop_denoising_time_after_peak,
+            derived_root=derived,
+            recording=rec.filename,
         )
-        data = load_suite2p(plane0)
+        data = load_suite2p(plane0, derived, rec.filename)
 
     log(f"  [{rec.filename}] building adjacency matrices…")
     res = suite2p_to_adjm(
@@ -313,6 +351,16 @@ def _compute_recording(
         spike_counts=_spike_counts(res, params.twop_activity),
         duration_s=duration_s, plane0=plane0, coord_norm=res.coord_norm,
     )
+    # Capture the field-of-view backdrop now, while the (large) suite2p data is
+    # already loaded. Phase 3 used to re-open the whole folder just for this;
+    # doing it here means the raw data is read once per recording, which is what
+    # lets a batch stream through bounded local storage.
+    if params.twop_network_background:
+        state.background = quantize_background(
+            _mean_image_background(data.mean_img, res.coord_norm))
+        if state.background is None:
+            log(f"  [{rec.filename}] note: no mean projection in ops — "
+                "network plots drawn without a backdrop")
     return state, _activity_stats_for(res, params, duration_s)
 
 
@@ -337,6 +385,11 @@ def _load_recording(
     except Exception as e:
         log(f"  [{rec.filename}] SKIP: could not read {path}: {e}")
         return None
+    # Phase 1 didn't run, so the backdrop it would have captured is loaded from
+    # whatever the previous run persisted (present in a bundle, absent if that
+    # run had backgrounds switched off).
+    state.background = load_background(
+        path.with_name(f"{rec.filename}{BACKGROUND_SUFFIX}"))
     log(f"  [{rec.filename}] reusing adjacency matrices from {path}")
     return state, stats
 
@@ -410,31 +463,57 @@ def _resolve_cell_types(params, rec, channels, log):
     return (groups if groups.n_groups else None), markers
 
 
-def _reload_for_plots(params, rec, state, log):
-    """Re-open the recording's suite2p folder for the plotting phase.
+def _build_source(params: Params, log):
+    """The source a run reads recordings from — local folder or remote store.
+
+    Also fills in the two folders a remote run needs but nobody should have to
+    configure: the fetch cache and the derived-data directory both default
+    under ``output_data_folder``, shared across runs so neither the download nor
+    the denoising is repeated.
+    """
+    from meanap.remote.source import RecordingSource
+    from meanap.params import default_cache_dir, default_derived_dir
+    from meanap.remote import open_store
+    from meanap.remote.cache import FileCache, resolve_budget
+
+    store = open_store(params)
+    params.derived_data_folder = default_derived_dir(params, store.copies)
+    if not store.copies:
+        return RecordingSource(store=store, cache=None, log=log)
+
+    cache_dir = default_cache_dir(params)
+    budget = resolve_budget(cache_dir, params.cache_budget_gb)
+    log(f"Remote data: {store}")
+    log(f"  cache   {cache_dir}  ({budget / 1e9:.1f} GB budget, "
+        f"prefetch depth {params.prefetch_depth})")
+    log(f"  derived {params.derived_data_folder}")
+    return RecordingSource(
+        store=store, cache=FileCache(root=cache_dir, budget_bytes=budget), log=log)
+
+
+def _reload_for_plots(params, rec, state, log, source=None):
+    """Re-open the recording's suite2p folder, only if something still needs it.
 
     Phase 1 deliberately drops the fluorescence matrices (hundreds of MB each),
-    so the trace figures and the mean-projection backdrop both need the folder
-    read again — once, here, rather than per figure family.
+    and it now also captures the mean-projection backdrop (``state.background``)
+    while that data is open. So the *only* remaining reason to re-read the raw
+    folder is the per-cell trace figures. With ``num_2p_traces = 0`` — express
+    mode's usual case — a whole batch touches each recording's raw data exactly
+    once, which is what makes streaming it through a bounded cache viable.
     """
-    if not (params.num_2p_traces or params.twop_network_background):
-        return None, None
+    if not params.num_2p_traces:
+        return None, state.background
     try:
-        data = load_suite2p(state.plane0)
+        # The folder may have been released after phase 1; ask the source for
+        # it again rather than assuming the path still resolves.
+        plane0 = (source.plane0(rec.filename) if source is not None
+                  else state.plane0)
+        data = load_suite2p(plane0, params.derived_data_folder or None,
+                            rec.filename)
     except Exception as e:
         log(f"  [{rec.filename}] warning: could not re-read suite2p data: {e}")
-        return None, None
-
-    background = None
-    if params.twop_network_background:
-        # Quantised here, before anything draws it, so the pipeline's figure and
-        # a viewer's reconstruction come from the same array (see store.py).
-        background = quantize_background(
-            _mean_image_background(data.mean_img, state.coord_norm))
-        if background is None:
-            log(f"  [{rec.filename}] note: no mean projection in ops — "
-                "network plots drawn without a backdrop")
-    return data, background
+        return None, state.background
+    return data, state.background
 
 
 def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, log,

--- a/src/meanap/catnap/store.py
+++ b/src/meanap/catnap/store.py
@@ -88,6 +88,11 @@ class RecordingState:
     #: ``(min, max)`` used to normalise the pixel centroids onto ``coords`` —
     #: needed to map the mean projection image into the same frame.
     coord_norm: tuple[float, float] = (0.0, 1.0)
+    #: ``(image, extent)`` field-of-view backdrop, captured in phase 1 while the
+    #: suite2p data is already open and persisted separately (see
+    #: :func:`save_background`). Held here so phase 3 need not re-read the raw
+    #: folder for it — the difference between one pass over the raw data and two.
+    background: tuple | None = None
 
 
 def lag_from_adjm_key(key: str) -> int:

--- a/src/meanap/gui/panels/paths.py
+++ b/src/meanap/gui/panels/paths.py
@@ -73,6 +73,12 @@ class PathsPanel(QWidget):
         self.custom_grp_order = QLineEdit()
         self.custom_grp_order.setToolTip("Comma-separated list of group names (e.g. 'WT,KO')")
 
+        self.raw_data.setToolTip(
+            "Folder holding your recordings — or paste a Dropbox folder share "
+            "link to analyse them without downloading the whole dataset. "
+            "Recordings are then fetched one at a time and discarded once "
+            "analysed; the cache and denoising outputs go under the output "
+            "folder.")
         form.addRow("Raw data folder", self.raw_data)
         form.addRow("Spreadsheet file", self.spreadsheet)
         form.addRow("Spreadsheet range", self.spreadsheet_range)

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -142,6 +142,21 @@ class Params:
     # reconstructs the rest on demand — see pipeline/bundle.py.
     express_mode: bool = False
 
+    # ── Remote data ──────────────────────────────────────────────────────────
+    # ``raw_data`` may be a Dropbox folder share link instead of a path. Then
+    # recordings are fetched one at a time and dropped once analysed, so a batch
+    # can exceed local disk — see meanap/remote/. Nothing else needs setting:
+    # the cache and derived folders default under ``output_data_folder``.
+    #
+    # Where fetched recordings are held. Empty = <output_data_folder>/MEANAP-cache.
+    cache_dir: str = ""
+    # Ceiling on that cache, in GB. None = a quarter of free disk, capped at 50.
+    cache_budget_gb: float | None = None
+    # How many recordings to fetch ahead of the one being analysed. 1 hides the
+    # download behind the compute for most datasets; each extra level costs
+    # another recording's worth of local storage for diminishing return.
+    prefetch_depth: int = 1
+
     # ── Parallelism ──────────────────────────────────────────────────────────
     # None = auto-size against available cores/RAM (see pipeline/parallel.py).
     # Step 1 threads over channels on one shared ~3.8 GB array (RAM-safe);
@@ -155,6 +170,12 @@ class Params:
     # The CAT-NAP execution path (steps 2-4) is being ported — see
     # python/CATNAP_PORT_PLAN.md.
     suite2p_mode: bool = False
+    # Where CAT-NAP writes the files it derives from suite2p output (denoising
+    # results, the cached ``ops`` fields). Empty means: beside the suite2p
+    # inputs for local data — what every run did before this existed — and
+    # <output_data_folder>/MEANAP-derived when the source is remote, where
+    # writing back is impossible. See catnap/derived.py.
+    derived_data_folder: str = ""
     twop_activity: str = "peaks"
     twop_redo_denoising: bool = False
     remove_nodes_with_no_peaks: bool = False
@@ -242,6 +263,60 @@ class Params:
 
 #: Name of the parameter snapshot written into every output folder.
 PARAMS_FILENAME = "params.json"
+
+#: Path fields that may hold a remote URL rather than a local path. A share
+#: link is an unauthenticated grant of access to the whole dataset, and
+#: ``params.json`` is packed into every ``.meanap`` bundle — so without this,
+#: sending someone your results would also send them your data. Redaction is by
+#: *value*: a local path in the same field is left alone, since it reveals a
+#: directory layout rather than a way in.
+SECRET_URL_FIELDS = ("raw_data", "prior_analysis_path", "spreadsheet_file_name")
+
+REDACTED = "<remote source redacted>"
+
+
+def is_remote_url(value: str) -> bool:
+    """Whether a path field is actually a URL."""
+    return isinstance(value, str) and "://" in value
+
+
+def redact(raw: dict) -> dict:
+    """Replace remote URLs with a placeholder, for params leaving the machine.
+
+    A placeholder rather than an empty string: a reader should be able to tell
+    that something was removed, not conclude the field was never set.
+    """
+    out = dict(raw)
+    for key in SECRET_URL_FIELDS:
+        if is_remote_url(out.get(key, "")):
+            out[key] = REDACTED
+    return out
+
+
+def default_cache_dir(params: "Params") -> Path:
+    """Where fetched recordings are held, if not configured.
+
+    Under ``output_data_folder`` — the *parent* of the dated run folders — so
+    successive runs share one cache instead of re-fetching everything.
+    """
+    if params.cache_dir:
+        return Path(params.cache_dir)
+    base = Path(params.output_data_folder or ".")
+    return base / "MEANAP-cache"
+
+
+def default_derived_dir(params: "Params", remote: bool) -> str:
+    """Where CAT-NAP writes files it derives from suite2p output.
+
+    Beside the inputs for local data (unchanged behaviour); under
+    ``output_data_folder`` when remote, where writing back is impossible.
+    Shared across runs, so denoising is not repeated every time.
+    """
+    if params.derived_data_folder:
+        return params.derived_data_folder
+    if not remote:
+        return ""
+    return str(Path(params.output_data_folder or ".") / "MEANAP-derived")
 
 
 def save_params(params: Params, output_root: Path | str) -> Path:

--- a/src/meanap/pipeline/bundle.py
+++ b/src/meanap/pipeline/bundle.py
@@ -48,7 +48,7 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from meanap.params import PARAMS_FILENAME, Params, load_params
+from meanap.params import PARAMS_FILENAME, Params, load_params, redact
 
 __all__ = [
     "BUNDLE_SUFFIX",
@@ -225,6 +225,14 @@ def write_bundle(
                 continue
             rel = path.relative_to(root)
             if _is_reconstructable_member(rel):
+                continue
+            if rel.as_posix() == PARAMS_FILENAME:
+                # The copy in the output folder keeps everything — it never
+                # leaves this machine. The copy that travels does not.
+                with open(path) as fh:
+                    zf.writestr(PARAMS_FILENAME,
+                                json.dumps(redact(json.load(fh)), indent=2,
+                                           sort_keys=True))
                 continue
             zf.write(path, rel.as_posix())
 

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -8,11 +8,12 @@ import time
 from pathlib import Path
 from typing import Callable
 
-from meanap.params import PARAMS_FILENAME, Params, save_params
+from meanap.params import (
+    PARAMS_FILENAME, Params, default_cache_dir, is_remote_url, save_params,
+)
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
 from meanap.pipeline.io import (
     RAW_EXTENSIONS,
-    find_raw_file,
     load_raw_recording,
     save_spike_times_npz,
 )
@@ -88,6 +89,11 @@ def run_pipeline(
         log("Random seed: not set — stochastic steps (3, 4) will differ between runs.")
     else:
         log(f"Random seed: {params.random_seed} — stochastic steps are reproducible.")
+
+    # A remote source is checked before any transfer: listing is free, and a
+    # batch that silently shrinks is the failure worth spending seconds to avoid.
+    if is_remote_url(params.raw_data):
+        _check_remote_source(params, recordings, log)
 
     # CAT-NAP (suite2p calcium imaging) path. In MATLAB, Params.suite2pMode == 1
     # replaces spike detection + connectivity (steps 1 & 3) with suite2pToAdjm,
@@ -241,6 +247,56 @@ def run_pipeline(
     return output_root
 
 
+def _build_raw_source(params: Params, log):
+    """The source step 1 reads recordings from — local folder or remote store."""
+    from meanap.params import default_cache_dir
+    from meanap.remote import open_store
+    from meanap.remote.cache import FileCache, resolve_budget
+    from meanap.remote.source import RecordingSource
+
+    store = open_store(params)
+    if not store.copies:
+        return RecordingSource(store=store, cache=None, log=log)
+
+    cache_dir = default_cache_dir(params)
+    budget = resolve_budget(cache_dir, params.cache_budget_gb)
+    log(f"Remote data: {store}")
+    log(f"  cache {cache_dir}  ({budget / 1e9:.1f} GB budget, "
+        f"prefetch depth {params.prefetch_depth})")
+    return RecordingSource(
+        store=store, cache=FileCache(root=cache_dir, budget_bytes=budget), log=log)
+
+
+def _check_remote_source(params: Params, recordings, log) -> None:
+    """Pre-flight a remote source before any transfer starts.
+
+    Listing costs nothing, so there is no reason to discover a missing
+    recording after an hour of downloading — and every reason not to: a batch
+    that quietly analyses a fraction of what was asked for still produces
+    group comparisons and cartography boundaries, computed from the fraction.
+    """
+    from meanap.remote import open_store, run_preflight
+
+    store = open_store(params)
+    names = [r.filename for r in recordings]
+    report = run_preflight(
+        store, names,
+        mode="catnap" if params.suite2p_mode else "ephys",
+        spreadsheet=params.spreadsheet_file_name or None,
+        cache_dir=default_cache_dir(params),
+        cache_budget_gb=params.cache_budget_gb,
+        prefetch_depth=params.prefetch_depth,
+    )
+    log("\n=== Pre-flight ===")
+    for line in report.render().splitlines():
+        log(line)
+    if not report.ok:
+        raise ValueError(
+            "The remote source is not ready to run (see the pre-flight report "
+            "above). Fix the problems listed, or run meanap-preflight with "
+            "--write-spreadsheet to correct recording names.")
+
+
 def _write_run_bundle(
     params: Params, recordings, output_root: Path, log, *, mode: str,
     embedded_figures: list[str] | None = None,
@@ -301,13 +357,17 @@ def _run_step1_spike_detection(
         raise ValueError("Raw data folder must be set to run step 1 (spike detection)")
 
     spike_dir = output_root / "1_SpikeDetection" / "1A_SpikeDetectedData"
-    raw_dir = Path(params.raw_data)
     cost_list = params.cost_list if isinstance(params.cost_list, list) else [params.cost_list]
 
-    for rec in recordings:
+    # Recordings arrive with the next one already being fetched when the source
+    # is remote, and each is released once its spike times are written — so a
+    # batch's peak local storage is one or two recordings, not the dataset.
+    source = _build_raw_source(params, log)
+
+    for rec, raw_path in source.stream(recordings, depth=params.prefetch_depth,
+                                       kind="ephys"):
         check_cancel(should_cancel)
-        raw_path = find_raw_file(raw_dir, rec.filename)
-        if raw_path is None:
+        if isinstance(raw_path, BaseException):
             log(f"  ! raw file not found, skipping: {rec.filename}"
                 f" (looked for {', '.join(RAW_EXTENSIONS)})")
             continue
@@ -350,3 +410,10 @@ def _run_step1_spike_detection(
         from meanap.pipeline.plotting import plot_spike_detection_checks
         log(f"  [{rec.filename}] generating spike detection check plots…")
         plot_spike_detection_checks(dat, result, params, rec.filename, check_dir)
+
+        # Spike times and the checks are on disk; the raw voltage is no longer
+        # needed. An Axion plate shared with other wells is kept until the last
+        # of them is done.
+        del dat
+        source.unpin(rec.filename)
+        source.release(rec.filename)

--- a/src/meanap/remote/__init__.py
+++ b/src/meanap/remote/__init__.py
@@ -1,0 +1,41 @@
+"""Reading raw data that isn't on this machine.
+
+The pipeline consumes raw recordings through a tiny read-only protocol
+(:mod:`meanap.remote.base`), so the same code path serves a local directory and
+a remote source. :mod:`meanap.remote.cache` bounds how much of a remote dataset
+is resident at once, which is what allows a batch larger than the local disk.
+"""
+
+from meanap.remote.base import RemoteEntry, RemoteStore, store_id_for
+from meanap.remote.cache import CacheFull, FileCache, resolve_budget
+from meanap.remote.dropbox_link import (
+    DropboxInterfaceChanged, DropboxLinkStore, parse_share_url,
+)
+from meanap.remote.local import LocalStore
+from meanap.remote.preflight import PreflightReport, run_preflight, find_spreadsheet
+from meanap.remote.source import RecordingSource
+
+__all__ = [
+    "RemoteEntry", "RemoteStore", "store_id_for",
+    "FileCache", "CacheFull", "resolve_budget",
+    "LocalStore",
+    "DropboxLinkStore", "DropboxInterfaceChanged", "parse_share_url",
+    "open_store",
+    "PreflightReport", "run_preflight", "find_spreadsheet",
+    "RecordingSource",
+]
+
+
+def open_store(params) -> "RemoteStore":
+    """The store a run reads raw data from.
+
+    ``Params.raw_data`` doubles as the source: a Dropbox folder share link when
+    it looks like a URL, a local directory otherwise. One field rather than two
+    means there is no way to set them inconsistently, and nothing else in the
+    pipeline has to branch on where the data lives.
+    """
+    from meanap.params import is_remote_url
+
+    if is_remote_url(params.raw_data):
+        return DropboxLinkStore(params.raw_data)
+    return LocalStore(params.raw_data)

--- a/src/meanap/remote/base.py
+++ b/src/meanap/remote/base.py
@@ -1,0 +1,77 @@
+"""What MEA-NAP needs from a place raw data lives.
+
+Deliberately three operations, not a filesystem. Everything the pipeline does
+with raw data reduces to *list a folder*, *ask how big a file is*, and *get me
+the bytes* — it never seeks, appends, or writes back (once
+:mod:`meanap.catnap.derived` moved the derived files out). Keeping the protocol
+that small is what lets a scraped share-link backend satisfy it as honestly as
+a local directory does.
+
+Two properties matter more than they look:
+
+``size`` **comes from listing.** Both backends report sizes without
+transferring anything, which is what makes a pre-flight estimate — total
+download, time, peak disk — possible before a run starts rather than
+discovered at recording eleven of thirteen.
+
+``store_id`` **identifies the source, not the URL.** The cache is keyed by it,
+so the same dataset reached through a re-issued link is still a cache hit, and
+two different datasets can never collide.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Protocol, runtime_checkable
+
+__all__ = ["RemoteEntry", "RemoteStore", "ProgressFn", "store_id_for"]
+
+#: Called with ``(bytes_so_far, total_or_None)`` during a fetch.
+ProgressFn = Callable[[int, "int | None"], None]
+
+
+@dataclass(frozen=True)
+class RemoteEntry:
+    """One item in a store, addressed by a POSIX path relative to its root."""
+
+    path: str
+    is_dir: bool
+    size: int | None = None
+
+    @property
+    def name(self) -> str:
+        return self.path.rsplit("/", 1)[-1]
+
+
+@runtime_checkable
+class RemoteStore(Protocol):
+    """A read-only source of recordings."""
+
+    #: Stable identity of the underlying data, used to key the cache.
+    store_id: str
+
+    #: Whether :meth:`fetch` copies bytes. ``False`` for a local directory,
+    #: which hands back the original path — a local run must never duplicate
+    #: gigabytes just to satisfy an abstraction.
+    copies: bool
+
+    def list(self, path: str = "") -> list[RemoteEntry]:
+        """Entries directly under *path*. Empty list if it isn't a folder."""
+
+    def stat(self, path: str) -> RemoteEntry | None:
+        """Metadata for one path, or ``None`` if absent."""
+
+    def fetch(self, path: str, dest: Path, progress: ProgressFn | None = None) -> Path:
+        """Materialise *path* locally and return where it landed.
+
+        Implementations must be safe to call when *dest* already holds a
+        complete copy, and must not leave a partial file behind on failure —
+        the cache treats "the file is there" as "the file is whole".
+        """
+
+
+def store_id_for(*parts: str) -> str:
+    """A short, stable id from whatever identifies a source."""
+    return hashlib.sha256("\x00".join(parts).encode()).hexdigest()[:16]

--- a/src/meanap/remote/cache.py
+++ b/src/meanap/remote/cache.py
@@ -1,0 +1,332 @@
+"""A local cache for remote files, bounded by a byte budget.
+
+This is what lets a batch larger than the disk run at all: fetch a recording,
+analyse it, drop it, fetch the next. The pipeline already works one recording at
+a time and — since :mod:`meanap.catnap.derived` — reads each one exactly once,
+so peak usage is one recording plus whatever is being fetched ahead, not the
+whole dataset.
+
+Two rules keep that safe:
+
+**Pinned files are never evicted.** Anything the current recording needs, and
+anything being fetched ahead of it, is pinned. Without this a large prefetch
+could evict the file the analysis is reading.
+
+**Presence means completeness.** The cache — not each backend — fetches to a
+temporary name and renames into place, so a crashed or cancelled download never
+leaves a truncated file that later looks like a cache hit. Centralising it here
+means a new backend cannot get it subtly wrong; backends just write to the path
+they are handed. Rename is atomic within a filesystem, which is why the
+temporary lives beside its target rather than in ``/tmp``. Any ``.part`` left by
+a killed process is swept when the cache is opened.
+
+Recency is tracked with the file's own mtime, touched on access, rather than a
+separate index — one less thing to corrupt, and it survives restarts.
+
+**Thread-safe by necessity, not ambition.** Prefetching fetches the next
+recording while the current one is analysed, so eviction runs concurrently with
+reads. Pinning would be worthless if the pin set could be updated non-atomically
+while ``make_room`` walked it, so both are serialised under one lock.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from meanap.remote.base import ProgressFn, RemoteStore
+
+__all__ = ["FileCache", "CacheFull", "resolve_budget", "DEFAULT_BUDGET_FRACTION",
+           "MAX_AUTO_BUDGET_BYTES", "PARTIAL_SUFFIX"]
+
+#: Extension used while a fetch is in flight. Never a valid cache entry.
+PARTIAL_SUFFIX = ".part"
+
+#: Share of free disk an auto-sized budget will claim. Deliberately modest:
+#: the cache is transient scratch, and filling a user's disk to run an analysis
+#: is a worse failure than running slowly.
+DEFAULT_BUDGET_FRACTION = 0.25
+
+#: Ceiling on an auto-sized budget. Past this, more cache stops helping —
+#: the pipeline only ever needs a couple of recordings resident.
+MAX_AUTO_BUDGET_BYTES = 50 * 1000**3
+
+
+class CacheFull(RuntimeError):
+    """The budget cannot accommodate what the run needs.
+
+    Raised up front where possible, with the numbers, rather than after an
+    hour of downloading.
+    """
+
+
+def resolve_budget(
+    cache_dir: Path | str,
+    configured_gb: float | None = None,
+    required_bytes: int = 0,
+) -> int:
+    """Decide the cache budget in bytes, and check it can hold *required_bytes*.
+
+    ``configured_gb`` wins when given. Otherwise a quarter of the free space on
+    the cache's own filesystem, capped — measured on the cache directory rather
+    than the working directory, since the two are often different disks.
+    """
+    cache_dir = Path(cache_dir)
+    probe = cache_dir
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    free = shutil.disk_usage(probe).free
+
+    if configured_gb is not None:
+        budget = int(configured_gb * 1000**3)
+        if budget > free:
+            raise CacheFull(
+                f"Cache budget {configured_gb:.1f} GB exceeds the "
+                f"{free / 1000**3:.1f} GB free on {probe}.")
+    else:
+        budget = int(min(free * DEFAULT_BUDGET_FRACTION, MAX_AUTO_BUDGET_BYTES))
+
+    if required_bytes and required_bytes > budget:
+        raise CacheFull(
+            f"This run needs {required_bytes / 1000**3:.2f} GB resident at once "
+            f"(the largest recording, plus anything fetched ahead of it), but the "
+            f"cache budget is {budget / 1000**3:.2f} GB. Raise "
+            f"Params.cache_budget_gb, reduce Params.prefetch_depth, or free disk "
+            f"space — {free / 1000**3:.1f} GB is currently free on {probe}.")
+    return budget
+
+
+@dataclass
+class FileCache:
+    """Byte-bounded local store of files fetched from a :class:`RemoteStore`."""
+
+    root: Path
+    budget_bytes: int
+    _pinned: set[Path] = field(default_factory=set)
+    #: Bytes promised to fetches that are in flight. Without this two threads
+    #: each pass the budget check, then both download, and the cache overshoots
+    #: by however much was being fetched concurrently.
+    _reserved: dict = field(default_factory=dict)
+    _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
+
+    def __post_init__(self) -> None:
+        self.root = Path(self.root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        # A previous process killed mid-fetch leaves these behind; they are
+        # never useful, and they would otherwise count against the budget.
+        for stale in self.root.rglob(f"*{PARTIAL_SUFFIX}"):
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+
+    # ── layout ───────────────────────────────────────────────────────────────
+
+    def path_for(self, store: RemoteStore, rel_path: str) -> Path:
+        """Where a store's file lives locally.
+
+        Mirrors the remote tree under a per-store directory, so the cache is
+        browsable and a stale entry can be deleted by hand.
+        """
+        return self.root / store.store_id / rel_path.strip("/")
+
+    # ── accounting ───────────────────────────────────────────────────────────
+
+    def _files(self) -> list[Path]:
+        return [p for p in self.root.rglob("*") if p.is_file()]
+
+    def _size(self, path: Path) -> int:
+        """Size, or 0 if it vanished — another thread may be evicting."""
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0
+
+    def usage(self) -> int:
+        """Bytes accounted for: complete files, plus fetches in flight.
+
+        A ``.part`` is covered by its reservation (the file's *full* size, not
+        the fraction downloaded so far), so counting its bytes on disk as well
+        would charge for the same fetch twice.
+        """
+        with self._lock:
+            reserved = sum(self._reserved.values())
+        on_disk = sum(self._size(p) for p in self._files()
+                      if not p.name.endswith(PARTIAL_SUFFIX))
+        return on_disk + reserved
+
+    def free(self) -> int:
+        return max(0, self.budget_bytes - self.usage())
+
+    # ── pinning ──────────────────────────────────────────────────────────────
+
+    @contextmanager
+    def pinned(self, paths):
+        """Protect *paths* from eviction for the duration of the block."""
+        resolved = {Path(p) for p in paths}
+        with self._lock:
+            self._pinned |= resolved
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._pinned -= resolved
+
+    def pin(self, path: Path) -> None:
+        with self._lock:
+            self._pinned.add(Path(path))
+
+    def unpin(self, path: Path) -> None:
+        with self._lock:
+            self._pinned.discard(Path(path))
+
+    def _members(self, base: Path) -> set[Path]:
+        """The cached files at *base* — which may itself be one.
+
+        CAT-NAP addresses a recording by its folder, electrophysiology by a
+        single file. ``rglob`` yields nothing for a file, so a path that is
+        already a file would otherwise pin and evict nothing at all.
+        """
+        if base.is_file():
+            return {base}
+        return {p for p in base.rglob("*") if p.is_file()}
+
+    def pin_prefix(self, store: RemoteStore, prefix: str) -> None:
+        """Pin everything currently cached at or under *prefix*."""
+        base = self.path_for(store, prefix)
+        with self._lock:
+            self._pinned |= self._members(base)
+
+    def unpin_prefix(self, store: RemoteStore, prefix: str) -> None:
+        base = self.path_for(store, prefix)
+        with self._lock:
+            self._pinned -= self._members(base)
+
+    # ── eviction ─────────────────────────────────────────────────────────────
+
+    def make_room(self, needed: int) -> None:
+        """Evict least-recently-used unpinned files until *needed* bytes fit."""
+        with self._lock:
+            self._make_room_locked(needed)
+
+    def _make_room_locked(self, needed: int) -> None:
+        if needed > self.budget_bytes:
+            raise CacheFull(
+                f"A single file of {needed / 1e6:.0f} MB exceeds the whole cache "
+                f"budget of {self.budget_bytes / 1e6:.0f} MB.")
+        if self.free() >= needed:
+            return
+
+        def mtime(path: Path) -> float:
+            try:
+                return path.stat().st_mtime
+            except OSError:
+                return 0.0
+
+        candidates = sorted(
+            (p for p in self._files() if p not in self._pinned),
+            key=mtime,
+        )
+        for path in candidates:
+            if self.free() >= needed:
+                return
+            try:
+                path.unlink()
+            except OSError:
+                continue
+
+        if self.free() < needed:
+            pinned_bytes = sum(self._size(p) for p in self._pinned)
+            raise CacheFull(
+                f"Cannot free {needed / 1e6:.0f} MB: {pinned_bytes / 1e6:.0f} MB is "
+                f"pinned by work in progress and the budget is "
+                f"{self.budget_bytes / 1e6:.0f} MB. Raise Params.cache_budget_gb or "
+                f"reduce Params.prefetch_depth.")
+
+    def evict(self, store: RemoteStore, rel_path: str) -> None:
+        """Drop one cached file. Silent if absent or pinned."""
+        path = self.path_for(store, rel_path)
+        if path in self._pinned or not path.exists():
+            return
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+    def evict_prefix(self, store: RemoteStore, prefix: str) -> int:
+        """Drop everything under a subtree, returning bytes reclaimed.
+
+        How a finished recording is released: the pipeline knows when its
+        derived outputs are safely written, which the cache cannot infer.
+        """
+        base = self.path_for(store, prefix)
+        if not base.exists():
+            return 0
+        freed = 0
+        with self._lock:
+            targets = sorted(self._members(base) - self._pinned, reverse=True)
+        for path in targets:
+            size = self._size(path)
+            try:
+                path.unlink()
+                freed += size
+            except OSError:
+                pass
+        return freed
+
+    # ── the operation everything else exists for ─────────────────────────────
+
+    def get(
+        self, store: RemoteStore, rel_path: str,
+        progress: ProgressFn | None = None,
+    ) -> Path:
+        """Return a local path for *rel_path*, fetching it if necessary.
+
+        For a store that doesn't copy (a local directory) this returns the
+        original file and the cache stays empty — no accounting, no eviction,
+        nothing duplicated.
+        """
+        if not store.copies:
+            return store.fetch(rel_path, self.root)
+
+        target = self.path_for(store, rel_path)
+        if target.exists():
+            os.utime(target, None)  # mark as most recently used
+            if progress is not None:
+                size = target.stat().st_size
+                progress(size, size)
+            return target
+
+        entry = store.stat(rel_path)
+        # Reserve space and claim the destination under one lock, so two
+        # prefetch threads cannot each pass the budget check and then both
+        # write.
+        size = entry.size if entry and entry.size else 0
+        partial = target.with_name(target.name + PARTIAL_SUFFIX)
+        # Reserve, pin and claim the destination under one lock. The download
+        # itself runs outside it — serialising fetches would defeat prefetching
+        # — so the reservation is what keeps concurrent fetches inside budget,
+        # and the pin is what stops one thread evicting another's partial.
+        with self._lock:
+            self._make_room_locked(size)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            self._pinned |= {target, partial}
+            self._reserved[partial] = size
+        try:
+            try:
+                store.fetch(rel_path, partial, progress)
+                partial.replace(target)
+            except BaseException:
+                # Includes KeyboardInterrupt: a cancelled run must not leave
+                # something that the next run treats as a complete cached file.
+                partial.unlink(missing_ok=True)
+                raise
+        finally:
+            with self._lock:
+                self._reserved.pop(partial, None)
+                self._pinned -= {target, partial}
+        return target

--- a/src/meanap/remote/cli.py
+++ b/src/meanap/remote/cli.py
@@ -1,0 +1,129 @@
+"""``meanap-preflight`` — check a dataset before committing to a run.
+
+Answers, in seconds and without downloading anything: are the recordings my
+spreadsheet names actually there, how much will this transfer, and will it fit?
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import sys
+import tempfile
+from pathlib import Path
+
+__all__ = ["main"]
+
+#: Column headers a batch spreadsheet uses for the recording name, in the
+#: variants MEA-NAP has accepted over time.
+_NAME_HINTS = ("recording filename", "recording file name", "filename", "file name")
+
+
+def _recording_names(text: str) -> list[str]:
+    rows = list(csv.DictReader(io.StringIO(text)))
+    if not rows:
+        return []
+    header = next(
+        (c for c in rows[0] if c and c.strip().lower() in _NAME_HINTS),
+        next((c for c in rows[0] if c and "name" in c.lower()), None),
+    )
+    if header is None:
+        raise SystemExit(
+            "Could not find a recording-name column in the spreadsheet "
+            f"(saw: {', '.join(c for c in rows[0] if c)}).")
+    return [r[header].strip() for r in rows if (r.get(header) or "").strip()]
+
+
+def _write_fixed_spreadsheet(text: str, name_map: dict, out: Path) -> int:
+    """Copy a batch spreadsheet, renaming recordings to the folders on disk.
+
+    Rewriting the *spreadsheet* rather than the data is usually the safer half
+    of the fix: a share link is read-only, and folder names may be referenced
+    by other people's notes. Everything else in the file is preserved verbatim.
+    """
+    rows = list(csv.DictReader(io.StringIO(text)))
+    if not rows:
+        raise SystemExit("Cannot rewrite an empty spreadsheet.")
+    header = next(
+        (c for c in rows[0] if c and c.strip().lower() in _NAME_HINTS),
+        next((c for c in rows[0] if c and "name" in c.lower()), None),
+    )
+    changed = 0
+    for row in rows:
+        current = (row.get(header) or "").strip()
+        if current in name_map:
+            row[header] = name_map[current]
+            changed += 1
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="meanap-preflight",
+        description="Check a local folder or Dropbox share link before a run.")
+    ap.add_argument("source", help="a folder, or a Dropbox folder share link")
+    ap.add_argument("--spreadsheet", default="",
+                    help="batch CSV (default: the only .csv in the source)")
+    ap.add_argument("--mode", choices=("catnap", "ephys"), default="catnap")
+    ap.add_argument("--cache-dir", default="")
+    ap.add_argument("--budget-gb", type=float, default=None)
+    ap.add_argument("--prefetch-depth", type=int, default=1)
+    ap.add_argument("--write-spreadsheet", metavar="OUT.csv", default="",
+                    help="write a copy of the batch file with recording names "
+                         "corrected to the folder names actually present")
+    args = ap.parse_args(argv)
+
+    from meanap.remote.cache import FileCache
+    from meanap.remote.dropbox_link import DropboxLinkStore
+    from meanap.remote.local import LocalStore
+    from meanap.remote.preflight import find_spreadsheet, run_preflight
+
+    store = (DropboxLinkStore(args.source) if "://" in args.source
+             else LocalStore(args.source))
+
+    sheet = find_spreadsheet(store, args.spreadsheet)
+    if sheet is None:
+        raise SystemExit(
+            "No batch spreadsheet found. Pass --spreadsheet with its name, or "
+            "put exactly one .csv at the top level of the source.")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cache_dir = Path(args.cache_dir or tmp) / "meanap-cache"
+        cache = FileCache(root=cache_dir, budget_bytes=10 * 1000**3)
+        local = cache.get(store, sheet) if store.stat(sheet) else Path(sheet)
+        # Read it here: the cache lives in the temporary directory, so the file
+        # is gone by the time the rewrite below runs.
+        sheet_text = local.read_text(errors="replace")
+        names = _recording_names(sheet_text)
+        if not names:
+            raise SystemExit(f"{sheet} lists no recordings.")
+
+        report = run_preflight(
+            store, names, mode=args.mode, spreadsheet=sheet,
+            cache_dir=cache_dir if store.copies else None,
+            cache_budget_gb=args.budget_gb, prefetch_depth=args.prefetch_depth,
+        )
+
+    if args.write_spreadsheet:
+        written = _write_fixed_spreadsheet(
+            sheet_text, report.name_map,
+            Path(args.write_spreadsheet))
+        print(f"Wrote {written} corrected name(s) to {args.write_spreadsheet}\n")
+
+    print(report.render())
+    if not report.ok:
+        print("\nThis dataset is not ready to run.", file=sys.stderr)
+        return 1
+    print("\nReady to run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meanap/remote/dropbox_link.py
+++ b/src/meanap/remote/dropbox_link.py
@@ -1,0 +1,277 @@
+"""Read a public Dropbox folder share link, one file at a time.
+
+A folder share link looks like a dead end: the only *documented* unauthenticated
+operation is downloading the whole folder as a generated zip, which for a real
+dataset means tens of gigabytes and no way to take a part of it. Dropbox's own
+web interface obviously does better than that, and it does so with endpoints
+that need no token:
+
+===============================  ===========================================
+list a folder                    ``POST /list_shared_link_folder_entries``
+                                 with the CSRF token from the share page
+descend into a subfolder         the child's **own** ``secure_hash`` (from its
+                                 ``href``) *plus* the full ``sub_path``
+download one file                the entry's ``href`` with ``raw=1``
+===============================  ===========================================
+
+All three were verified against a live 14 GB link, including ``Range`` support
+on the download (``206`` with ``Content-Range``), which is what makes an
+interrupted fetch resumable rather than restarted.
+
+.. warning::
+
+   **This is not a public API.** It is what dropbox.com's front end happens to
+   use, it is unversioned, and it can change without notice. It is confined to
+   this module so that when it breaks, one adapter fails with an actionable
+   message rather than the pipeline misbehaving somewhere unrelated — see
+   :class:`DropboxInterfaceChanged`. A synced folder or an ``rclone`` mount
+   reaches the same data through supported means and needs none of this.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+from pathlib import Path
+
+from meanap.remote.base import ProgressFn, RemoteEntry, store_id_for
+from meanap.remote.http import HttpClient, HttpError
+
+__all__ = ["DropboxLinkStore", "DropboxInterfaceChanged", "parse_share_url"]
+
+_LISTING_URL = "https://www.dropbox.com/list_shared_link_folder_entries"
+_LINK_RE = re.compile(r"/scl/(?P<kind>fo|fi)/(?P<key>[^/]+)/(?P<hash>[^/?]+)")
+
+
+class DropboxInterfaceChanged(RuntimeError):
+    """Dropbox's web endpoints no longer behave as this adapter expects.
+
+    Raised instead of a parse error or an empty listing, because "the folder
+    looks empty" is the most damaging way this could fail: a run would proceed
+    and quietly analyse nothing.
+    """
+
+    def __init__(self, detail: str):
+        super().__init__(
+            f"{detail}\n\nThe Dropbox share-link reader depends on undocumented "
+            "web endpoints, which appear to have changed. Use a synced Dropbox "
+            "folder or an 'rclone mount' and point Params.raw_data at it — both "
+            "reach the same data through supported interfaces.")
+
+
+def parse_share_url(url: str) -> tuple[str, str, str]:
+    """Split a share link into ``(link_key, secure_hash, rlkey)``.
+
+    Raises :class:`ValueError` with a specific reason — a file link, or a link
+    missing its ``rlkey`` — rather than failing later with an opaque HTTP error.
+    """
+    match = _LINK_RE.search(url)
+    if not match:
+        raise ValueError(
+            f"Not a Dropbox share link: {url!r}. Expected something like "
+            "https://www.dropbox.com/scl/fo/<id>/<hash>?rlkey=<key>")
+    if match.group("kind") == "fi":
+        raise ValueError(
+            "That is a link to a single file (/scl/fi/...). MEA-NAP needs a "
+            "link to the folder containing your recordings — share the folder "
+            "instead.")
+    rlkey = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query).get("rlkey", [""])[0]
+    if not rlkey:
+        raise ValueError(
+            "The share link has no 'rlkey' parameter. Copy the whole link from "
+            "Dropbox's Share dialog, including everything after the '?'.")
+    return match.group("key"), match.group("hash"), rlkey
+
+
+class DropboxLinkStore:
+    """A :class:`~meanap.remote.base.RemoteStore` over a public folder link."""
+
+    copies = True
+
+    def __init__(self, url: str, client: HttpClient | None = None):
+        self.link_key, self.root_hash, self.rlkey = parse_share_url(url)
+        self.url = url
+        self.store_id = store_id_for("dropbox", self.link_key)
+        self._http = client or HttpClient()
+        self._csrf: str | None = None
+        # dir path -> {"hash": str, "entries": [RemoteEntry], "hrefs": {name: url}}
+        self._dirs: dict[str, dict] = {}
+
+    def __repr__(self) -> str:
+        return f"DropboxLinkStore({self.link_key})"
+
+    # ── session ──────────────────────────────────────────────────────────────
+
+    def _token(self, refresh: bool = False) -> str:
+        """CSRF token for the listing endpoint, from the share page's cookies."""
+        if self._csrf and not refresh:
+            return self._csrf
+        self._http.get(self.url)
+        token = self._http.cookie("__Host-js_csrf")
+        if not token:
+            raise DropboxInterfaceChanged(
+                "The share page did not set the expected CSRF cookie.")
+        self._csrf = token
+        return token
+
+    def _listing_call(self, secure_hash: str, sub_path: str) -> dict:
+        fields = {
+            "t": self._token(), "link_key": self.link_key,
+            "secure_hash": secure_hash, "rlkey": self.rlkey,
+            "sub_path": sub_path, "link_type": "s",
+        }
+        try:
+            resp = self._http.post_form(
+                _LISTING_URL, fields, {"X-Requested-With": "XMLHttpRequest"})
+        except HttpError as e:
+            # An expired session presents as a 403/404 from this endpoint; one
+            # retry with a fresh token distinguishes that from a real absence.
+            if e.status in (403, 404):
+                fields["t"] = self._token(refresh=True)
+                resp = self._http.post_form(
+                    _LISTING_URL, fields, {"X-Requested-With": "XMLHttpRequest"})
+            else:
+                raise
+        try:
+            return json.loads(resp.text())
+        except json.JSONDecodeError:
+            raise DropboxInterfaceChanged(
+                "The folder-listing endpoint returned HTML instead of JSON."
+            ) from None
+
+    # ── directory walk ───────────────────────────────────────────────────────
+
+    def _dir(self, path: str) -> dict:
+        """Listing metadata for a directory, walking (and caching) from the root.
+
+        Each level needs the *child's* ``secure_hash`` together with the full
+        path so far — the parent's hash gives a 404. Cached because a tree walk
+        would otherwise re-request every ancestor for every leaf.
+        """
+        path = path.strip("/")
+        if path in self._dirs:
+            return self._dirs[path]
+
+        if not path:
+            info = self._load_dir(self.root_hash, "")
+            self._dirs[""] = info
+            return info
+
+        parent_path, _, name = path.rpartition("/")
+        parent = self._dir(parent_path)
+        href = parent["hrefs"].get(name)
+        if href is None:
+            raise FileNotFoundError(path)
+        match = _LINK_RE.search(href)
+        if not match:
+            raise DropboxInterfaceChanged(f"Unrecognised entry link for {path!r}.")
+        info = self._load_dir(match.group("hash"), "/" + path)
+        self._dirs[path] = info
+        return info
+
+    def _load_dir(self, secure_hash: str, sub_path: str) -> dict:
+        data = self._listing_call(secure_hash, sub_path)
+        if "entries" not in data:
+            raise DropboxInterfaceChanged(
+                f"Folder listing had no 'entries' key (got: {sorted(data)[:6]}).")
+
+        prefix = sub_path.strip("/")
+        entries, hrefs = [], {}
+        for raw in data["entries"]:
+            name = raw.get("filename")
+            if not name:
+                continue
+            entries.append(RemoteEntry(
+                path=f"{prefix}/{name}" if prefix else name,
+                is_dir=bool(raw.get("is_dir")),
+                size=None if raw.get("is_dir") else raw.get("bytes"),
+            ))
+            hrefs[name] = raw.get("href", "")
+
+        if data.get("has_more_entries"):
+            # Not yet needed — the pagination voucher is only issued for very
+            # large folders. Say so rather than silently truncating a batch.
+            raise DropboxInterfaceChanged(
+                f"Folder '{sub_path or '/'}' has more entries than one response "
+                f"returns ({data.get('total_num_entries')} total); paginated "
+                "listings are not implemented.")
+        return {"hash": secure_hash, "entries": entries, "hrefs": hrefs}
+
+    # ── RemoteStore ──────────────────────────────────────────────────────────
+
+    def list(self, path: str = "") -> list[RemoteEntry]:
+        try:
+            return list(self._dir(path)["entries"])
+        except FileNotFoundError:
+            return []
+
+    def stat(self, path: str) -> RemoteEntry | None:
+        path = path.strip("/")
+        if not path:
+            return RemoteEntry("", True, None)
+        parent, _, name = path.rpartition("/")
+        try:
+            entries = self._dir(parent)["entries"]
+        except FileNotFoundError:
+            return None
+        return next((e for e in entries if e.name == name), None)
+
+    def _download_url(self, path: str) -> str:
+        """The direct-bytes URL for a file: its href with ``raw=1``.
+
+        ``dl=1`` returns an HTML interstitial rather than the file, which is the
+        kind of thing that would otherwise be discovered by writing a 24 MB HTML
+        page into a ``.npy``.
+        """
+        parent, _, name = path.strip("/").rpartition("/")
+        href = self._dir(parent)["hrefs"].get(name)
+        if not href:
+            raise FileNotFoundError(path)
+        split = urllib.parse.urlsplit(href)
+        query = urllib.parse.parse_qs(split.query)
+        query.pop("dl", None)
+        query["raw"] = ["1"]
+        return urllib.parse.urlunsplit(
+            split._replace(query=urllib.parse.urlencode(query, doseq=True)))
+
+    def fetch(self, path: str, dest: Path, progress: ProgressFn | None = None) -> Path:
+        """Download one file to *dest*, resuming if a partial is already there.
+
+        The caller (:class:`~meanap.remote.cache.FileCache`) owns atomicity and
+        hands over a temporary path; resuming across *its* retries is why the
+        partial is appended to rather than replaced.
+        """
+        url = self._download_url(path)
+        entry = self.stat(path)
+        total = entry.size if entry else None
+
+        have = dest.stat().st_size if dest.exists() else 0
+        if total is not None and have >= total:
+            return dest
+
+        status, headers, chunks = self._http.stream(url, start=have)
+        # A server that ignores Range answers 200 with the whole file; appending
+        # then would corrupt it, so start over.
+        mode = "ab"
+        if have and status != 206:
+            have, mode = 0, "wb"
+
+        ctype = headers.get("Content-Type", "")
+        if ctype.startswith("text/html"):
+            raise DropboxInterfaceChanged(
+                f"Downloading {path!r} returned a web page instead of file data.")
+
+        written = have
+        with open(dest, mode) as fh:
+            for block in chunks:
+                fh.write(block)
+                written += len(block)
+                if progress is not None:
+                    progress(written, total)
+
+        if total is not None and written != total:
+            raise HttpError(
+                f"{path}: got {written} bytes, expected {total}. The download "
+                "was truncated; it will be retried from here.")
+        return dest

--- a/src/meanap/remote/http.py
+++ b/src/meanap/remote/http.py
@@ -1,0 +1,173 @@
+"""A very small HTTP client: cookies, retries, ranged streaming.
+
+Standard library only, deliberately. The remote-data feature is optional, and
+adding ``requests`` to the core dependencies of an analysis package so that one
+backend can talk to one website is a poor trade — the same reasoning that keeps
+the viewer on ``http.server``.
+
+Everything network-facing lives behind :class:`HttpClient` so the Dropbox
+backend can be tested without a network: the tests substitute a fake client and
+drive the retry, resume and throttling paths that a live connection would only
+exercise by luck.
+"""
+
+from __future__ import annotations
+
+import gzip
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from http.cookiejar import CookieJar
+from typing import Iterator
+
+__all__ = ["HttpClient", "HttpResponse", "HttpError", "USER_AGENT"]
+
+#: Dropbox serves its single-page app, not JSON, to clients it doesn't
+#: recognise as browsers. This is required for the listing endpoint to answer.
+USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+              "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+
+#: Retried with backoff: throttling, and the transient 5xx family.
+_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+class HttpError(RuntimeError):
+    """A request failed after exhausting retries."""
+
+    def __init__(self, message: str, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass
+class HttpResponse:
+    status: int
+    headers: dict
+    body: bytes = b""
+
+    def text(self) -> str:
+        return self.body.decode("utf-8", "replace")
+
+
+@dataclass
+class HttpClient:
+    """Cookie-aware client with exponential backoff.
+
+    One cookie jar per instance: Dropbox's listing endpoint needs both a session
+    cookie and the CSRF token it sets, so the client that fetches the share page
+    must be the one that lists it.
+    """
+
+    timeout: float = 90.0
+    retries: int = 4
+    backoff: float = 1.5
+    _jar: CookieJar = field(default_factory=CookieJar)
+
+    def __post_init__(self) -> None:
+        self._opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(self._jar))
+
+    # ── cookies ──────────────────────────────────────────────────────────────
+
+    def cookie(self, name: str) -> str | None:
+        for c in self._jar:
+            if c.name == name:
+                return c.value
+        return None
+
+    # ── requests ─────────────────────────────────────────────────────────────
+
+    def _request(self, url: str, *, data: bytes | None = None,
+                 headers: dict | None = None, stream: bool = False):
+        req = urllib.request.Request(url, data=data, method="POST" if data else "GET")
+        req.add_header("User-Agent", USER_AGENT)
+        req.add_header("Accept-Encoding", "gzip")
+        for k, v in (headers or {}).items():
+            req.add_header(k, v)
+        return self._opener.open(req, timeout=self.timeout)
+
+    def _with_retries(self, describe: str, attempt):
+        """Run *attempt*, retrying throttling and transient failures.
+
+        A 4xx that isn't throttling is not retried: it will not become true by
+        waiting, and burning four timeouts on it hides the real error.
+        """
+        last = None
+        for i in range(self.retries):
+            try:
+                return attempt()
+            except urllib.error.HTTPError as e:
+                last = e
+                if e.code not in _RETRY_STATUSES:
+                    raise HttpError(f"{describe}: HTTP {e.code}", e.code) from e
+            except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as e:
+                last = e
+            if i < self.retries - 1:
+                time.sleep(self.backoff ** i)
+        status = getattr(last, "code", None)
+        raise HttpError(f"{describe}: giving up after {self.retries} attempts "
+                        f"({type(last).__name__}: {last})", status)
+
+    def get(self, url: str, headers: dict | None = None) -> HttpResponse:
+        def attempt() -> HttpResponse:
+            with self._request(url, headers=headers) as r:
+                body = r.read()
+                if r.headers.get("Content-Encoding") == "gzip":
+                    body = gzip.decompress(body)
+                return HttpResponse(r.status, dict(r.headers), body)
+        return self._with_retries(f"GET {_short(url)}", attempt)
+
+    def post_form(self, url: str, fields: dict,
+                  headers: dict | None = None) -> HttpResponse:
+        data = urllib.parse.urlencode(fields).encode()
+        merged = {"Content-Type": "application/x-www-form-urlencoded"}
+        merged.update(headers or {})
+
+        def attempt() -> HttpResponse:
+            with self._request(url, data=data, headers=merged) as r:
+                body = r.read()
+                if r.headers.get("Content-Encoding") == "gzip":
+                    body = gzip.decompress(body)
+                return HttpResponse(r.status, dict(r.headers), body)
+        return self._with_retries(f"POST {_short(url)}", attempt)
+
+    def stream(self, url: str, start: int = 0,
+               chunk_size: int = 1 << 20) -> tuple[int, dict, Iterator[bytes]]:
+        """Open a ranged download, returning ``(status, headers, chunks)``.
+
+        ``start`` resumes a partial download. A server that ignores the range
+        answers 200 rather than 206; the caller must notice and restart, which
+        is why the status is returned rather than swallowed.
+        """
+        headers = {"Range": f"bytes={start}-"} if start else {}
+        # Range and transparent gzip do not mix — the byte offsets would refer
+        # to different streams.
+        req = urllib.request.Request(url, method="GET")
+        req.add_header("User-Agent", USER_AGENT)
+        for k, v in headers.items():
+            req.add_header(k, v)
+
+        def attempt():
+            return self._opener.open(req, timeout=self.timeout)
+
+        resp = self._with_retries(f"GET {_short(url)}", attempt)
+
+        def chunks() -> Iterator[bytes]:
+            try:
+                while True:
+                    block = resp.read(chunk_size)
+                    if not block:
+                        return
+                    yield block
+            finally:
+                resp.close()
+
+        return resp.status, dict(resp.headers), chunks()
+
+
+def _short(url: str) -> str:
+    """URLs here carry access secrets; keep them out of exception text."""
+    parsed = urllib.parse.urlsplit(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"

--- a/src/meanap/remote/local.py
+++ b/src/meanap/remote/local.py
@@ -1,0 +1,76 @@
+"""A local directory, presented as a :class:`~meanap.remote.base.RemoteStore`.
+
+Exists so the pipeline has one code path rather than two. The important detail
+is that :meth:`LocalStore.fetch` returns the *original* path instead of copying:
+a local run must not duplicate gigabytes to satisfy an abstraction, and the
+cache knows not to account for bytes it doesn't own (``copies = False``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meanap.remote.base import ProgressFn, RemoteEntry, store_id_for
+
+__all__ = ["LocalStore"]
+
+
+class LocalStore:
+    """Reads a directory tree that is already on this machine."""
+
+    copies = False
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root).expanduser().resolve()
+        self.store_id = store_id_for("local", str(self.root))
+
+    def __repr__(self) -> str:
+        return f"LocalStore({self.root})"
+
+    def _resolve(self, path: str) -> Path:
+        """Join a store-relative path, refusing anything that escapes the root.
+
+        The paths come from spreadsheets and recording names, so a stray ``..``
+        is a user error rather than an attack — but the failure should be a
+        clear refusal either way.
+        """
+        target = (self.root / path.strip("/")).resolve() if path else self.root
+        if target != self.root and self.root not in target.parents:
+            raise ValueError(f"{path!r} points outside {self.root}")
+        return target
+
+    def list(self, path: str = "") -> list[RemoteEntry]:
+        target = self._resolve(path)
+        if not target.is_dir():
+            return []
+        prefix = f"{path.strip('/')}/" if path.strip("/") else ""
+        out = []
+        for child in sorted(target.iterdir()):
+            out.append(RemoteEntry(
+                path=f"{prefix}{child.name}",
+                is_dir=child.is_dir(),
+                size=None if child.is_dir() else child.stat().st_size,
+            ))
+        return out
+
+    def stat(self, path: str) -> RemoteEntry | None:
+        try:
+            target = self._resolve(path)
+        except ValueError:
+            return None
+        if not target.exists():
+            return None
+        return RemoteEntry(
+            path=path.strip("/"), is_dir=target.is_dir(),
+            size=None if target.is_dir() else target.stat().st_size,
+        )
+
+    def fetch(self, path: str, dest: Path, progress: ProgressFn | None = None) -> Path:
+        """Return the file where it already is; *dest* is ignored."""
+        target = self._resolve(path)
+        if not target.is_file():
+            raise FileNotFoundError(f"{path} not found under {self.root}")
+        if progress is not None:
+            size = target.stat().st_size
+            progress(size, size)
+        return target

--- a/src/meanap/remote/prefetch.py
+++ b/src/meanap/remote/prefetch.py
@@ -1,0 +1,75 @@
+"""Fetch the next recording while the current one is being analysed.
+
+The pipeline is a loop over recordings that are independent until the batch-wide
+barrier, and analysing one takes far longer than fetching it — measured on the
+CAT-NAP example data, roughly 275 s of compute against 95 s of transfer. Run
+serially that transfer is dead time; overlapped, it disappears.
+
+The generator here is deliberately the whole mechanism. Fetching runs on one
+background thread with a bounded lookahead, so at any moment at most
+``depth + 1`` recordings are resident — which is exactly the quantity the cache
+budget is checked against in pre-flight. Deeper lookahead buys nothing once
+compute dominates and costs another recording's worth of disk.
+
+A failed fetch is yielded as the exception rather than raised, so one
+unreadable recording skips that recording instead of ending the batch.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Callable, Iterable, Iterator, TypeVar
+
+__all__ = ["stream_ahead"]
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def stream_ahead(
+    items: Iterable[T],
+    fetch: Callable[[T], R],
+    *,
+    depth: int = 1,
+    on_yield: Callable[[T], None] | None = None,
+) -> Iterator[tuple[T, R | BaseException]]:
+    """Yield ``(item, fetched)`` in order, keeping *depth* fetches in flight.
+
+    ``fetch`` runs on a worker thread. Results are yielded strictly in the
+    original order — the pipeline's batch statistics depend on recordings being
+    processed in spreadsheet order, and a "whichever finishes first" stream
+    would quietly change which recordings pair with which.
+
+    ``on_yield`` is called just before each item is handed over, after its
+    fetch completed: the hook the caller uses to pin what it is about to read.
+    """
+    depth = max(0, depth)
+    iterator = iter(items)
+    pending: deque[tuple[T, Future]] = deque()
+
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="meanap-prefetch") as pool:
+        def submit_next() -> bool:
+            try:
+                item = next(iterator)
+            except StopIteration:
+                return False
+            pending.append((item, pool.submit(fetch, item)))
+            return True
+
+        for _ in range(depth + 1):
+            if not submit_next():
+                break
+
+        while pending:
+            item, future = pending.popleft()
+            try:
+                result: R | BaseException = future.result()
+            except BaseException as exc:  # noqa: BLE001 - handed to the caller
+                result = exc
+            if on_yield is not None and not isinstance(result, BaseException):
+                on_yield(item)
+            yield item, result
+            # Queue the next one only now, so the number resident stays bounded
+            # by what the caller has actually finished with.
+            submit_next()

--- a/src/meanap/remote/preflight.py
+++ b/src/meanap/remote/preflight.py
@@ -1,0 +1,299 @@
+"""Check a dataset can actually be analysed, before fetching a byte of it.
+
+Listing a remote folder returns names *and sizes* without transferring
+anything, so everything worth knowing up front is cheap: which recordings the
+spreadsheet names are actually present, which are missing a file the pipeline
+needs, how much will be downloaded, and whether it will fit in the cache
+budget. A few dozen requests, seconds, no data.
+
+The alternative is discovering at recording eleven of thirteen that one folder
+never had a ``plane0`` — after an hour of downloading. Which is why this refuses
+to start a run rather than warning and proceeding: a batch that silently
+analyses twelve of thirteen recordings produces a result that looks complete.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from meanap.remote.base import RemoteStore
+
+__all__ = [
+    "CATNAP_REQUIRED", "CATNAP_OPTIONAL", "EPHYS_EXTENSIONS",
+    "RecordingCheck", "PreflightReport", "run_preflight", "find_spreadsheet",
+]
+
+#: Without these, :func:`~meanap.catnap.loader.load_suite2p` cannot run.
+CATNAP_REQUIRED = ("stat.npy", "F.npy", "iscell.npy", "ops.npy")
+
+#: Fetched when present. ``spks.npy`` is needed only for that activity type;
+#: the denoising outputs are produced locally when absent.
+CATNAP_OPTIONAL = (
+    "spks.npy", "Fdenoised.npy", "timePoints.npy",
+    "peakStartFrames.npy", "peakEndFrames.npy", "peakHeights.npy",
+    "eventAreas.npy",
+)
+
+EPHYS_EXTENSIONS = (".mat", ".h5", ".raw")
+
+#: How many individual failures to spell out before summarising. A batch
+#: spreadsheet can name hundreds of recordings; a report that lists every one
+#: of them is a report nobody reads.
+MAX_LISTED = 8
+
+#: Throughput assumed for the time estimate. Measured at 6–9 MB/s against a
+#: Dropbox share link; deliberately the pessimistic end, since an estimate that
+#: turns out optimistic is the one that annoys.
+ASSUMED_MB_PER_S = 6.0
+
+
+@dataclass
+class RecordingCheck:
+    """What was found for one recording named by the spreadsheet."""
+
+    name: str
+    found: bool
+    missing: list[str] = field(default_factory=list)
+    fetch_bytes: int = 0
+    skipped_bytes: int = 0
+    needs_denoising: bool = False
+    #: A folder that is present and looks like this recording under another
+    #: name. Renamed folders are the commonest reason a batch silently shrinks.
+    suggestion: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.found and not self.missing
+
+
+@dataclass
+class PreflightReport:
+    mode: str
+    source: str
+    spreadsheet: str | None
+    recordings: list[RecordingCheck] = field(default_factory=list)
+    unreferenced: list[str] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    budget_bytes: int = 0
+    free_bytes: int = 0
+    peak_bytes: int = 0
+
+    @property
+    def usable(self) -> list[RecordingCheck]:
+        return [r for r in self.recordings if r.ok]
+
+    @property
+    def fetch_bytes(self) -> int:
+        return sum(r.fetch_bytes for r in self.usable)
+
+    @property
+    def skipped_bytes(self) -> int:
+        return sum(r.skipped_bytes for r in self.usable)
+
+    @property
+    def name_map(self) -> dict:
+        """Spreadsheet name → the folder that actually holds it.
+
+        Only unambiguous matches appear. Applying this is preferable to editing
+        either side by hand: the spreadsheet is often shared or published, and
+        the data folder is frequently read-only.
+        """
+        return {r.name: r.suggestion for r in self.recordings if r.suggestion}
+
+    @property
+    def ok(self) -> bool:
+        return not self.problems and bool(self.usable)
+
+    def render(self) -> str:
+        """The report a user reads before committing to a run."""
+        gb = 1e9
+        lines = [f"Source: {self.source}", f"Mode:   {self.mode}"]
+        if self.spreadsheet:
+            lines.append(f"Batch:  {self.spreadsheet}")
+        lines.append("")
+
+        ok = self.usable
+        lines.append(f"  ✓ {len(ok)} of {len(self.recordings)} recordings ready")
+
+        failed = [r for r in self.recordings if not r.ok]
+        for rec in failed[:MAX_LISTED]:
+            why = ("not found" if not rec.found
+                   else "missing " + ", ".join(rec.missing))
+            hint = (f"\n      ↳ the folder '{rec.suggestion}' looks like this "
+                    "recording under a different name" if rec.suggestion else "")
+            lines.append(f"  ✗ {rec.name} — {why}{hint}")
+        if len(failed) > MAX_LISTED:
+            lines.append(f"  ✗ …and {len(failed) - MAX_LISTED} more not found")
+
+        unmatched = [n for n in self.unreferenced
+                     if n not in {r.suggestion for r in self.recordings}]
+        for name in unmatched[:MAX_LISTED]:
+            lines.append(f"  ! {name} — present but not in the spreadsheet")
+        if len(unmatched) > MAX_LISTED:
+            lines.append(f"  ! …and {len(unmatched) - MAX_LISTED} more unreferenced")
+
+        denoise = [r for r in ok if r.needs_denoising]
+        if denoise:
+            lines.append(f"  · {len(denoise)} of {len(ok)} need denoising, "
+                         "which will run locally")
+
+        lines.append("")
+        if self.fetch_bytes:
+            mins = self.fetch_bytes / 1e6 / ASSUMED_MB_PER_S / 60
+            lines.append(f"  Download      {self.fetch_bytes / gb:6.2f} GB"
+                         + (f"   ({self.skipped_bytes / gb:.2f} GB skipped — "
+                            "files the pipeline never opens)"
+                            if self.skipped_bytes else ""))
+            lines.append(f"  Est. transfer {mins:6.0f} min at "
+                         f"{ASSUMED_MB_PER_S:.0f} MB/s")
+        if self.budget_bytes:
+            fits = "OK" if self.peak_bytes <= self.budget_bytes else "TOO SMALL"
+            lines.append(f"  Peak storage  {self.peak_bytes / gb:6.2f} GB"
+                         f"   (budget {self.budget_bytes / gb:.2f} GB, "
+                         f"{self.free_bytes / gb:.0f} GB free)  {fits}")
+
+        for w in self.warnings:
+            lines.append(f"\n  Warning: {w}")
+        for p in self.problems:
+            lines.append(f"\n  Problem: {p}")
+        return "\n".join(lines)
+
+
+def find_spreadsheet(store: RemoteStore, configured: str = "") -> str | None:
+    """Locate the batch spreadsheet within the source.
+
+    Prefers what the user configured; otherwise falls back to a single ``.csv``
+    at the top level, which is how a shared folder is usually laid out. Two or
+    more candidates is ambiguous, so it asks rather than guessing.
+    """
+    if configured:
+        name = Path(configured).name
+        if store.stat(name) is not None:
+            return name
+        if Path(configured).exists():
+            return configured
+        return None
+    csvs = [e.path for e in store.list()
+            if not e.is_dir and fnmatch.fnmatch(e.path.lower(), "*.csv")]
+    return csvs[0] if len(csvs) == 1 else None
+
+
+def _check_catnap(store: RemoteStore, name: str) -> RecordingCheck:
+    plane0 = f"{name}/suite2p/plane0"
+    entries = {e.name: e for e in store.list(plane0)}
+    if not entries:
+        return RecordingCheck(name=name, found=False,
+                              missing=["suite2p/plane0"])
+
+    missing = [f for f in CATNAP_REQUIRED if f not in entries]
+    wanted = set(CATNAP_REQUIRED) | set(CATNAP_OPTIONAL)
+    fetch = sum(e.size or 0 for n, e in entries.items() if n in wanted)
+    skipped = sum(e.size or 0 for n, e in entries.items() if n not in wanted)
+    return RecordingCheck(
+        name=name, found=True, missing=missing,
+        fetch_bytes=fetch, skipped_bytes=skipped,
+        needs_denoising="Fdenoised.npy" not in entries,
+    )
+
+
+def _check_ephys(store: RemoteStore, name: str) -> RecordingCheck:
+    for ext in EPHYS_EXTENSIONS:
+        entry = store.stat(f"{name}{ext}")
+        if entry is not None:
+            return RecordingCheck(name=name, found=True,
+                                  fetch_bytes=entry.size or 0)
+    return RecordingCheck(
+        name=name, found=False,
+        missing=[f"{name}{{{','.join(EPHYS_EXTENSIONS)}}}"])
+
+
+def _suggest_renames(report: PreflightReport) -> None:
+    """Point each missing recording at a present folder that resembles it."""
+    leftovers = list(report.unreferenced)
+    for rec in report.recordings:
+        if rec.found:
+            continue
+        for name in leftovers:
+            stripped = name.strip()
+            if stripped == rec.name or stripped.startswith(rec.name + " ") \
+                    or rec.name.startswith(stripped + " "):
+                rec.suggestion = name
+                leftovers.remove(name)
+                break
+
+    renamed = [r for r in report.recordings if r.suggestion]
+    if renamed:
+        report.problems.append(
+            f"{len(renamed)} recording(s) exist in the source under a slightly "
+            f"different folder name (e.g. '{renamed[0].name}' vs "
+            f"'{renamed[0].suggestion}'). Rename the folders, or edit the "
+            "spreadsheet to match — otherwise they will be silently skipped.")
+
+
+def run_preflight(
+    store: RemoteStore,
+    recording_names: list[str],
+    *,
+    mode: str = "catnap",
+    spreadsheet: str | None = None,
+    cache_dir: Path | str | None = None,
+    cache_budget_gb: float | None = None,
+    prefetch_depth: int = 1,
+) -> PreflightReport:
+    """Inspect a source and report whether the named recordings can be analysed.
+
+    Does no transfer beyond folder listings. ``recording_names`` comes from the
+    batch spreadsheet; anything present in the source but not named there is
+    reported as unreferenced rather than silently analysed or silently ignored.
+    """
+    report = PreflightReport(mode=mode, source=str(store),
+                             spreadsheet=spreadsheet)
+
+    check = _check_catnap if mode == "catnap" else _check_ephys
+    for name in recording_names:
+        report.recordings.append(check(store, name))
+
+    named = set(recording_names)
+    present = [e.name for e in store.list() if e.is_dir]
+    report.unreferenced = [n for n in present if n not in named]
+
+    # Match renamed folders back to the spreadsheet. A folder gaining a suffix
+    # ("… David Oluigbo") is invisible to an exact-name lookup, and the result
+    # is a batch that quietly analyses a fraction of what was asked for — the
+    # exact failure this whole check exists to prevent.
+    _suggest_renames(report)
+
+    if not report.usable:
+        report.problems.append(
+            "No recording in the spreadsheet has the files this mode needs — "
+            "check that the source folder and the spreadsheet describe the "
+            "same dataset.")
+    elif len(report.usable) < len(report.recordings):
+        n = len(report.recordings) - len(report.usable)
+        report.warnings.append(
+            f"{n} recording(s) will be skipped. Batch comparisons and the "
+            "node-cartography boundaries are computed across whichever "
+            "recordings actually run, so results will not match a complete "
+            "batch.")
+
+    if store.copies and cache_dir is not None:
+        from meanap.remote.cache import CacheFull, resolve_budget
+
+        largest = max((r.fetch_bytes for r in report.usable), default=0)
+        report.peak_bytes = largest * (prefetch_depth + 1)
+        try:
+            report.budget_bytes = resolve_budget(
+                cache_dir, cache_budget_gb, required_bytes=report.peak_bytes)
+        except CacheFull as e:
+            report.problems.append(str(e))
+            report.budget_bytes = 0
+        import shutil
+        probe = Path(cache_dir)
+        while not probe.exists() and probe != probe.parent:
+            probe = probe.parent
+        report.free_bytes = shutil.disk_usage(probe).free
+
+    return report

--- a/src/meanap/remote/source.py
+++ b/src/meanap/remote/source.py
@@ -1,0 +1,214 @@
+"""Where the pipeline gets a recording's raw data from.
+
+Both analysis paths want ordinary local files: CAT-NAP a ``suite2p/plane0``
+directory, electrophysiology a single ``.mat``/``.h5``/``.raw``. This produces
+them, whether the data is already on disk or has to be fetched — and for the
+remote case, fetches the *next* recording while the current one is analysed and
+drops each one as soon as its results are safely written.
+
+Three decisions make that work without touching the loaders:
+
+**The cache mirrors the remote tree**, so a fetched folder or file is an
+ordinary path. Nothing downstream knows or cares where it came from.
+
+**Only the files the pipeline opens are fetched.** The listing gives names and
+sizes for free, so the ``.csv`` exports, ``Fneu.npy`` and ``stat.xlsx`` that
+suite2p writes alongside — about a fifth of a folder — are never transferred.
+
+**Releases are reference-counted.** One Axion ``.raw`` holds a whole plate and
+MEA-NAP treats each well as its own recording, so several recordings share a
+file. Evicting it when the first of them finishes would re-download it for the
+next; the count is what prevents that.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, Iterator
+
+from meanap.remote.base import RemoteStore
+from meanap.remote.cache import FileCache
+from meanap.remote.preflight import (
+    CATNAP_OPTIONAL, CATNAP_REQUIRED, EPHYS_EXTENSIONS,
+)
+from meanap.remote.prefetch import stream_ahead
+
+__all__ = ["RecordingSource", "SUITE2P_SUBDIR"]
+
+SUITE2P_SUBDIR = "suite2p/plane0"
+
+#: Everything :func:`load_suite2p` may open, in one set.
+WANTED = frozenset(CATNAP_REQUIRED) | frozenset(CATNAP_OPTIONAL)
+
+
+@dataclass
+class RecordingSource:
+    """Supplies local ``plane0`` directories, fetching and evicting as needed."""
+
+    store: RemoteStore
+    cache: FileCache | None = None
+    log: Callable[[str], None] = print
+    #: Spreadsheet name → the folder that actually holds it, from pre-flight.
+    #: Applying it here means neither the spreadsheet nor the data folder has
+    #: to be edited for a run to find its recordings.
+    name_map: dict = field(default_factory=dict)
+    #: cache-relative path → how many not-yet-released recordings still need it.
+    _holders: dict = field(default_factory=dict, repr=False)
+
+    @property
+    def remote(self) -> bool:
+        return self.store.copies
+
+    def folder(self, recording: str) -> str:
+        return self.name_map.get(recording, recording)
+
+    def _hold(self, recording: str, rel: str) -> None:
+        """Record that *recording* is using *rel*, so a shared file survives."""
+        self._holders.setdefault(rel, set()).add(recording)
+
+    def _rels_for(self, recording: str) -> list[str]:
+        return [rel for rel, users in self._holders.items() if recording in users]
+
+    def plane0(self, recording: str) -> Path:
+        """A local ``suite2p/plane0`` for *recording*, fetching it if remote.
+
+        Raises :class:`FileNotFoundError` when the recording has no suite2p
+        output, which the caller reports as a skip.
+        """
+        rel = f"{self.folder(recording)}/{SUITE2P_SUBDIR}"
+        if not self.remote:
+            local = self.store.fetch_dir_path(rel) if hasattr(
+                self.store, "fetch_dir_path") else Path(self.store.root) / rel
+            if not (local / "stat.npy").exists():
+                raise FileNotFoundError(f"no suite2p output at {local}")
+            return local
+
+        if self.cache is None:
+            raise ValueError("A remote source needs a cache.")
+
+        entries = [e for e in self.store.list(rel) if not e.is_dir]
+        if not entries:
+            raise FileNotFoundError(f"no suite2p output at {rel}")
+
+        wanted = [e for e in entries if e.name in WANTED]
+        skipped = sum(e.size or 0 for e in entries if e.name not in WANTED)
+        total = sum(e.size or 0 for e in wanted)
+        self.log(f"  [{recording}] fetching {total / 1e6:.0f} MB"
+                 + (f" (skipping {skipped / 1e6:.0f} MB the pipeline never opens)"
+                    if skipped else ""))
+        for entry in wanted:
+            self.cache.get(self.store, entry.path)
+        return self.cache.path_for(self.store, rel)
+
+    def raw_file(self, recording: str):
+        """A local electrophysiology recording, fetching it if remote.
+
+        Returns a :class:`~meanap.pipeline.io.RawSource` so an Axion plate
+        carries which well this recording is. Raises :class:`FileNotFoundError`
+        when no supported file exists.
+        """
+        from meanap.pipeline.io import RawSource, find_raw_file, split_well_suffix
+
+        name = self.folder(recording)
+        if not self.remote:
+            found = find_raw_file(Path(self.store.root), name)
+            if found is None:
+                raise FileNotFoundError(
+                    f"no raw recording for {name} in {self.store.root}")
+            return found
+
+        if self.cache is None:
+            raise ValueError("A remote source needs a cache.")
+
+        rel, well = None, None
+        for ext in EPHYS_EXTENSIONS:
+            if self.store.stat(f"{name}{ext}") is not None:
+                rel = f"{name}{ext}"
+                break
+        if rel is None:
+            split = split_well_suffix(name)
+            if split is not None and self.store.stat(f"{split[0]}.raw") is not None:
+                rel, well = f"{split[0]}.raw", split[1]
+        if rel is None:
+            raise FileNotFoundError(
+                f"no raw recording for {name} "
+                f"(looked for {', '.join(EPHYS_EXTENSIONS)})")
+
+        entry = self.store.stat(rel)
+        self._hold(recording, rel)
+        cached = self.cache.path_for(self.store, rel)
+        if not cached.exists():
+            self.log(f"  [{recording}] fetching {(entry.size or 0) / 1e6:.0f} MB")
+        return RawSource(self.cache.get(self.store, rel), well)
+
+    def release(self, recording: str) -> None:
+        """Drop a recording's raw data now that its results are written.
+
+        Called by the pipeline rather than inferred, because only the pipeline
+        knows when the derived outputs are safely on disk. A file still held by
+        another recording — an Axion plate shared between wells — is kept.
+        Cheap and silent for a local source, which owns nothing to release.
+        """
+        if not self.remote or self.cache is None:
+            return
+
+        freed = 0
+        for rel in self._rels_for(recording):
+            users = self._holders[rel]
+            users.discard(recording)
+            if users:
+                self.log(f"  [{recording}] keeping {Path(rel).name} — "
+                         f"{len(users)} more recording(s) need it")
+                continue
+            del self._holders[rel]
+            freed += self.cache.evict_prefix(self.store, rel)
+
+        # CAT-NAP holds a folder rather than named files.
+        freed += self.cache.evict_prefix(self.store, self.folder(recording))
+        if freed:
+            self.log(f"  [{recording}] released {freed / 1e6:.0f} MB "
+                     f"(cache now {self.cache.usage() / 1e6:.0f} MB)")
+
+    def stream(
+        self, recordings: Iterable, depth: int = 1, kind: str = "catnap",
+    ) -> Iterator[tuple[object, object]]:
+        """Yield ``(recording, data)`` in order, fetching ahead when remote.
+
+        ``kind`` selects what "data" means: a ``plane0`` directory for CAT-NAP,
+        a :class:`RawSource` for electrophysiology. A local source yields
+        immediately and does no work in the background — there is nothing to
+        overlap, and a thread to hand back a path would only add a way to fail.
+        """
+        get = self.plane0 if kind == "catnap" else self.raw_file
+
+        if not self.remote:
+            for rec in recordings:
+                try:
+                    yield rec, get(rec.filename)
+                except BaseException as exc:  # noqa: BLE001
+                    yield rec, exc
+            return
+
+        def pin(rec) -> None:
+            if self.cache is None:
+                return
+            self.cache.pin_prefix(self.store, self.folder(rec.filename))
+            for rel in self._rels_for(rec.filename):
+                self.cache.pin_prefix(self.store, rel)
+
+        yield from stream_ahead(
+            recordings, lambda rec: get(rec.filename), depth=depth, on_yield=pin,
+        )
+
+    def unpin(self, recording: str) -> None:
+        """Release the eviction hold taken when this recording was handed over.
+
+        Takes a name, like every other method here — the stream yields whole
+        recording records, but the source is addressed by name throughout.
+        """
+        if not self.remote or self.cache is None:
+            return
+        self.cache.unpin_prefix(self.store, self.folder(recording))
+        for rel in self._rels_for(recording):
+            self.cache.unpin_prefix(self.store, rel)


### PR DESCRIPTION
A batch that doesn't fit on disk can now be analysed. Put a Dropbox folder share link in `Params.raw_data` instead of a path and recordings are fetched one at a time, analysed, and dropped — so a run needs one or two recordings of local storage, not the whole dataset. Measured on a real 13-recording folder: 1.96 GB of source streamed through a 0.72 GB working set, and the peak does not grow with the batch.

Deliberately one field, not several: `raw_data` doubles as the source, and the fetch cache and derived-data folder default under `output_data_folder`. Nothing else needs configuring, and there is no way to set two fields inconsistently.

**Dropbox share links can serve individual files.** The documented unauthenticated operation is downloading the whole folder as a generated zip — 14 GB, no partial fetch. But dropbox.com's own front end does better, with endpoints that need no token: `list_shared_link_folder_entries` for listings, each entry's own `secure_hash` plus `sub_path` to recurse, and `raw=1` (not `dl=1`, which returns an interstitial page) for the bytes. Range requests work, so downloads resume. All verified against a live link. This is undocumented and unversioned, so it is confined to one adapter that fails loudly and names the supported alternatives — a synced folder or an `rclone mount`.

**Pre-flight before any transfer.** Listing returns names *and sizes* for free, so a run reports up front which recordings are present, what will be downloaded, and whether it fits — in seconds. A remote run does this automatically and refuses to start when the source is unusable, because the group comparisons and cartography boundaries are computed from whichever recordings actually ran: a silently-shortened batch still produces results, and they look complete. It also matches renamed folders back to spreadsheet rows, which found 12 such mismatches in a real dataset that would otherwise have reduced a 13-recording batch to 1.

Both analysis paths are wired: CAT-NAP fetches a `suite2p/plane0` folder, electrophysiology one raw file. Releases are reference-counted, because one Axion `.raw` holds a plate and MEA-NAP treats each well as its own recording — evicting after the first well would re-download it for the next.

Three prerequisite fixes, each worth making on its own merits:

- CAT-NAP wrote six denoising outputs *into the suite2p folder*. Against read-only or remote data that fails, or silently uploads ~48 MB per recording back to the source. They now go to a derived directory; reads check there first and fall back, so existing datasets are unaffected.
- `ops.npy` is a pickle — 493 MB in the example dataset — read in full to reach two fields. Now cached to a 5.6 MB sidecar: 9.4x faster, and 90% less to fetch per recording on a second run.
- CAT-NAP opened each raw folder twice. Capturing the field-of-view backdrop in phase 1 makes the common case single-pass, which is what allows a recording to be released immediately.

Bugs found by testing rather than by inspection:

- Concurrent fetches each passed the budget check and both downloaded, and one thread could evict another's half-written file. In-flight fetches now hold a byte reservation and a pin.
- `pin_prefix`/`evict_prefix` used `rglob`, which yields nothing for a *file* path — so an electrophysiology recording was never pinned (evictable while being read) and never evicted (cache filled). Invisible to CAT-NAP, which only ever passes folders.
- Share links reaching bundled `params.json` would have shipped an unauthenticated grant of access alongside results. Redaction is by value, so the same field holding a local path is left alone.

Docs: new docs/python/remote-data.md, `meanap-preflight` CLI (with `--write-spreadsheet` to correct recording names without editing either side), and `meanap.remote`/`meanap.viewer` added to the API reference.

Known limits, stated in the docs: Dropbox folder links only, the stim path still assumes local data, and folders large enough to paginate a listing are refused rather than silently truncated.


Claude-Session: https://claude.ai/code/session_01U2GsZ8XZ7kfTvMNq2XDPvs