### PR TITLE
feat(gui): wrap tooltips, and add an express-mode toggle

### DIFF
--- a/python/test_gui_tooltips.py
+++ b/python/test_gui_tooltips.py
@@ -1,0 +1,266 @@
+"""Test GUI behaviour that is easy to break and hard to notice: tooltip
+wrapping, and the express-mode toggle.
+
+Run from the repo root::
+
+    uv run python python/test_gui_tooltips.py
+
+Qt lays a plain-text tooltip out on one line however long it is. Before this,
+the widest in the app rendered at **1468 px** — most of a laptop screen, one
+line tall, usually covering the control it was describing.
+
+The checks measure what Qt would actually draw, via ``QTextDocument``, rather
+than counting characters: a character count passes on the developer's font and
+fails on someone else's. Runs headless (``QT_QPA_PLATFORM=offscreen``), so no
+display is needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from PyQt6.QtGui import QAction, QFontMetrics, QTextDocument  # noqa: E402
+from PyQt6.QtWidgets import QApplication, QWidget  # noqa: E402
+
+from meanap.gui.tooltip import (  # noqa: E402
+    MAX_TOOLTIP_PX, TOOLTIP_QSS, format_tooltip, install_tooltip_style,
+    set_tooltip, wrap_to_width, wrap_tooltips,
+)
+
+Check = tuple[str, bool, str]
+
+#: Allow a little slack over the target: a wrapped line is at most the limit
+#: plus whatever the final word overhangs by, and rich text adds padding.
+LIMIT_PX = MAX_TOOLTIP_PX + 40
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+def _drawn_width(text: str, font) -> int:
+    """How wide Qt will actually render this tooltip."""
+    doc = QTextDocument()
+    doc.setDefaultFont(font)
+    if text.strip().startswith("<"):
+        doc.setHtml(text)
+    else:
+        doc.setPlainText(text)
+    doc.setTextWidth(-1)
+    return int(doc.idealWidth())
+
+
+def _wrapping_checks(app: QApplication) -> list[Check]:
+    checks: list[Check] = []
+    metrics = QFontMetrics(app.font())
+
+    long_text = (
+        "Folder holding your recordings — or paste a Dropbox folder share link "
+        "to analyse them without downloading the whole dataset, which is useful "
+        "when the batch is larger than the disk you have available.")
+    lines = wrap_to_width(long_text, metrics, MAX_TOOLTIP_PX)
+    checks.append(("long text is split into several lines", len(lines) > 2,
+                   f"{len(lines)}"))
+    checks.append(("every line fits the target width",
+                   all(metrics.horizontalAdvance(ln) <= MAX_TOOLTIP_PX for ln in lines),
+                   f"{max(metrics.horizontalAdvance(ln) for ln in lines)} px"))
+    checks.append(("no words are lost or duplicated",
+                   " ".join(lines).split() == long_text.split(), ""))
+
+    # Deliberate line breaks must survive.
+    shaped = wrap_to_width("first line\nsecond line", metrics, MAX_TOOLTIP_PX)
+    checks.append(("existing newlines are kept as breaks",
+                   shaped == ["first line", "second line"], f"{shaped}"))
+
+    # A single over-long word is left intact rather than broken mid-word.
+    huge = "supercalifragilistic_expialidocious_identifier_that_is_very_long"
+    checks.append(("an unbreakable word is not split",
+                   wrap_to_width(huge, metrics, 50) == [huge], ""))
+    return checks
+
+
+def _format_checks(app: QApplication) -> list[Check]:
+    checks: list[Check] = []
+
+    short = "Step to stop at, inclusive (1–4)"
+    checks.append(("short text is left alone",
+                   format_tooltip(short) == short, ""))
+
+    rich = "<b>already</b> markup"
+    checks.append(("existing rich text is not re-wrapped",
+                   format_tooltip(rich) == rich, ""))
+    checks.append(("empty text is left alone", format_tooltip("") == "", ""))
+
+    long_text = "word " * 80
+    out = format_tooltip(long_text)
+    checks.append(("long text becomes rich text with breaks",
+                   out.startswith("<div>") and "<br>" in out, out[:40]))
+    checks.append(("…and renders within the limit",
+                   _drawn_width(out, app.font()) <= LIMIT_PX,
+                   f"{_drawn_width(out, app.font())} px"))
+
+    # Text with markup characters must be escaped, not interpreted.
+    tricky = format_tooltip("compare a < b and " + "pad " * 60)
+    checks.append(("angle brackets in text are escaped",
+                   "&lt;" in tricky, tricky[:60]))
+
+    # Formatting is idempotent — wrap_tooltips runs once, but a second call
+    # (a re-shown window, say) must not nest markup.
+    checks.append(("formatting twice changes nothing",
+                   format_tooltip(out) == out, ""))
+    return checks
+
+
+def _window_checks(app: QApplication) -> list[Check]:
+    from meanap.gui.main_window import MainWindow
+
+    checks: list[Check] = []
+    window = MainWindow()
+
+    targets = [window, *window.findChildren(QWidget), *window.findChildren(QAction)]
+    tips = [(t, t.toolTip()) for t in targets if t.toolTip()]
+    checks.append(("the window has tooltips to check", len(tips) > 10, f"{len(tips)}"))
+
+    widest, worst = 0, ""
+    for target, text in tips:
+        font = target.font() if hasattr(target, "font") else app.font()
+        px = _drawn_width(text, font)
+        if px > widest:
+            widest, worst = px, text
+    checks.append((f"no tooltip is wider than {LIMIT_PX} px (worst {widest} px)",
+                   widest <= LIMIT_PX, worst[:70]))
+
+    multiline = [t for _, t in tips if "<br>" in t]
+    checks.append(("the long ones actually wrapped", len(multiline) >= 3,
+                   f"{len(multiline)}"))
+
+    # Toolbar tooltips live on QAction, not QWidget — the case originally missed.
+    actions = [a for a in window.findChildren(QAction) if a.toolTip()]
+    checks.append(("action tooltips are covered too", len(actions) > 0,
+                   f"{len(actions)}"))
+    action_widths = [_drawn_width(a.toolTip(), app.font()) for a in actions]
+    checks.append(("…and are within the limit",
+                   all(px <= LIMIT_PX for px in action_widths),
+                   f"{max(action_widths) if action_widths else 0} px"))
+
+    checks.append(("tooltip styling is installed",
+                   "QToolTip" in (app.styleSheet() or ""), ""))
+    checks.append(("…matching the tutorial bubble's panel colour",
+                   "#2d323b" in TOOLTIP_QSS, ""))
+
+    # Running the pass again must be a no-op, not a second wrap.
+    again = wrap_tooltips(window)
+    checks.append(("a second wrapping pass changes nothing", again == 0, f"{again}"))
+
+    # And the styling install must not clobber an existing theme.
+    before = app.styleSheet()
+    install_tooltip_style(app)
+    checks.append(("re-installing the style is idempotent",
+                   app.styleSheet() == before, ""))
+    return checks
+
+
+def _express_toggle_checks(app: QApplication) -> list[Check]:
+    """The express-mode checkbox must reach an actual run, not just Params.
+
+    A control that sets a field nobody reads is worse than no control: the user
+    ticks it, the run behaves as before, and nothing says why.
+    """
+    from meanap.gui.main_window import MainWindow
+    from meanap.params import Params
+
+    checks: list[Check] = []
+    window = MainWindow()
+    pipe = window._pipeline_panel
+
+    checks.append(("the Pipeline tab has an express-mode toggle",
+                   hasattr(pipe, "express_mode"), ""))
+    checks.append(("it is off by default, matching Params",
+                   pipe.express_mode.isChecked() is False
+                   and Params().express_mode is False, ""))
+
+    pipe.load(Params(express_mode=True))
+    checks.append(("loading a run with express on ticks it",
+                   pipe.express_mode.isChecked(), ""))
+    pipe.load(Params(express_mode=False))
+    checks.append(("…and off unticks it",
+                   not pipe.express_mode.isChecked(), ""))
+
+    pipe.express_mode.setChecked(True)
+    saved = Params()
+    pipe.save(saved)
+    checks.append(("ticking it sets Params.express_mode", saved.express_mode, ""))
+    pipe.express_mode.setChecked(False)
+    saved2 = Params(express_mode=True)
+    pipe.save(saved2)
+    checks.append(("unticking it clears Params.express_mode",
+                   not saved2.express_mode, ""))
+
+    # _collect_params is what the Run button actually builds a run from, so
+    # that is the path worth asserting on — not just the panel's own save().
+    window._pipeline_panel.express_mode.setChecked(True)
+    collected = window._collect_params()
+    checks.append(("the params a run is built from carry it",
+                   collected.express_mode, ""))
+    window._pipeline_panel.express_mode.setChecked(False)
+    checks.append(("…and reflect it being turned off",
+                   not window._collect_params().express_mode, ""))
+
+    checks.append(("the toggle explains what it does",
+                   len(pipe.express_mode.toolTip()) > 80, ""))
+    checks.append(("…and that tooltip is wrapped like the rest",
+                   pipe.express_mode.toolTip().startswith("<div>"),
+                   pipe.express_mode.toolTip()[:30]))
+    return checks
+
+
+def _helper_checks(app: QApplication) -> list[Check]:
+    checks: list[Check] = []
+    w = QWidget()
+    set_tooltip(w, "short")
+    checks.append(("set_tooltip leaves short text plain", w.toolTip() == "short", ""))
+    set_tooltip(w, "word " * 80)
+    checks.append(("set_tooltip wraps long text", "<br>" in w.toolTip(), ""))
+    checks.append(("…within the limit",
+                   _drawn_width(w.toolTip(), w.font()) <= LIMIT_PX,
+                   f"{_drawn_width(w.toolTip(), w.font())} px"))
+    return checks
+
+
+def main() -> int:
+    app = QApplication.instance() or QApplication([])
+    print("=" * 70)
+    print("GUI: tooltips and the express-mode toggle")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [
+        ("A — wrapping by measured width:", _wrapping_checks),
+        ("B — formatting rules:", _format_checks),
+        ("C — the real window:", _window_checks),
+        ("D — the express-mode toggle:", _express_toggle_checks),
+        ("E — the set_tooltip helper:", _helper_checks),
+    ]:
+        p, n = _report(title, build(app))
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -31,6 +31,7 @@ from meanap.gui.panels.stim_preview import StimPreviewPanel
 from meanap.gui.panels.pipeline import PipelinePanel
 from meanap.gui.panels.catnap import CatNapPanel
 from meanap.gui.panels.network_viewer import NetworkViewerPanel
+from meanap.gui.tooltip import install_tooltip_style, wrap_tooltips
 from meanap.gui.tutorial import TutorialOverlay, TutorialStep, tabbar_target
 
 
@@ -70,6 +71,12 @@ class MainWindow(QMainWindow):
         self._build_toolbar()
         self._build_tabs()
         self._load_params(self._params)
+        # Wrap every tooltip in one pass, once the whole UI exists. Doing it
+        # here rather than at each call site means a tooltip written anywhere
+        # is formatted without its author having to remember — Qt otherwise
+        # lays a long one out on a single line, wider than the screen.
+        install_tooltip_style()
+        wrap_tooltips(self)
         self._maybe_show_tutorial_on_first_launch()
 
     # ── UI construction ───────────────────────────────────────────────────────

--- a/src/meanap/gui/panels/pipeline.py
+++ b/src/meanap/gui/panels/pipeline.py
@@ -102,9 +102,23 @@ class PipelinePanel(QWidget):
         seed_layout.addWidget(self.random_seed)
         seed_layout.addStretch()
 
+        # Express mode skips every figure that can be rebuilt from the run's
+        # own data and writes one shareable .meanap bundle instead. The numbers
+        # are identical either way — only the drawing is deferred.
+        self.express_mode = QCheckBox()
+        self.express_mode.setToolTip(
+            "Skip figures that can be redrawn later and write a single small "
+            ".meanap bundle instead. On the example dataset that turns 483 "
+            "figures and 56 MB into 6 figures and 2.2 MB, and saves about a "
+            "fifth of the run time. The numbers are identical either way — "
+            "open the bundle with 'meanap-viewer' to draw any figure on demand, "
+            "in PNG or editable SVG."
+        )
+
         form2.addRow("Verbose level", self.verbose_level)
         form2.addRow("Time each step", self.time_processes)
         form2.addRow("Fixed random seed", seed_row)
+        form2.addRow("Express mode", self.express_mode)
 
         # ── Run controls ──────────────────────────────────────────────────────
         run_box = QGroupBox("Run")
@@ -163,6 +177,7 @@ class PipelinePanel(QWidget):
         if idx >= 0:
             self.verbose_level.setCurrentIndex(idx)
         self.time_processes.setChecked(params.time_processes)
+        self.express_mode.setChecked(params.express_mode)
         self.use_random_seed.setChecked(params.random_seed is not None)
         if params.random_seed is not None:
             self.random_seed.setValue(int(params.random_seed))
@@ -176,6 +191,7 @@ class PipelinePanel(QWidget):
         params.prior_analysis = self.prior_analysis.isChecked()
         params.verbose_level = self.verbose_level.currentText()
         params.time_processes = self.time_processes.isChecked()
+        params.express_mode = self.express_mode.isChecked()
         params.random_seed = (
             self.random_seed.value() if self.use_random_seed.isChecked() else None
         )

--- a/src/meanap/gui/tooltip.py
+++ b/src/meanap/gui/tooltip.py
@@ -1,0 +1,152 @@
+"""Tooltips that wrap, and look like the tutorial bubbles.
+
+Qt lays a plain-text tooltip out on a single line however long it is. The
+longest in this app rendered at 1468 px — most of a laptop screen, in a strip
+one line tall, usually overlapping the very control it describes. Anything
+worth explaining in a sentence was therefore unreadable.
+
+Two changes fix it:
+
+**Wrap by measured width, not character count.** A fixed character count guesses
+wrong on a different font or display scale. :func:`wrap_to_width` asks the
+actual font how wide each candidate line is, so the result is the requested
+pixel width whatever the theme.
+
+**Match the tutorial bubble**, which already solved "present a paragraph over a
+dimmed UI": same dark panel, accent border, rounded corners, generous padding.
+A tooltip and a tutorial step are the same kind of object — a short explanation
+anchored to a control — and looking the same makes that legible.
+
+Applied in bulk by :func:`wrap_tooltips`, so a tooltip written anywhere in the
+GUI is formatted without its author having to remember to do it.
+"""
+
+from __future__ import annotations
+
+import html
+
+from PyQt6.QtCore import QObject
+from PyQt6.QtGui import QAction, QFontMetrics
+from PyQt6.QtWidgets import QApplication, QToolTip, QWidget
+
+from meanap.gui.tutorial import ACCENT
+
+__all__ = ["TOOLTIP_QSS", "MAX_TOOLTIP_PX", "format_tooltip", "wrap_to_width",
+           "set_tooltip", "wrap_tooltips", "install_tooltip_style"]
+
+#: Target width for a wrapped tooltip. Narrower than the tutorial bubble's 560:
+#: a tooltip appears unbidden next to the cursor, so it should occupy less of
+#: the screen than something the reader deliberately opened.
+MAX_TOOLTIP_PX = 380
+
+#: Styled to match ``TutorialOverlay``'s bubble.
+TOOLTIP_QSS = (
+    "QToolTip {"
+    "  background-color: #2d323b;"
+    "  color: #f2f4f8;"
+    f"  border: 1px solid {ACCENT};"
+    "  border-radius: 6px;"
+    "  padding: 6px 9px;"
+    "  font-size: 12px;"
+    "}"
+)
+
+
+def wrap_to_width(text: str, metrics: QFontMetrics, max_px: int) -> list[str]:
+    """Split *text* into lines no wider than *max_px*, by measurement.
+
+    Existing newlines are honoured as hard breaks, so a tooltip that was
+    deliberately laid out keeps its shape. A single word wider than the limit is
+    left over-long rather than broken mid-word — a hyphenated identifier is
+    worse to read split than to read wide.
+    """
+    lines: list[str] = []
+    for paragraph in text.splitlines() or [""]:
+        words = paragraph.split()
+        if not words:
+            lines.append("")
+            continue
+        current = words[0]
+        for word in words[1:]:
+            candidate = f"{current} {word}"
+            if metrics.horizontalAdvance(candidate) <= max_px:
+                current = candidate
+            else:
+                lines.append(current)
+                current = word
+        lines.append(current)
+    return lines
+
+
+def format_tooltip(text: str, widget: QObject | None = None,
+                   max_px: int = MAX_TOOLTIP_PX) -> str:
+    """Turn tooltip text into wrapped rich text.
+
+    Returns the input untouched when it is already rich text — a caller that
+    wrote markup meant it — or when it is short enough to need no help.
+    """
+    stripped = text.strip()
+    if not stripped or stripped.startswith("<"):
+        return text
+
+    # A QAction has a tooltip but no font of its own; fall back to the
+    # application's, which is what Qt draws its tooltip with anyway.
+    font = getattr(widget, "font", None)
+    font = font() if callable(font) else None
+    if font is None:
+        app = QApplication.instance()
+        font = app.font() if app is not None else None
+    if font is None:
+        return text
+    metrics = QFontMetrics(font)
+    if metrics.horizontalAdvance(stripped) <= max_px and "\n" not in stripped:
+        return text
+
+    lines = wrap_to_width(stripped, metrics, max_px)
+    return "<div>" + "<br>".join(html.escape(line) for line in lines) + "</div>"
+
+
+def set_tooltip(target: QObject, text: str, max_px: int = MAX_TOOLTIP_PX) -> None:
+    """Set a tooltip, wrapped to a readable width."""
+    target.setToolTip(format_tooltip(text, target, max_px))
+
+
+def wrap_tooltips(root: QWidget, max_px: int = MAX_TOOLTIP_PX) -> int:
+    """Wrap every tooltip already set on *root* and its children.
+
+    Covers ``QAction`` as well as ``QWidget``: toolbar and menu tooltips live
+    on actions, which are not widgets, and would otherwise be the only ones
+    left unwrapped — exactly the long "what does this button do" text that
+    needed wrapping most.
+
+    Called once after a window is built, so tooltips written anywhere in the
+    GUI are formatted without each author remembering to. Returns how many were
+    changed.
+    """
+    changed = 0
+    targets = [root, *root.findChildren(QWidget), *root.findChildren(QAction)]
+    for target in targets:
+        current = target.toolTip()
+        if not current:
+            continue
+        formatted = format_tooltip(current, target, max_px)
+        if formatted != current:
+            target.setToolTip(formatted)
+            changed += 1
+    return changed
+
+
+def install_tooltip_style(app: QApplication | None = None) -> None:
+    """Append the tooltip styling to the application stylesheet.
+
+    Appended rather than assigned: the app already carries a theme, and
+    replacing its stylesheet to restyle tooltips would discard it.
+    """
+    app = app or QApplication.instance()
+    if app is None:
+        return
+    existing = app.styleSheet() or ""
+    if "QToolTip" in existing:
+        return
+    app.setStyleSheet(existing + "\n" + TOOLTIP_QSS)
+    QToolTip.setFont(app.font())


### PR DESCRIPTION
Qt lays a plain-text tooltip out on a single line however long it is. The widest in this app rendered at 1468 px — most of a laptop screen, one line tall, usually covering the very control it described. Anything worth explaining in a sentence was therefore unreadable. The widest is now 382 px, and none exceed 420.

Wrapping is by measured pixel width rather than character count: a character count passes on one font and fails on another theme or display scale, so `wrap_to_width` asks the actual font how wide each candidate line is.

Applied in one pass after the window is built, not at each of the 23 call sites — a tooltip written anywhere in the GUI is then formatted without its author remembering to, including any added later. `set_tooltip()` covers anything set dynamically after construction.

Tooltips are styled to match the tutorial bubbles: same dark panel, accent border, rounded corners, padding. A tooltip and a tutorial step are the same kind of object — a short explanation anchored to a control — so they should read the same.

The pass covers `QAction` as well as `QWidget`. Toolbar and menu tooltips live on actions, which are not widgets; a widget-only walk missed six of them, including the longest "what does this button do" text that most needed wrapping.

Also adds a Pipeline-tab checkbox for express mode, which until now was reachable only from Python. Its tooltip states the trade concretely — 483 figures and 56 MB become 6 and 2.2 MB, about a fifth less run time, identical numbers either way.

Tests (`python/test_gui_tooltips.py`, headless) measure what Qt would actually draw via QTextDocument, and cover the ways this would silently rot: markup characters must be escaped rather than interpreted, deliberate newlines must survive, an unbreakable identifier must not be split mid-word, and a second wrapping pass must be a no-op rather than nesting markup. The express-mode checks assert on `_collect_params()` — what the Run button actually builds a run from — because a control that sets a field nobody reads is worse than no control.


Claude-Session: https://claude.ai/code/session_01U2GsZ8XZ7kfTvMNq2XDPvs