### PR TITLE
Make the express bundle findable, and the batch comparisons selectable

### DIFF
--- a/docs/python/express-mode.md
+++ b/docs/python/express-mode.md
@@ -21,6 +21,37 @@ Then browse the result:
 uv run meanap-viewer path/to/OutputData….meanap
 ```
 
+In the GUI it is the **Express mode** tick box on the Pipeline tab, and it
+applies to **🧪 Test pipeline** runs too.
+
+## Where the bundle goes
+
+Beside the output folder, not inside it — the folder is named after the run and
+the bundle takes the same name:
+
+```
+OutputData07Aug2026/            the output folder
+OutputData07Aug2026.meanap      the bundle          ← one level up, alongside it
+```
+
+This is the single most common "express mode didn't produce anything" report:
+the file is there, just not where the figures used to be. An express run ends
+by naming it in the status log, in a framed block after the timing lines, with
+the command that opens it.
+
+## Opening a bundle from the GUI
+
+Three routes, all equivalent to running `meanap-viewer` yourself:
+
+- **🌐 View report** after an express run — the button notices the run was
+  express and opens the bundle in the viewer instead of building a
+  near-empty `report.html` from the handful of figures on disk;
+- **Open bundle…** in the toolbar;
+- **drag the `.meanap` file onto the window**.
+
+Each bundle gets its own viewer; they all shut down when MEA-NAP closes. See
+[Opening a bundle](gui-guide.md#opening-a-bundle).
+
 ## What it costs and what it saves
 
 Measured on the same dataset and settings as the MATLAB-vs-Python comparison
@@ -152,6 +183,8 @@ inputs, ship a small bundle back.
 uv run meanap-viewer path/to/Run.meanap        # or an output folder
 uv run meanap-viewer Run.meanap --port 9000 --no-browser
 ```
+
+(Or open it from the GUI — [above](#opening-a-bundle-from-the-gui).)
 
 A local web app: figure list on the left, the figure in the middle, and the
 full Network Viewer control set on the right — node layout, colour map, edge

--- a/docs/python/express-mode.md
+++ b/docs/python/express-mode.md
@@ -186,27 +186,108 @@ uv run meanap-viewer Run.meanap --port 9000 --no-browser
 
 (Or open it from the GUI — [above](#opening-a-bundle-from-the-gui).)
 
-A local web app: figure list on the left, the figure in the middle, and the
-full Network Viewer control set on the right — node layout, colour map, edge
-threshold and method, maximum edges drawn, node size and scaling, edge widths.
-Changing any of them re-renders through the same Python that drew the original.
+A local web app in three tabs, one per kind of question a run answers.
+
+Every figure can be downloaded as **PNG, SVG or PDF**. SVG is real vector markup
+with editable paths, so a figure can go straight into Illustrator or Inkscape
+for a manuscript.
+
+### Recordings
+
+One spatial network plot at a time, with the full Network Viewer control set on
+the right — node layout, colour map, edge threshold and method, maximum edges
+drawn, node size and scaling, edge widths. Changing any of them re-renders
+through the same Python that drew the original.
 
 Defaults reproduce the pipeline's own figure exactly; the controls are opt-in
 changes on top of it.
 
-Each figure can be downloaded as **PNG, SVG or PDF**. SVG is real vector markup
-with editable paths, so a figure can go straight into Illustrator or Inkscape
-for a manuscript.
+### Comparisons
 
-Comparison families are shown as a gallery of thumbnails. The styling controls
-are hidden there rather than disabled — they apply to spatial network plots,
-and nothing in a violin-plot gallery reads them.
+The 2B and 4B half-violin sets — network metrics and neuronal activity by group
+and age. These are the run's bulk: on a three-lag run the 4B set alone is **274
+small multiples**. Rather than show them all, the tab selects the one you want
+by the address each figure actually has:
+
+| Facet | Choices |
+|---|---|
+| **Lag** | the run's STTC lags (hidden for 2B activity, which has none) |
+| **Level** | recording — one point per recording; node — one per node |
+| **Split** | by group (panel per group, age on x), by age (panel per age, group on x), or both stacked |
+| **Metric** | the metric list on the left, which follows the level |
+
+Each figure is drawn on demand and is **byte-identical** to the one the
+pipeline writes to `4B_GroupComparisons/…`; the folder and the viewer are two
+routes to the same picture. On the example dataset that is 0.2 s for the figure
+you asked for, against 36 s to draw all 274.
+
+"Both" shows the two splits stacked for one metric. The download buttons are
+hidden there — one button cannot mean two figures — so pick a single split to
+export.
+
+#### Colours
+
+The same panel sets the palettes, which apply to the comparison figures and the
+across-lag ones alike. The two axes are different kinds of variable and get
+different kinds of palette:
+
+| | what it is | presets |
+|---|---|---|
+| **Ages** | ordered, so a sequential colormap | `viridis` (default), `viridis_r`, `plasma`, `plasma_r`, `cividis`, `magma`, `inferno`, `grey` |
+| **Groups** | unordered, so a categorical list | `meanap` (default, MATLAB's `groupColors`), `okabe-ito`, `tab10`, `grey` |
+
+`okabe-ito` is worth knowing about: eight hues that stay distinguishable under
+all common colour-vision deficiencies. A genotype comparison printed in a paper
+will be read by someone who cannot separate the default red and green.
+
+Either can be overridden with your own colours — hex codes or names, comma
+separated, in group order or youngest age first. A short list cycles rather
+than failing, and a colour that isn't one is refused with a message naming it.
+
+```
+Custom group colours:  #e63946, #1d3557
+Custom age colours:    crimson, #abc, tab:blue
+```
+
+The defaults reproduce the pipeline's own figures exactly, so an untouched
+panel still gives you byte-identical output.
+
+The same settings exist as `Params` fields, so a full run can be given them up
+front rather than restyled afterwards:
+
+```python
+Params(
+    group_color_scheme="okabe-ito",
+    age_color_scheme="cividis",
+    group_colors=["#e63946", "#1d3557"],   # overrides the scheme
+)
+```
+
+### Across lags
+
+The two sets whose subject is the lag itself, and which therefore answer a
+different question from anything sliced at one lag:
+
+- **Graph metrics by lag** — one figure per recording-level metric, each
+  metric's mean ± SEM against STTC lag, one line per DIV;
+- **Node cartography by lag** — the six role proportions against DIV, one
+  figure per lag.
+
+This tab is absent on a single-lag run: a curve through one point says nothing.
+
+### Galleries
+
+A few CAT-NAP sets — activity by cell type, cell-type subnetworks — have no
+per-figure address, so they stay galleries of thumbnails, listed under the
+Comparisons tab and clearly separated from the faceted sets. The styling
+controls are hidden outside the Recordings tab rather than disabled: they apply
+to spatial network plots, and no violin or line plot reads them.
 
 ```{note}
-The gallery renders a whole family at once (the plotting routines emit a folder
-per call and can't be asked for a single figure), so the first view of the
-network family takes a few seconds; it is then cached and instant. Thumbnails
-render at 96 dpi; downloads use the authored resolution.
+A gallery renders its whole family at once (those plotting routines emit a
+folder per call and can't be asked for a single figure), so the first view takes
+a few seconds; it is then cached and instant. Thumbnails render at 96 dpi;
+downloads use the authored resolution.
 ```
 
 The viewer binds to `127.0.0.1` by default. A bundle is unpublished data and

--- a/docs/python/gui-guide.md
+++ b/docs/python/gui-guide.md
@@ -5,7 +5,9 @@ interface: one tab per section of the pipeline. Parameters round-trip to and
 from a `Params` dataclass (`meanap.params.Params`, see the
 [API reference](api/index.rst)) via each panel's `load()`/`save()` methods, and
 can be saved/reloaded as JSON from the toolbar (**New**, **Open params…**,
-**Save params…**).
+**Save params…**). The toolbar also has **Open bundle…**, which opens a
+`.meanap` run bundle in the viewer without running anything — see
+[Opening a bundle](#opening-a-bundle).
 
 ```{admonition} In a hurry?
 :class: tip
@@ -194,12 +196,42 @@ Run controls and step selection.
 | **Optional steps** | Extra steps to run alongside the core 4, e.g. `generateCSV`. |
 | **Verbose level** | `Normal`, `Verbose`, or `Debug` logging detail in the status log. |
 | **Time each step** | Records per-step wall-clock time to `step_durations.json` in the output folder. |
+| **Fixed random seed** | Makes the stochastic steps (3 and 4) reproducible. Off — the default, matching MATLAB — gives a fresh seed per run. |
+| **Express mode** | Skips every figure that can be redrawn later and writes one small `.meanap` bundle instead. The numbers are identical either way; see [Express mode and run bundles](express-mode.md). |
 
 The four buttons under **Run**:
 
 - **🧪 Test pipeline** — downloads the bundled example dataset and runs the
-  full pipeline against it (see [Quickstart](quickstart.md)).
+  full pipeline against it (see [Quickstart](quickstart.md)). It works with
+  **Express mode** ticked, and bundles the example run like any other.
 - **▶ Run pipeline** — runs against whatever's configured in Paths/Recording/etc.
 - **■ Stop** — cancels a running pipeline at the next step boundary.
-- **🌐 View report** — (re)generates `report.html` for the current output
-  folder and opens it — see [Output report](output-report.md).
+- **🌐 View report** — opens the last run's results in your browser, picking the
+  right artifact for the run:
+  - a **normal run** → (re)generates `report.html` in the output folder — see
+    [Output report](output-report.md);
+  - an **express run** → opens its `.meanap` bundle in the viewer, which draws
+    any figure on demand in PNG or editable SVG.
+
+  With no run in this session it falls back to the output folder the Paths tab
+  describes, including the dated default name (`OutputData<ddMonyyyy>`) used
+  when **Output folder name** is blank.
+
+### Opening a bundle
+
+A `.meanap` bundle does not need a run, or even the data it came from — it is a
+file people email each other. Two ways to open one:
+
+- **Open bundle…** in the toolbar;
+- **drag the `.meanap` file onto the window**, anywhere.
+
+Either starts the viewer and opens a browser on it. Each bundle gets its own
+viewer, all of them shut down when MEA-NAP closes, and opening the same bundle
+twice reuses the page already serving it.
+
+```{note}
+The bundle is written **beside** the output folder, not inside it —
+`OutputData07Aug2026/` and `OutputData07Aug2026.meanap` sit side by side. The
+status log repeats the full path in a framed block at the end of an express
+run, after the timing lines.
+```

--- a/docs/python/output-report.md
+++ b/docs/python/output-report.md
@@ -4,6 +4,13 @@ After a pipeline run (or against any existing MEA-NAP output folder), the
 **🌐 View report** button on the Pipeline tab generates `report.html` at the
 root of that output folder and opens it in your browser.
 
+```{note}
+If the run used {doc}`express-mode`, that button opens the run's `.meanap`
+bundle in the interactive viewer instead — an express run writes almost no
+figures, so a report built from that folder would show a nearly empty page. See
+[Related: the interactive viewer](#related-the-interactive-viewer) below.
+```
+
 ```python
 # You can also generate it directly, without the GUI:
 from meanap.pipeline.report import generate_report
@@ -56,3 +63,8 @@ walking them through the tree by hand.
 instead, which redraws them on demand and can export SVG. The two are
 complementary: `report.html` needs nothing installed, the viewer needs Python
 running but can restyle and re-export.
+
+The GUI picks between them for you: **🌐 View report** opens the viewer for an
+express run and builds `report.html` for a full one. You can also open any
+bundle directly with **Open bundle…** in the toolbar, or by dragging the
+`.meanap` file onto the window.

--- a/python/test_bundle_render.py
+++ b/python/test_bundle_render.py
@@ -95,8 +95,13 @@ def _params(out_dir: Path, **kw) -> Params:
     return p
 
 
-def _seed_prior(tmp: Path, name: str = "Prior") -> Path:
-    """A prior run holding just the step-2 state, ready to resume from."""
+def _seed_prior(tmp: Path, name: str = "Prior", lags: tuple[int, ...] = (LAG,)) -> Path:
+    """A prior run holding just the step-2 state, ready to resume from.
+
+    ``lags`` seeds one adjacency per STTC lag. More than one is what the
+    across-lag figures need — a curve through a single point says nothing, so
+    those sets aren't offered on a one-lag run.
+    """
     from meanap.pipeline.output_folders import create_output_folders
 
     from meanap.catnap.subnetwork import CellTypeGroups
@@ -110,7 +115,8 @@ def _seed_prior(tmp: Path, name: str = "Prior") -> Path:
     markers = np.eye(N_UNITS, 2)
     for i, rec in enumerate(_recordings()):
         state = RecordingState(
-            adjMs={f"adjM{LAG}mslag": _adjacency(20 + i)},
+            adjMs={f"adjM{lag}mslag": _adjacency(20 + i + 7 * j)
+                   for j, lag in enumerate(lags)},
             coords=np.random.default_rng(i).random((N_UNITS, 2)) * 8.0,
             channels=np.arange(1, N_UNITS + 1),
             spike_counts=np.full(N_UNITS, 100.0),
@@ -131,12 +137,13 @@ def _seed_prior(tmp: Path, name: str = "Prior") -> Path:
     return prior
 
 
-def _run(tmp: Path, name: str, *, express: bool) -> Path:
+def _run(tmp: Path, name: str, *, express: bool,
+         lags: tuple[int, ...] = (LAG,)) -> Path:
     """Resume a run from the seeded prior, in express or full mode."""
     from meanap.pipeline.runner import run_pipeline
     import pandas as pd
 
-    prior = _seed_prior(tmp, f"{name}Prior")
+    prior = _seed_prior(tmp, f"{name}Prior", lags)
     sheet = tmp / f"{name}.csv"
     pd.DataFrame([{"Recording filename": r.filename, "DIV": r.div, "Group": r.group}
                   for r in _recordings()]).to_csv(sheet, index=False)
@@ -144,7 +151,7 @@ def _run(tmp: Path, name: str, *, express: bool) -> Path:
     p = _params(tmp, output_data_folder_name=name, express_mode=express,
                 prior_analysis_path=str(prior),
                 spreadsheet_file_name=str(sheet), spreadsheet_range="2:100",
-                raw_data=str(tmp / "no-raw"))
+                raw_data=str(tmp / "no-raw"), func_con_lag_val=list(lags))
     return run_pipeline(p, log=lambda m: None)
 
 
@@ -683,6 +690,376 @@ def _gallery_cache_checks() -> list[Check]:
     return checks
 
 
+def _palette_checks() -> list[Check]:
+    """Age and group colours: presets, custom lists, and an unchanged default.
+
+    The default is the load-bearing one. Every pixel-parity guarantee in this
+    file rests on an unstyled render matching the pipeline's figure, so a
+    ``ColorScheme()`` that shifted any colour would quietly break all of them.
+    """
+    import matplotlib.cm as cm
+
+    from meanap.params import Params
+    from meanap.pipeline.palette import (
+        AGE_SCHEMES, GROUP_SCHEMES, ColorScheme, parse_colors,
+    )
+    from meanap.pipeline.plotting_step4 import _div_colors, _group_colors
+
+    checks: list[Check] = []
+    historical_groups = [
+        (0.996, 0.670, 0.318), (0.780, 0.114, 0.114), (0.459, 0.000, 0.376),
+        (0.027, 0.306, 0.659), (0.5, 0.5, 0.5),
+    ]
+    age_ok = all(
+        _div_colors(n) == [tuple(cm.viridis(x)[:3]) for x in np.linspace(1, 0, n)]
+        for n in (1, 2, 3, 5, 9)
+    )
+    checks.append(("the default age palette is still flipud(viridis)", age_ok, ""))
+    group_ok = all(
+        _group_colors(n) == [historical_groups[i % 5] for i in range(n)]
+        for n in (1, 3, 5, 8)
+    )
+    checks.append(("the default group palette is still MATLAB's groupColors",
+                   group_ok, ""))
+    checks.append(("…and Params defaults resolve to that same scheme",
+                   ColorScheme.from_params(Params()) == ColorScheme(), ""))
+
+    checks.append(("every age scheme yields the requested number of colours",
+                   all(len(ColorScheme(age_scheme=s).ages(4)) == 4
+                       for s in AGE_SCHEMES), ""))
+    checks.append(("every group scheme does too",
+                   all(len(ColorScheme(group_scheme=s).groups(4)) == 4
+                       for s in GROUP_SCHEMES), ""))
+    checks.append(("a preset actually changes the colours",
+                   ColorScheme(group_scheme="okabe-ito").groups(3)
+                   != ColorScheme().groups(3), ""))
+    checks.append(("age schemes are ordered, so first ≠ last",
+                   ColorScheme(age_scheme="plasma").ages(3)[0]
+                   != ColorScheme(age_scheme="plasma").ages(3)[-1], ""))
+    # Endpoints only: a 256-entry lookup table rounds an interior sample to a
+    # different index depending on which direction it is approached from, so
+    # the middle of a reversed map is a neighbouring colour, not the same one.
+    fwd = ColorScheme(age_scheme="viridis").ages(3)
+    rev = ColorScheme(age_scheme="viridis_r").ages(3)
+    checks.append(("_r swaps which end of the colormap the youngest age gets",
+                   fwd[0] == rev[-1] and fwd[-1] == rev[0] and fwd != rev,
+                   f"{fwd[0]} vs {rev[-1]}"))
+
+    checks.append(("custom colours win over the scheme",
+                   ColorScheme(group_scheme="tab10",
+                               group_colors=["#ff0000"]).groups(1)
+                   == [(1.0, 0.0, 0.0)], ""))
+    checks.append(("…and cycle when there are fewer than there are groups",
+                   ColorScheme(group_colors=["#ff0000", "#0000ff"]).groups(3)
+                   == [(1.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0)], ""))
+    checks.append(("a comma-separated string is accepted, as a text box gives it",
+                   ColorScheme(age_colors="#ff0000, blue").ages(2)
+                   == [(1.0, 0.0, 0.0), (0.0, 0.0, 1.0)], ""))
+    checks.append(("names, hex-3 and hex-6 all parse",
+                   len(parse_colors(["crimson", "#abc", "#1f77b4"])) == 3, ""))
+
+    for bad, expect, name in [
+        (dict(group_scheme="rainbow"), "Unknown group colour scheme", "group scheme"),
+        (dict(age_scheme="jet"), "Unknown age colour scheme", "age scheme"),
+        (dict(group_colors=["#zzzzzz"]), "is not a colour", "colour code"),
+    ]:
+        try:
+            ColorScheme(**bad)
+            message = ""
+        except ValueError as e:
+            message = str(e)
+        checks.append((f"a bad {name} is refused at construction",
+                       expect in message, message[:60]))
+    return checks
+
+
+def _palette_render_checks() -> list[Check]:
+    """A scheme reaches the drawn figure, and the default leaves it untouched."""
+    from meanap.pipeline.palette import ColorScheme
+    from meanap.pipeline.render import load_context, render_comparison_figure
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        express = _run(tmp, "Express", express=True)
+
+        with open_bundle(express.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+
+            def draw(name, **overrides):
+                return render_comparison_figure(
+                    ctx, "network", "recording", "age", "Dens", tmp / name,
+                    lag=LAG, overrides=overrides or None)
+
+            plain = draw("plain")
+            same = draw("same", group_color_scheme="meanap")
+            okabe = draw("okabe", group_color_scheme="okabe-ito")
+            custom = draw("custom", group_colors=["#ff0000", "#00ff00"])
+            ages = draw("ages", age_color_scheme="plasma")
+
+            checks.append(("passing the default scheme changes nothing",
+                           _digest(plain) == _digest(same), ""))
+            checks.append(("a group preset changes the figure",
+                           _digest(plain) != _digest(okabe), ""))
+            checks.append(("custom group colours change the figure",
+                           _digest(plain) != _digest(custom), ""))
+            checks.append(("…and differ from the preset too",
+                           _digest(custom) != _digest(okabe), ""))
+            # This split colours by group, so the age scheme must not touch it —
+            # a control that redraws when it has no business to would break the
+            # render cache's promise that one address is one figure.
+            checks.append(("the age scheme leaves a by-age split alone",
+                           _digest(plain) == _digest(ages), ""))
+
+            by_group = render_comparison_figure(
+                ctx, "network", "recording", "group", "Dens", tmp / "bg", lag=LAG)
+            by_group_plasma = render_comparison_figure(
+                ctx, "network", "recording", "group", "Dens", tmp / "bgp", lag=LAG,
+                overrides={"age_color_scheme": "plasma"})
+            checks.append(("…but does change a by-group split, where ages are the x",
+                           _digest(by_group) != _digest(by_group_plasma), ""))
+
+            try:
+                draw("bad", group_colors=["#zzzzzz"])
+                message = ""
+            except ValueError as e:
+                message = str(e)
+            checks.append(("a bad colour is refused before drawing",
+                           "is not a colour" in message, message[:50]))
+
+            # The scheme must survive into the folder-at-a-time path as well,
+            # or the gallery families would disagree with the faceted ones.
+            from meanap.pipeline.render import render_group_family
+            fam_plain = render_group_family(ctx, "network", tmp / "famA")
+            fam_okabe = render_group_family(
+                ctx, "network", tmp / "famB",
+                overrides={"group_color_scheme": "okabe-ito"})
+            rel = Path("4_NetworkActivity/4B_GroupComparisons/4_RecordingsByAge"
+                       f"/HalfViolinPlots/Lag{LAG}ms/Dens_byDIV.png")
+            checks.append(("the family renderer honours the scheme too",
+                           bool(fam_plain) and bool(fam_okabe)
+                           and _digest(tmp / "famA" / rel)
+                           != _digest(tmp / "famB" / rel), ""))
+    return checks
+
+
+def _one_comparison_checks() -> list[Check]:
+    """One 4B figure at a time must equal the same figure drawn as a folder.
+
+    The viewer's comparison tab is only worth having if selecting a metric
+    shows the figure the pipeline would have written — not something close to
+    it. Both paths call ``plot_half_violin_by_x`` through the same frames, and
+    this holds them to that: every address rendered alone, byte-compared
+    against the family render of the same run.
+    """
+    from meanap.pipeline.render import (
+        comparison_lags, comparison_metrics, load_context,
+        render_comparison_figure, render_group_family,
+    )
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        express = _run(tmp, "Express", express=True)
+
+        with open_bundle(express.with_suffix(BUNDLE_SUFFIX)) as b:
+            ctx = load_context(b)
+
+            family_out = tmp / "family"
+            written = {p.relative_to(family_out): p
+                       for p in render_group_family(ctx, "network", family_out)}
+            checks.append(("the family render produced the reference figures",
+                           len(written) > 0, f"{len(written)}"))
+
+            checks.append(("the lags are discoverable", comparison_lags(ctx) == [LAG],
+                           f"{comparison_lags(ctx)}"))
+            checks.append(("a lagless family reports no lags",
+                           comparison_lags(ctx, "ephys_activity") == [], ""))
+
+            rec_metrics = comparison_metrics("network", "recording")
+            node_metrics = comparison_metrics("network", "node")
+            checks.append(("both levels advertise metrics",
+                           len(rec_metrics) > 10 and len(node_metrics) >= 5,
+                           f"{len(rec_metrics)}/{len(node_metrics)}"))
+
+            one_out = tmp / "single"
+            compared = identical = missing = 0
+            mismatched: list[str] = []
+            for level, metrics in (("recording", rec_metrics), ("node", node_metrics)):
+                for split in ("group", "age"):
+                    for metric in metrics:
+                        path = render_comparison_figure(
+                            ctx, "network", level, split, metric, one_out, lag=LAG)
+                        rel = path.relative_to(one_out)
+                        reference = written.get(rel)
+                        if reference is None:
+                            missing += 1
+                            mismatched.append(f"no family figure at {rel}")
+                            continue
+                        compared += 1
+                        if _digest(reference) == _digest(path):
+                            identical += 1
+                        else:
+                            mismatched.append(rel.as_posix())
+
+            checks.append(("every address lands on a family figure's path",
+                           missing == 0, f"{missing} unmatched: {mismatched[:2]}"))
+            checks.append((f"single renders are pixel-identical ({identical}/{compared})",
+                           compared > 0 and identical == compared,
+                           f"differ: {mismatched[:3]}"))
+            checks.append(("…and that covered both levels and both splits",
+                           compared == 2 * (len(rec_metrics) + len(node_metrics)),
+                           f"{compared}"))
+
+            svg = render_comparison_figure(
+                ctx, "network", "recording", "group", "Dens", tmp / "svg",
+                lag=LAG, fmt="svg")
+            checks.append(("a comparison figure renders as svg",
+                           svg.suffix == ".svg" and svg.stat().st_size > 0, ""))
+
+            # Every rejection a viewer can provoke, said in a way that names the
+            # alternative — these are user-visible 400s, not internal asserts.
+            def _refused(**kw) -> str:
+                args = {"family": "network", "level": "recording", "split": "group",
+                        "metric": "Dens", "lag": LAG, **kw}
+                try:
+                    render_comparison_figure(
+                        ctx, args["family"], args["level"], args["split"],
+                        args["metric"], tmp / "bad", lag=args["lag"])
+                except ValueError as e:
+                    return str(e)
+                return ""
+
+            checks.append(("an unknown family is refused",
+                           "Unknown comparison family" in _refused(family="nope"), ""))
+            checks.append(("an unknown level is refused",
+                           "Unknown level" in _refused(level="cell"), ""))
+            checks.append(("an unknown split is refused",
+                           "Unknown split" in _refused(split="sideways"), ""))
+            checks.append(("an unknown metric is refused, naming the level",
+                           "recording-level metric" in _refused(metric="NotAMetric"), ""))
+            checks.append(("a missing lag is refused, listing the ones that exist",
+                           str(LAG) in _refused(lag=None), _refused(lag=None)[:60]))
+            checks.append(("a lag the run doesn't have is refused",
+                           "this run has" in _refused(lag=999), ""))
+            checks.append(("passing a lag to a lagless family is refused",
+                           "do not depend on the STTC lag"
+                           in _refused(family="ephys_activity", metric="FRmean"), ""))
+    return checks
+
+
+def _comparison_frames_checks() -> list[Check]:
+    """The extracted frame builders must feed both plotting paths identically.
+
+    ``plot_step2_group_comparisons`` and ``render_comparison_figure`` now share
+    ``ephys_comparison_frames``; this is the 2B half of the parity check, built
+    without a bundle because the CAT-NAP fixture has no electrophysiology
+    stats.
+    """
+    import json as _json
+
+    from meanap.params import Params
+    from meanap.pipeline.plotting_step2 import (
+        EPHYS_NODE_METRICS, EPHYS_REC_METRICS, ephys_comparison_frames,
+        plot_step2_group_comparisons,
+    )
+    from meanap.pipeline.plotting_step4 import netmet_comparison_frames
+    from meanap.pipeline.render import RenderContext, render_comparison_figure
+
+    checks: list[Check] = []
+    recs = _recordings()
+    n = 8
+    # Recording-level entries must be scalars and node-level ones per-channel
+    # arrays, as step 2 writes them — the plotter coerces a metric column with
+    # float(), so a list parked in a recording-level column is a hard error.
+    stats = {
+        rec.filename: {
+            "FR": list(np.linspace(1.0, 3.0, n) + i),
+            "FRactive": list(np.linspace(1.0, 3.0, n) + i),
+            "channelBurstRate": list(np.linspace(0.5, 2.0, n) + i),
+            "FRmean": 2.0 + i, "FRmedian": 1.9 + i, "numActiveElec": n,
+            "channelAveBurstRate": 1.2 + i,
+        }
+        for i, rec in enumerate(recs)
+    }
+
+    df_rec, df_node = ephys_comparison_frames(recs, stats)
+    checks.append(("2B frames have one row per recording", len(df_rec) == len(recs),
+                   f"{len(df_rec)}"))
+    checks.append(("…and one node row per channel per recording",
+                   len(df_node) == n * len(recs), f"{len(df_node)}"))
+    checks.append(("…carrying the grouping columns",
+                   {"FileName", "Grp", "DIV"} <= set(df_rec.columns), ""))
+    checks.append(("2B frames carry no Lag column",
+                   "Lag" not in df_rec.columns, ""))
+
+    ordered_rec, _ = ephys_comparison_frames(recs, stats, ["KO", "WT"])
+    checks.append(("a custom group order becomes an ordered categorical",
+                   list(ordered_rec["Grp"].cat.categories) == ["KO", "WT"], ""))
+
+    # The node frame is empty when no recording has per-channel data. The
+    # ordering step used to raise KeyError on that frame rather than skip it.
+    flat = {rec.filename: {"FRmean": 1.0} for rec in recs}
+    empty_rec, empty_node = ephys_comparison_frames(recs, flat, ["KO", "WT"])
+    checks.append(("an empty node frame doesn't break the group ordering",
+                   not empty_rec.empty and empty_node.empty, ""))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        # The step-2 plotter appends "2B_GroupComparisons" to whatever it is
+        # given, and render_group_family hands it <root>/2_NeuronalActivity —
+        # so mirror that, or the two paths can't be compared.
+        folder_out = tmp / "folder"
+        plot_step2_group_comparisons(recs, stats, folder_out / "2_NeuronalActivity")
+        reference = {p.relative_to(folder_out): p for p in folder_out.rglob("*.png")}
+        checks.append(("2B folder render produced figures", len(reference) > 0,
+                       f"{len(reference)}"))
+
+        root = tmp / "root"
+        (root / "2_NeuronalActivity").mkdir(parents=True)
+        with open(root / "2_NeuronalActivity" / "ephys_results.json", "w") as fh:
+            _json.dump(stats, fh)
+        ctx = RenderContext(
+            params=Params(), recordings={r.filename: r for r in recs},
+            results={}, batch_bounds={}, root=root, mode="ephys")
+
+        one_out = tmp / "single"
+        compared = identical = 0
+        mismatched: list[str] = []
+        for level, metrics in (("recording", EPHYS_REC_METRICS),
+                               ("node", EPHYS_NODE_METRICS)):
+            for split in ("group", "age"):
+                for metric in metrics:
+                    path = render_comparison_figure(
+                        ctx, "ephys_activity", level, split, metric, one_out)
+                    ref = reference.get(path.relative_to(one_out))
+                    if ref is None:
+                        mismatched.append(f"no folder figure at {path.relative_to(one_out)}")
+                        continue
+                    compared += 1
+                    if _digest(ref) == _digest(path):
+                        identical += 1
+                    else:
+                        mismatched.append(path.name)
+
+        checks.append((f"2B single renders are pixel-identical ({identical}/{compared})",
+                       compared > 0 and identical == compared and not mismatched,
+                       f"{mismatched[:3]}"))
+
+    # 4B frames: the same shape, plus the lag column the network family needs.
+    results = {
+        rec.filename: {f"{LAG}mslag": {"Dens": 0.3 + i, "ND": list(np.arange(n) + i)}}
+        for i, rec in enumerate(recs)
+    }
+    net_rec, net_node = netmet_comparison_frames(recs, results)
+    checks.append(("4B frames carry the Lag column",
+                   list(net_rec["Lag"].unique()) == [f"{LAG}mslag"],
+                   f"{list(net_rec['Lag'].unique())}"))
+    checks.append(("…and one node row per channel per recording per lag",
+                   len(net_node) == n * len(recs), f"{len(net_node)}"))
+    return checks
+
+
 def _ephys_render_checks() -> list[Check]:
     """The renderer must read electrophysiology output too, not just CAT-NAP.
 
@@ -915,6 +1292,10 @@ def main() -> int:
         ("Section D3 — 2B / 4B batch comparisons:", _group_family_checks),
         ("Section D3b — cell types without the spreadsheet:",
          _cell_type_self_contained_checks),
+        ("Section D3c — one 4B comparison figure at a time:", _one_comparison_checks),
+        ("Section D3e — age and group palettes:", _palette_checks),
+        ("Section D3f — palettes reaching the figure:", _palette_render_checks),
+        ("Section D3d — the shared comparison frames (2B):", _comparison_frames_checks),
         ("Section D4 — thumbnail resolution and caching:", _gallery_cache_checks),
         ("Section D5 — electrophysiology output:", _ephys_render_checks),
         ("Section D6 — manifest honesty:", _manifest_honesty_checks),

--- a/python/test_gui_bundle_viewer.py
+++ b/python/test_gui_bundle_viewer.py
@@ -1,0 +1,332 @@
+"""Test the GUI's routes into a ``.meanap`` bundle: View report, and drag-drop.
+
+Run from the repo root::
+
+    uv run python python/test_gui_bundle_viewer.py
+
+Express mode leaves almost no figures on disk, so the old View report — which
+built a static page from whatever PNGs it found — showed an express run as a
+near-empty page, indistinguishable from a run that failed. The button now picks
+its destination from what the run actually produced, and a bundle can be opened
+without any run at all, from the toolbar or by dropping the file on the window.
+
+Runs against real bundles from a small synthetic pipeline run (shared with
+``test_bundle_render``) and starts the real viewer server, offscreen
+(``QT_QPA_PLATFORM=offscreen``) — no display, no example dataset, no MATLAB.
+
+Sections:
+
+  A. View report routing — bundle to the viewer, full run to the HTML report;
+  B. opening bundles — dedupe, teardown, and unreadable files;
+  C. drag and drop — what the window claims and what it refuses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "python"))
+
+from PyQt6.QtCore import QMimeData, QUrl  # noqa: E402
+from PyQt6.QtGui import QAction  # noqa: E402
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from test_bundle_render import BUNDLE_SUFFIX, _run  # noqa: E402
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else (f"  [{detail}]" if detail else "")
+        print(f"  {flag} {name}{suffix}")
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+class _FakeDrag:
+    """Enough of a QDragEnterEvent for the window's handlers.
+
+    A real one cannot be constructed without a live drag session, and the
+    behaviour under test — which files are claimed — is pure inspection of the
+    mime data plus an accept/ignore decision.
+    """
+
+    def __init__(self, paths: list[str], *, local: bool = True) -> None:
+        self._mime = QMimeData()
+        self._mime.setUrls([
+            QUrl.fromLocalFile(p) if local else QUrl(p) for p in paths
+        ])
+        self.accepted = False
+        self.ignored = False
+
+    def mimeData(self) -> QMimeData:  # noqa: N802 - Qt naming
+        return self._mime
+
+    def acceptProposedAction(self) -> None:  # noqa: N802 - Qt naming
+        self.accepted = True
+
+    def ignore(self) -> None:
+        self.ignored = True
+
+
+class _EmptyDrag(_FakeDrag):
+    """A drag carrying no URLs at all — text, say."""
+
+    def __init__(self) -> None:
+        super().__init__([])
+        self._mime = QMimeData()
+        self._mime.setText("some text")
+
+
+def _opened_urls(window, monkey: list[str]):
+    """Point the window's browser call at a list instead of a real browser."""
+    import meanap.gui.main_window as mw
+
+    mw.webbrowser = type("_Stub", (), {"open": staticmethod(monkey.append)})()
+    return mw
+
+
+# ── Section A: View report routing ────────────────────────────────────────────
+
+
+def _routing_checks(app: QApplication, express_root: Path, full_root: Path) -> list[Check]:
+    from meanap.gui.main_window import MainWindow
+    from meanap.params import Params
+
+    checks: list[Check] = []
+    opened: list[str] = []
+    window = MainWindow()
+    _opened_urls(window, opened)
+
+    bundle = express_root.with_suffix(BUNDLE_SUFFIX)
+
+    # An express run: the bundle is the only complete record of it, so that is
+    # where View report must go.
+    window._params = Params(express_mode=True)
+    window._on_pipeline_finished(express_root)
+    window._on_view_report()
+    checks.append(("express run: View report opens a viewer URL",
+                   len(opened) == 1 and opened[0].startswith("http://"),
+                   str(opened)))
+    checks.append(("…and it is the viewer, not a file:// report",
+                   not opened[0].startswith("file:"), str(opened[:1])))
+    checks.append(("…serving something a browser can load",
+                   urllib.request.urlopen(opened[0]).status == 200
+                   if opened else False, ""))
+    checks.append(("…and no report.html was written into the folder",
+                   not (express_root / "report.html").exists(), ""))
+
+    # Clicking again must not start a second server for the same bundle.
+    before = len(window._viewers)
+    window._on_view_report()
+    checks.append(("clicking twice reuses the running viewer",
+                   len(window._viewers) == before and opened[1] == opened[0],
+                   f"{before} → {len(window._viewers)}"))
+
+    # A full run has the figures on disk; the static report is still right.
+    window2 = MainWindow()
+    opened2: list[str] = []
+    _opened_urls(window2, opened2)
+    window2._params = Params(express_mode=False)
+    window2._on_pipeline_finished(full_root)
+    window2._on_view_report()
+    checks.append(("full run: View report still builds the HTML report",
+                   len(opened2) == 1 and opened2[0].startswith("file:"), str(opened2)))
+    checks.append(("…and that report exists on disk",
+                   (full_root / "report.html").is_file(), ""))
+    checks.append(("…without starting a viewer",
+                   len(window2._viewers) == 0, str(len(window2._viewers))))
+
+    # A bundle sitting beside the folder is found even in a session that never
+    # ran anything — the case where someone reopens yesterday's results.
+    window3 = MainWindow()
+    opened3: list[str] = []
+    _opened_urls(window3, opened3)
+    window3._paths_panel.output_data_folder.set_value(str(express_root.parent))
+    window3._paths_panel.output_data_folder_name.setText(express_root.name)
+    window3._on_view_report()
+    checks.append(("a bundle is found from the paths alone, with no run",
+                   len(opened3) == 1 and opened3[0].startswith("http://"), str(opened3)))
+
+    for w in (window, window2, window3):
+        w._viewers.close_all()
+    return checks
+
+
+# ── Section B: opening bundles ────────────────────────────────────────────────
+
+
+def _open_checks(app: QApplication, express_root: Path) -> list[Check]:
+    from meanap.gui.main_window import MainWindow
+
+    checks: list[Check] = []
+    bundle = express_root.with_suffix(BUNDLE_SUFFIX)
+    opened: list[str] = []
+    window = MainWindow()
+    _opened_urls(window, opened)
+
+    ok = window._open_in_viewer(bundle)
+    checks.append(("opening a bundle succeeds", ok, ""))
+    url = window._viewers.url_for(bundle)
+    checks.append(("the session is addressable by path", url == opened[-1], str(url)))
+    checks.append(("the log says where the viewer is",
+                   url in window._pipeline_panel.log.toPlainText(), ""))
+
+    checks.append(("the same bundle by a different path is one session",
+                   window._viewers.open(Path(str(bundle))) == url
+                   and len(window._viewers) == 1, str(len(window._viewers))))
+
+    # Closing the window must hand the port and the extraction directory back.
+    port = int(url.rsplit(":", 1)[1].rstrip("/"))
+    window._viewers.close_all()
+    checks.append(("close_all shuts the servers down",
+                   len(window._viewers) == 0, ""))
+    checks.append(("…and frees the port", not _port_answering(port), str(port)))
+    checks.append(("close_all is safe to call twice",
+                   window._viewers.close_all() is None, ""))
+
+    # A file that is not a bundle must be refused with a message, not a stack
+    # trace — this is the "someone sent me the wrong file" case.
+    with tempfile.TemporaryDirectory() as tmp:
+        junk = Path(tmp) / "notes.meanap"
+        junk.write_text("this is not a zip")
+        errors: list[str] = []
+        _stub_critical(errors)
+        refused = window._open_in_viewer(junk)
+        checks.append(("a non-bundle file is refused", refused is False, ""))
+        checks.append(("…with an explanation naming the file",
+                       bool(errors) and "notes.meanap" in errors[0], str(errors)))
+        checks.append(("…and leaves no session behind",
+                       len(window._viewers) == 0, str(len(window._viewers))))
+    return checks
+
+
+def _stub_critical(sink: list[str]) -> None:
+    """Collect QMessageBox.critical text instead of blocking on a dialog."""
+    from PyQt6.QtWidgets import QMessageBox
+
+    QMessageBox.critical = staticmethod(  # type: ignore[method-assign]
+        lambda parent, title, text, *a, **k: sink.append(text)
+    )
+
+
+def _port_answering(port: int) -> bool:
+    import socket
+
+    with socket.socket() as s:
+        s.settimeout(0.3)
+        return s.connect_ex(("127.0.0.1", port)) == 0
+
+
+# ── Section C: drag and drop ──────────────────────────────────────────────────
+
+
+def _drop_checks(app: QApplication, express_root: Path) -> list[Check]:
+    from meanap.gui.main_window import MainWindow
+
+    checks: list[Check] = []
+    bundle = express_root.with_suffix(BUNDLE_SUFFIX)
+    window = MainWindow()
+    opened: list[str] = []
+    _opened_urls(window, opened)
+
+    checks.append(("the window accepts drops at all", window.acceptDrops(), ""))
+    checks.append(("the status log does not swallow them",
+                   not window._pipeline_panel.log.acceptDrops(), ""))
+
+    ev = _FakeDrag([str(bundle)])
+    window.dragEnterEvent(ev)
+    checks.append(("a dragged bundle is claimed", ev.accepted and not ev.ignored, ""))
+
+    ev = _FakeDrag([str(express_root / "params.json")])
+    window.dragEnterEvent(ev)
+    checks.append(("a dragged .json is not claimed", ev.ignored and not ev.accepted, ""))
+
+    ev = _FakeDrag([str(express_root)])
+    window.dragEnterEvent(ev)
+    checks.append(("a dragged folder is not claimed", ev.ignored and not ev.accepted, ""))
+
+    ev = _FakeDrag(["http://example.com/run.meanap"], local=False)
+    window.dragEnterEvent(ev)
+    checks.append(("a remote URL is not claimed", ev.ignored and not ev.accepted, ""))
+
+    ev = _EmptyDrag()
+    window.dragEnterEvent(ev)
+    checks.append(("dragged text is not claimed", ev.ignored and not ev.accepted, ""))
+
+    missing = express_root.parent / "gone.meanap"
+    ev = _FakeDrag([str(missing)])
+    window.dragEnterEvent(ev)
+    checks.append(("a .meanap that isn't there is not claimed",
+                   ev.ignored and not ev.accepted, ""))
+
+    drop = _FakeDrag([str(bundle)])
+    window.dropEvent(drop)
+    checks.append(("dropping it opens the viewer",
+                   drop.accepted and len(opened) == 1
+                   and opened[0].startswith("http://"), str(opened)))
+
+    # Two bundles dropped together get a viewer each — the ports differ, so the
+    # fallback off the preferred port has to work.
+    with tempfile.TemporaryDirectory() as tmp:
+        second = Path(tmp) / "Second.meanap"
+        second.write_bytes(bundle.read_bytes())
+        window.dropEvent(_FakeDrag([str(second)]))
+        urls = set(opened)
+        checks.append(("a second bundle gets its own viewer",
+                       len(window._viewers) == 2 and len(urls) == 2, str(sorted(urls))))
+        window._viewers.close_all()
+
+    # The toolbar route exists and is discoverable.
+    actions = {a.text(): a for a in window.findChildren(QAction)}
+    bundle_action = actions.get("Open bundle…")
+    checks.append(("the toolbar offers 'Open bundle…'", bundle_action is not None,
+                   str(sorted(actions))))
+    checks.append(("…and says drag-and-drop works too",
+                   bundle_action is not None and "drag" in bundle_action.toolTip().lower(),
+                   bundle_action.toolTip() if bundle_action else ""))
+    return checks
+
+
+def main() -> int:
+    app = QApplication.instance() or QApplication([])
+    print("=" * 70)
+    print("GUI: opening a .meanap bundle")
+    print("=" * 70)
+
+    total_pass = total = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        express_root = _run(tmp, "Express", express=True)
+        full_root = _run(tmp, "Full", express=False)
+
+        for title, build in [
+            ("A — View report routing:", lambda a: _routing_checks(a, express_root, full_root)),
+            ("B — opening bundles:", lambda a: _open_checks(a, express_root)),
+            ("C — drag and drop:", lambda a: _drop_checks(a, express_root)),
+        ]:
+            p, n = _report(title, build(app))
+            total_pass += p
+            total += n
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_gui_tooltips.py
+++ b/python/test_gui_tooltips.py
@@ -227,6 +227,62 @@ def _express_toggle_checks(app: QApplication) -> list[Check]:
     return checks
 
 
+def _bundle_notice_checks(app: QApplication) -> list[Check]:
+    """The express bundle must be findable after the run that wrote it.
+
+    It lands *beside* the output folder, not inside it, and the runner logs it
+    before the timing lines — so without a closing notice the one file the run
+    exists to produce scrolls out of sight in the place nobody looks.
+    """
+    import tempfile
+
+    from meanap.gui.main_window import MainWindow
+    from meanap.params import Params
+    from meanap.pipeline.bundle import BUNDLE_SUFFIX
+
+    checks: list[Check] = []
+    window = MainWindow()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_root = Path(tmp) / "OutputData01Jan2026"
+        out_root.mkdir()
+        bundle = out_root.with_suffix(BUNDLE_SUFFIX)
+        bundle.write_bytes(b"x" * 2_200_000)
+
+        window._params = Params(express_mode=True)
+        window._pipeline_panel.log.clear()
+        window._on_pipeline_finished(out_root)
+        text = window._pipeline_panel.log.toPlainText()
+        checks.append(("an express run names the bundle at the end",
+                       str(bundle) in text, text[-120:]))
+        checks.append(("…says it sits beside the output folder",
+                       "beside the output folder" in text, ""))
+        checks.append(("…gives the command that opens it",
+                       "meanap-viewer" in text, ""))
+        checks.append(("…after the 'Done.' line, so it reads last",
+                       text.index(str(bundle)) > text.index("Done."), ""))
+        checks.append(("the run remembers the bundle for later",
+                       window._last_bundle == bundle, str(window._last_bundle)))
+
+        # A non-express run must stay quiet even when a bundle from an earlier
+        # express run of the same day is still sitting next to the folder.
+        window._params = Params(express_mode=False)
+        window._pipeline_panel.log.clear()
+        window._on_pipeline_finished(out_root)
+        checks.append(("a full run says nothing about bundles",
+                       "meanap-viewer" not in window._pipeline_panel.log.toPlainText(), ""))
+
+        # Express on, but packing failed (the runner only warns) — no notice.
+        bundle.unlink()
+        window._params = Params(express_mode=True)
+        window._pipeline_panel.log.clear()
+        window._on_pipeline_finished(out_root)
+        checks.append(("no notice when no bundle was written",
+                       "meanap-viewer" not in window._pipeline_panel.log.toPlainText(), ""))
+
+    return checks
+
+
 def _helper_checks(app: QApplication) -> list[Check]:
     checks: list[Check] = []
     w = QWidget()
@@ -251,7 +307,8 @@ def main() -> int:
         ("B — formatting rules:", _format_checks),
         ("C — the real window:", _window_checks),
         ("D — the express-mode toggle:", _express_toggle_checks),
-        ("E — the set_tooltip helper:", _helper_checks),
+        ("E — the end-of-run bundle notice:", _bundle_notice_checks),
+        ("F — the set_tooltip helper:", _helper_checks),
     ]:
         p, n = _report(title, build(app))
         total_pass += p

--- a/python/test_viewer_server.py
+++ b/python/test_viewer_server.py
@@ -16,6 +16,7 @@ is the real one, so that is checked byte-for-byte against a full pipeline run.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import tempfile
@@ -205,11 +206,373 @@ def _all_checks() -> list[Check]:
     return checks
 
 
+def _comparison_checks() -> list[Check]:
+    """``/api/comparison``: the facets, and one figure at a time.
+
+    The gallery route can only hand over a whole family — 274 figures on a
+    three-lag run. These are the requests the comparison tab makes instead, so
+    what matters is that the advertised facets are exactly the addresses that
+    render, and that a bad one comes back as an actionable 400 rather than a
+    traceback.
+    """
+    from meanap.viewer.server import serve
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "Full", express=False)
+        express = _run(tmp, "Express", express=True)
+        bundle = express.with_suffix(BUNDLE_SUFFIX)
+
+        httpd, service = serve(bundle, port=0, background=True)
+        base = f"http://127.0.0.1:{httpd.server_address[1]}"
+        try:
+            _, body, _ = _get(base + "/api/manifest")
+            man = json.loads(body)
+            comparisons = {c["key"]: c for c in man.get("comparisons", [])}
+            checks.append(("the manifest advertises the network comparison family",
+                           "network" in comparisons, f"{sorted(comparisons)}"))
+            net = comparisons.get("network", {})
+            checks.append(("…with this run's lags", net.get("lags") == [LAG],
+                           f"{net.get('lags')}"))
+            checks.append(("…both levels, each with its metric list",
+                           {lv["key"] for lv in net.get("levels", [])}
+                           == {"recording", "node"}
+                           and all(lv["metrics"] for lv in net["levels"]),
+                           f"{[(lv['key'], len(lv['metrics'])) for lv in net.get('levels', [])]}"))
+            checks.append(("…and both splits",
+                           [s["key"] for s in net.get("splits", [])] == ["group", "age"],
+                           f"{net.get('splits')}"))
+            checks.append(("every facet carries a label for the UI",
+                           all(lv.get("label") for lv in net["levels"])
+                           and all(s.get("label") for s in net["splits"])
+                           and all(m.get("label")
+                                   for lv in net["levels"] for m in lv["metrics"]), ""))
+
+            metric = net["levels"][0]["metrics"][0]["name"]
+            address = (f"family=network&level=recording&split=group"
+                       f"&metric={metric}&lag={LAG}")
+
+            status, body, headers = _get(f"{base}/api/comparison?{address}")
+            checks.append(("a comparison figure is served", status == 200, str(status)))
+            checks.append(("…as a png", headers.get("Content-Type") == "image/png",
+                           headers.get("Content-Type", "")))
+            checks.append(("…with actual bytes in it", len(body) > 1000, f"{len(body)}"))
+
+            # The load-bearing one: what the endpoint serves must be the figure
+            # the pipeline wrote, not merely something plausible.
+            original = (full / "4_NetworkActivity" / "4B_GroupComparisons"
+                        / "3_RecordingsByGroup" / "HalfViolinPlots" / f"Lag{LAG}ms"
+                        / f"{metric}_byGroup.png")
+            checks.append(("…identical to the figure the full run wrote",
+                           original.exists()
+                           and hashlib.sha256(body).hexdigest() == _digest(original),
+                           f"{original.name} exists={original.exists()}"))
+
+            _, svg, headers = _get(f"{base}/api/comparison?{address}&fmt=svg")
+            checks.append(("svg is vector markup",
+                           headers.get("Content-Type") == "image/svg+xml"
+                           and b"<svg" in svg[:600], headers.get("Content-Type", "")))
+
+            _, _, headers = _get(f"{base}/api/comparison?{address}&download=1")
+            checks.append(("download sets a filename",
+                           f"{metric}_byGroup.png"
+                           in headers.get("Content-Disposition", ""),
+                           headers.get("Content-Disposition", "")))
+
+            _, thumb, _ = _get(f"{base}/api/comparison?{address}&thumb=1")
+            checks.append(("a thumbnail is smaller than the full render",
+                           0 < len(thumb) < len(body), f"{len(thumb)} vs {len(body)}"))
+
+            # Every advertised address must actually render — an offered
+            # control that 500s is worse than one that isn't there.
+            rendered = failed = 0
+            for level in net["levels"]:
+                for split in net["splits"]:
+                    for m in level["metrics"]:
+                        st, _, _ = _get(
+                            f"{base}/api/comparison?family=network&level={level['key']}"
+                            f"&split={split['key']}&metric={m['name']}&lag={LAG}&thumb=1")
+                        rendered += st == 200
+                        failed += st != 200
+            checks.append((f"every advertised address renders ({rendered} of them)",
+                           failed == 0 and rendered > 0, f"{failed} failed"))
+
+            for query, expect, name in [
+                ("family=nope&level=recording&split=group&metric=Dens&lag=25",
+                 "Unknown comparison family", "unknown family"),
+                ("family=network&level=cells&split=group&metric=Dens&lag=25",
+                 "Unknown level", "unknown level"),
+                ("family=network&level=recording&split=sideways&metric=Dens&lag=25",
+                 "Unknown split", "unknown split"),
+                ("family=network&level=recording&split=group&metric=Nope&lag=25",
+                 "recording-level metric", "unknown metric"),
+                ("family=network&level=recording&split=group&metric=Dens&lag=999",
+                 "this run has", "a lag the run lacks"),
+                ("family=network&level=recording&split=group&metric=Dens",
+                 "per-lag", "a missing lag"),
+                ("family=network&level=recording&split=group&metric=Dens&lag=abc",
+                 "whole number", "a non-numeric lag"),
+                ("family=network&level=recording&metric=Dens&lag=25",
+                 "missing required parameter 'split'", "a missing facet"),
+                ("family=network&level=recording&split=group&metric=Dens&lag=25&fmt=tiff",
+                 "unsupported format", "an unsupported format"),
+            ]:
+                status, body, _ = _get(f"{base}/api/comparison?{query}")
+                message = json.loads(body).get("error", "")
+                checks.append((f"{name} is a 400 that says why",
+                               status == 400 and expect in message,
+                               f"{status}: {message[:60]}"))
+        finally:
+            httpd.shutdown()
+            service.close()
+    return checks
+
+
+def _lag_series_checks() -> list[Check]:
+    """The Across-lags tab: figures whose subject is the lag itself.
+
+    Needs a two-lag run — the sets are deliberately not offered on a one-lag
+    run, since a curve through one point says nothing, and that suppression is
+    itself worth checking.
+    """
+    from meanap.viewer.server import serve
+
+    checks: list[Check] = []
+    lags = (10, 25)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "MultiFull", express=False, lags=lags)
+        express = _run(tmp, "MultiExpress", express=True, lags=lags)
+
+        httpd, service = serve(express.with_suffix(BUNDLE_SUFFIX), port=0,
+                               background=True)
+        base = f"http://127.0.0.1:{httpd.server_address[1]}"
+        try:
+            _, body, _ = _get(base + "/api/manifest")
+            man = json.loads(body)
+            sets = {s["key"]: s for s in man.get("lag_series", [])}
+            checks.append(("a multi-lag run offers both across-lag sets",
+                           {"graph_metrics", "cartography"} <= set(sets),
+                           f"{sorted(sets)}"))
+            checks.append(("graph metrics are keyed by metric",
+                           sets["graph_metrics"]["keyed_by"] == "metric"
+                           and len(sets["graph_metrics"]["options"]) > 5,
+                           f"{len(sets.get('graph_metrics', {}).get('options', []))}"))
+            checks.append(("cartography is keyed by lag, one per lag",
+                           sets["cartography"]["keyed_by"] == "lag"
+                           and [o["key"] for o in sets["cartography"]["options"]]
+                           == [str(x) for x in lags],
+                           f"{[o['key'] for o in sets['cartography']['options']]}"))
+            checks.append(("lag options are labelled in ms",
+                           all(o["label"].endswith(" ms")
+                               for o in sets["cartography"]["options"]), ""))
+
+            metric = sets["graph_metrics"]["options"][0]["key"]
+            status, curve, headers = _get(
+                f"{base}/api/lagseries?series=graph_metrics&key={metric}")
+            checks.append(("a lag curve is served", status == 200, str(status)))
+            checks.append(("…as a png",
+                           headers.get("Content-Type") == "image/png", ""))
+            original = (full / "4_NetworkActivity" / "4B_GroupComparisons"
+                        / "5_GraphMetricsByLag" / f"{metric}.png")
+            checks.append(("…identical to the figure the full run wrote",
+                           original.exists()
+                           and hashlib.sha256(curve).hexdigest() == _digest(original),
+                           f"{original.name} exists={original.exists()}"))
+
+            status, roles, _ = _get(
+                f"{base}/api/lagseries?series=cartography&key={lags[0]}")
+            cart = (full / "4_NetworkActivity" / "4B_GroupComparisons"
+                    / "6_NodeCartographyByLag" / f"NodeCartography{lags[0]}mslag.png")
+            checks.append(("a cartography figure is served and identical",
+                           status == 200 and cart.exists()
+                           and hashlib.sha256(roles).hexdigest() == _digest(cart),
+                           f"{status} exists={cart.exists()}"))
+
+            _, svg, headers = _get(
+                f"{base}/api/lagseries?series=graph_metrics&key={metric}&fmt=svg")
+            checks.append(("across-lag figures export as vector svg",
+                           headers.get("Content-Type") == "image/svg+xml"
+                           and b"<svg" in svg[:600], ""))
+
+            rendered = failed = 0
+            for spec in sets.values():
+                for opt in spec["options"]:
+                    st, _, _ = _get(f"{base}/api/lagseries?series={spec['key']}"
+                                    f"&key={opt['key']}&thumb=1")
+                    rendered += st == 200
+                    failed += st != 200
+            checks.append((f"every advertised across-lag figure renders ({rendered})",
+                           failed == 0 and rendered > 0, f"{failed} failed"))
+
+            for query, expect, name in [
+                ("series=nope&key=Dens", "Unknown across-lag set", "an unknown set"),
+                ("series=graph_metrics&key=Nope", "recording-level metric",
+                 "an unknown metric"),
+                ("series=cartography&key=999", "this run has", "a lag the run lacks"),
+                ("series=cartography&key=abc", "keyed by lag", "a non-numeric lag"),
+                ("series=graph_metrics", "missing required parameter 'key'",
+                 "a missing key"),
+            ]:
+                status, body, _ = _get(f"{base}/api/lagseries?{query}")
+                message = json.loads(body).get("error", "")
+                checks.append((f"{name} is a 400 that says why",
+                               status == 400 and expect in message,
+                               f"{status}: {message[:60]}"))
+        finally:
+            httpd.shutdown()
+            service.close()
+
+        # A one-lag run must not advertise a tab with nothing behind it.
+        single = _run(tmp, "SingleLag", express=True)
+        httpd, service = serve(single.with_suffix(BUNDLE_SUFFIX), port=0,
+                               background=True)
+        try:
+            _, body, _ = _get(
+                f"http://127.0.0.1:{httpd.server_address[1]}/api/manifest")
+            checks.append(("a one-lag run offers no across-lag sets",
+                           json.loads(body)["lag_series"] == [],
+                           f"{json.loads(body)['lag_series']}"))
+        finally:
+            httpd.shutdown()
+            service.close()
+    return checks
+
+
+def _color_checks() -> list[Check]:
+    """Age and group colours over HTTP: presets, custom lists, and defaults.
+
+    The default path is the one that matters most — an unstyled request must
+    still be the pipeline's own figure, which is what every parity claim in
+    these suites rests on.
+    """
+    from meanap.viewer.server import serve
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        full = _run(tmp, "Full", express=False)
+        express = _run(tmp, "Express", express=True)
+
+        httpd, service = serve(express.with_suffix(BUNDLE_SUFFIX), port=0,
+                               background=True)
+        base = f"http://127.0.0.1:{httpd.server_address[1]}"
+        try:
+            _, body, _ = _get(base + "/api/manifest")
+            controls = {c["key"]: c for c in json.loads(body).get("comparison_controls", [])}
+            checks.append(("the manifest advertises the colour controls",
+                           {"age_color_scheme", "age_colors", "group_color_scheme",
+                            "group_colors"} == set(controls),
+                           f"{sorted(controls)}"))
+            checks.append(("the schemes are offered as options",
+                           len(controls["group_color_scheme"]["options"]) >= 3
+                           and len(controls["age_color_scheme"]["options"]) >= 5, ""))
+            checks.append(("custom colours are a free-text control",
+                           controls["group_colors"]["kind"] == "colors", ""))
+            checks.append(("every control explains itself",
+                           all(c["help"] for c in controls.values()), ""))
+
+            address = ("family=network&level=recording&split=age&metric=Dens"
+                       f"&lag={LAG}")
+            _, plain, _ = _get(f"{base}/api/comparison?{address}")
+            _, same, _ = _get(
+                f"{base}/api/comparison?{address}&group_color_scheme=meanap")
+            _, okabe, _ = _get(
+                f"{base}/api/comparison?{address}&group_color_scheme=okabe-ito")
+            _, custom, _ = _get(
+                f"{base}/api/comparison?{address}&group_colors=%23ff0000,%230000ff")
+
+            original = (full / "4_NetworkActivity" / "4B_GroupComparisons"
+                        / "4_RecordingsByAge" / "HalfViolinPlots" / f"Lag{LAG}ms"
+                        / "Dens_byDIV.png")
+            checks.append(("an unstyled request is still the pipeline's figure",
+                           original.exists()
+                           and hashlib.sha256(plain).hexdigest() == _digest(original),
+                           f"exists={original.exists()}"))
+            checks.append(("asking for the default scheme changes nothing",
+                           hashlib.sha256(same).hexdigest()
+                           == hashlib.sha256(plain).hexdigest(), ""))
+            checks.append(("a preset changes the figure",
+                           hashlib.sha256(okabe).hexdigest()
+                           != hashlib.sha256(plain).hexdigest(), ""))
+            checks.append(("custom colours change it differently again",
+                           len({hashlib.sha256(b).hexdigest()
+                                for b in (plain, okabe, custom)}) == 3, ""))
+
+            # Across-lag figures colour their lines by DIV, so they read the
+            # age scheme; the same panel drives both, so it must reach here.
+            metric = "Dens"
+            _, curve, _ = _get(f"{base}/api/lagseries?series=graph_metrics&key={metric}")
+            _, curve2, _ = _get(f"{base}/api/lagseries?series=graph_metrics"
+                                f"&key={metric}&age_color_scheme=plasma")
+            checks.append(("across-lag figures honour the age scheme",
+                           len(curve) > 0 and hashlib.sha256(curve).hexdigest()
+                           != hashlib.sha256(curve2).hexdigest(), ""))
+
+            for query, expect, name in [
+                ("&group_colors=%23zzzzzz", "is not a colour", "a bad colour code"),
+                ("&age_color_scheme=jet", "is not one of", "a scheme that isn't offered"),
+            ]:
+                status, body, _ = _get(f"{base}/api/comparison?{address}{query}")
+                message = json.loads(body).get("error", "")
+                checks.append((f"{name} is a 400 that says why",
+                               status == 400 and expect in message,
+                               f"{status}: {message[:60]}"))
+        finally:
+            httpd.shutdown()
+            service.close()
+    return checks
+
+
+def _page_checks() -> list[Check]:
+    """The page ships the three tabs and their panels.
+
+    The page is one static string with no build step, so a missing element is
+    a silent dead control rather than a failure anything else would catch.
+    """
+    from meanap.viewer.page import PAGE_HTML
+
+    ids = [
+        "tab-recordings", "tab-comparisons", "tab-lags",
+        "side-recordings", "side-comparisons", "side-lags",
+        "cmp-family", "cmp-metrics", "cmp-lag", "cmp-level", "cmp-split",
+        "lag-series", "lag-options", "facets-panel", "controls-panel",
+        "cmp-controls", "cmp-reset", "facets-head",
+        "single", "pair", "gallery", "families",
+    ]
+    checks: list[Check] = [
+        (f"the page has #{name}", f'id="{name}"' in PAGE_HTML, "")
+        for name in ids
+    ]
+    checks.append(("the tab strip drives all three panes",
+                   PAGE_HTML.count('data-tab="') == 3,
+                   f"{PAGE_HTML.count('data-tab=')}"))
+    checks.append(("it asks the endpoints the server actually serves",
+                   all(route in PAGE_HTML for route in
+                       ("/api/manifest", "/api/figure", "/api/activity",
+                        "/api/comparison", "/api/lagseries", "/api/family",
+                        "/api/asset")), ""))
+    checks.append(("nothing external is fetched",
+                   "http://" not in PAGE_HTML and "https://" not in PAGE_HTML, ""))
+    return checks
+
+
 def main() -> int:
     print("=" * 70)
     print("MEA-NAP web viewer")
     print("=" * 70)
-    total_pass, total = _report("Serving a bundle over HTTP:", _all_checks())
+    total_pass = total = 0
+    for title, build in [
+        ("Serving a bundle over HTTP:", _all_checks),
+        ("Comparison figures by facet:", _comparison_checks),
+        ("Across-lag figures:", _lag_series_checks),
+        ("Age and group colours:", _color_checks),
+        ("The page's three tabs:", _page_checks),
+    ]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
     print(f"\n{'=' * 70}")
     print(f"Total: {total_pass}/{total} checks passed")
     print("=" * 70)

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -12,6 +12,7 @@ from PyQt6.QtGui import QAction
 from PyQt6.QtCore import Qt, QSettings, QSignalBlocker
 
 from meanap.params import Params
+from meanap.pipeline.bundle import BUNDLE_SUFFIX
 from meanap.pipeline.example_data import download_example_data
 from meanap.pipeline.report import generate_report
 from meanap.gui import theme
@@ -22,6 +23,7 @@ from meanap.gui.modes import (
     apply_mode_to_params, mode_for_params,
 )
 from meanap.gui.pipeline_worker import PipelineWorker
+from meanap.gui.viewer_session import ViewerSessions
 from meanap.gui.panels.paths import PathsPanel
 from meanap.gui.panels.recording import RecordingPanel
 from meanap.gui.panels.spike_detection import SpikeDetectionPanel
@@ -64,9 +66,16 @@ class MainWindow(QMainWindow):
         # would snap a "--mode catnap" launch straight back to the ephys tabs.
         apply_mode_to_params(mode, self._params)
         self._last_output_root: Path | None = None
+        self._last_bundle: Path | None = None
         self._current_theme = "dark"
         self._worker: PipelineWorker | None = None
         self._tutorial: TutorialOverlay | None = None
+        self._viewers = ViewerSessions()
+
+        # A bundle is a file people email each other, so dropping one on the
+        # window is the obvious way to open it. Accepted at the window level;
+        # see dragEnterEvent for why nothing else is claimed.
+        self.setAcceptDrops(True)
 
         self._build_toolbar()
         self._build_tabs()
@@ -99,6 +108,14 @@ class MainWindow(QMainWindow):
         act_save.setToolTip("Save current parameters to a JSON file")
         act_save.triggered.connect(self._on_save)
 
+        act_bundle = QAction("Open bundle…", self)
+        act_bundle.setToolTip(
+            "Open a .meanap run bundle — from an express run of your own, or "
+            "one someone sent you — and draw any of its figures in the viewer. "
+            "You can also drag the file onto this window."
+        )
+        act_bundle.triggered.connect(self._on_open_bundle)
+
         self._act_theme = QAction("☀  Light", self)
         self._act_theme.setToolTip("Toggle light / dark theme")
         self._act_theme.triggered.connect(self._on_toggle_theme)
@@ -111,6 +128,8 @@ class MainWindow(QMainWindow):
         tb.addSeparator()
         tb.addAction(act_open)
         tb.addAction(act_save)
+        tb.addSeparator()
+        tb.addAction(act_bundle)
         tb.addSeparator()
         tb.addAction(self._act_theme)
         tb.addAction(act_tutorial)
@@ -195,6 +214,12 @@ class MainWindow(QMainWindow):
         # Mark log widget so the monospace QSS rule applies
         self._pipeline_panel.log.setObjectName("log")
         self._catnap_panel._log.setObjectName("log")
+
+        # QTextEdit accepts drops even when read-only, and a child that accepts
+        # a drag stops it reaching the window — so a bundle dropped on the
+        # status log, the largest target on the Pipeline tab, would do nothing.
+        self._pipeline_panel.log.setAcceptDrops(False)
+        self._catnap_panel._log.setAcceptDrops(False)
 
         # Secondary-style buttons in CAT-NAP panel
         self._catnap_panel._scan_btn.setObjectName("secondary")
@@ -659,7 +684,33 @@ class MainWindow(QMainWindow):
     def _on_pipeline_finished(self, output_root: Path) -> None:
         self._last_output_root = output_root
         self._pipeline_panel.append_log(f"Done. Output folder: {output_root}")
+        self._announce_bundle(output_root)
         self._reset_run_buttons()
+
+    def _announce_bundle(self, output_root: Path) -> None:
+        """Say where the express bundle went, as the last thing in the log.
+
+        The runner already logs the path, but it does so before the timing
+        lines, so on an express run the one file the user is meant to keep
+        scrolls out of sight behind everything else. It also lands *beside* the
+        output folder rather than inside it, which is exactly the place nobody
+        looks — so repeat it at the end, framed, with the command that opens it.
+        """
+        if not (self._params is not None and self._params.express_mode):
+            return
+        bundle = output_root.with_suffix(BUNDLE_SUFFIX)
+        if not bundle.is_file():
+            return
+        self._last_bundle = bundle
+        size_mb = bundle.stat().st_size / 1e6
+        rule = "─" * 68
+        self._pipeline_panel.append_log(
+            f"\n{rule}\n"
+            f"  Express bundle ({size_mb:.1f} MB) — beside the output folder, not in it:\n"
+            f"    {bundle}\n"
+            f"  Draw any figure from it:  meanap-viewer \"{bundle}\"\n"
+            f"{rule}"
+        )
 
     def _on_pipeline_cancelled(self) -> None:
         self._pipeline_panel.append_log("Pipeline stopped.")
@@ -670,18 +721,51 @@ class MainWindow(QMainWindow):
         self._reset_run_buttons()
         QMessageBox.critical(self, "Pipeline error", message)
 
+    def _candidate_output_root(self) -> Path | None:
+        """The output folder View report should act on, run or no run.
+
+        Falls back to the same folder :func:`run_pipeline` would have created
+        from the current paths — including its dated default name, which the
+        Paths tab leaves blank — so the button works in a fresh session
+        pointed at yesterday's results.
+        """
+        if self._last_output_root is not None:
+            return self._last_output_root
+        params = self._collect_params()
+        if not params.output_data_folder:
+            return None
+        from meanap.pipeline.runner import default_output_folder_name
+        name = params.output_data_folder_name or default_output_folder_name()
+        return Path(params.output_data_folder) / name
+
     def _on_view_report(self) -> None:
-        output_root = self._last_output_root
-        if output_root is None:
-            params = self._collect_params()
-            if params.output_data_folder and params.output_data_folder_name:
-                output_root = Path(params.output_data_folder) / params.output_data_folder_name
+        """Open the run's results: the viewer for an express run, else the report.
+
+        An express run leaves almost no figures on disk — that is the point of
+        it — so building the static PNG report from that folder produces a page
+        that looks like a failed run. The bundle beside it holds everything, and
+        the viewer draws any figure from it on demand, so that is what "view the
+        report" means for those runs.
+        """
+        output_root = self._candidate_output_root()
+
+        bundle = self._last_bundle
+        if bundle is None and output_root is not None:
+            candidate = output_root.with_suffix(BUNDLE_SUFFIX)
+            if candidate.is_file():
+                bundle = candidate
+        if bundle is not None and bundle.is_file():
+            self._open_in_viewer(bundle)
+            return
 
         if output_root is None or not output_root.is_dir():
             QMessageBox.warning(
                 self, "No output folder found",
                 "Run the pipeline first, or set the Output data folder / name "
-                "(Paths tab) to an existing MEA-NAP output folder.",
+                "(Paths tab) to an existing MEA-NAP output folder.\n\n"
+                "To open an express run from another machine, use "
+                "'Open bundle…' in the toolbar, or drag its .meanap file onto "
+                "this window.",
             )
             return
 
@@ -694,10 +778,88 @@ class MainWindow(QMainWindow):
         self._pipeline_panel.append_log(f"Report generated: {report_path}")
         webbrowser.open(report_path.as_uri())
 
+    # ── Bundles ───────────────────────────────────────────────────────────────
+
+    def _on_open_bundle(self) -> None:
+        start_dir = str(self._last_bundle.parent) if self._last_bundle else ""
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Open a MEA-NAP run bundle", start_dir,
+            f"MEA-NAP bundles (*{BUNDLE_SUFFIX})",
+        )
+        if path:
+            self._open_in_viewer(Path(path))
+
+    def _open_in_viewer(self, source: Path) -> bool:
+        """Serve *source* in the local viewer and open a browser on it.
+
+        Reading a bundle means extracting and parsing it, which is quick but
+        not instant, so the wait is shown rather than looking like a click that
+        did nothing. Returns whether it opened.
+        """
+        already = self._viewers.url_for(source)
+        if already is None:
+            self._pipeline_panel.append_log(f"Opening in the viewer: {source}")
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            url = self._viewers.open(source)
+        except Exception as e:
+            QMessageBox.critical(self, "Could not open the bundle", str(e))
+            return False
+        finally:
+            QApplication.restoreOverrideCursor()
+
+        if already is None:
+            self._pipeline_panel.append_log(
+                f"Viewer serving at {url} — it stays up until MEA-NAP closes."
+            )
+        webbrowser.open(url)
+        return True
+
+    @staticmethod
+    def _dropped_bundles(event) -> list[Path]:
+        """The ``.meanap`` files in a drag event, in the order they were dragged."""
+        data = event.mimeData()
+        if not data.hasUrls():
+            return []
+        paths = []
+        for url in data.urls():
+            if not url.isLocalFile():
+                continue
+            path = Path(url.toLocalFile())
+            if path.suffix == BUNDLE_SUFFIX and path.is_file():
+                paths.append(path)
+        return paths
+
+    def dragEnterEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        # Only claim the drag when we can act on it: refusing everything else
+        # leaves the path fields free to accept a dragged file as text.
+        if self._dropped_bundles(event):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dragMoveEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        if self._dropped_bundles(event):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event) -> None:  # noqa: N802 - Qt naming
+        bundles = self._dropped_bundles(event)
+        if not bundles:
+            event.ignore()
+            return
+        event.acceptProposedAction()
+        for bundle in bundles:
+            self._open_in_viewer(bundle)
+
     def closeEvent(self, event) -> None:
         # A running QThread destroyed with its parent crashes Qt; ask the
         # pipeline to stop and give it a moment to reach a cancel checkpoint.
         if self._worker is not None and self._worker.isRunning():
             self._worker.request_cancel()
             self._worker.wait(5000)
+        # Each viewer holds a port and a temporary extraction directory; both
+        # live as long as the process unless handed back here.
+        self._viewers.close_all()
         super().closeEvent(event)

--- a/src/meanap/gui/panels/pipeline.py
+++ b/src/meanap/gui/panels/pipeline.py
@@ -141,8 +141,10 @@ class PipelinePanel(QWidget):
         self.view_report_btn = QPushButton("🌐  View report")
         self.view_report_btn.setFixedHeight(40)
         self.view_report_btn.setToolTip(
-            "Generate (or refresh) an HTML report of the output folder's "
-            "plots and open it in your browser"
+            "Open the last run's results in your browser. A normal run gets an "
+            "HTML report of the figures in the output folder; an express run "
+            "opens its .meanap bundle in the viewer instead, which draws any "
+            "figure on demand in PNG or editable SVG."
         )
 
         run_layout.addWidget(self.test_btn)

--- a/src/meanap/gui/viewer_session.py
+++ b/src/meanap/gui/viewer_session.py
@@ -1,0 +1,91 @@
+"""Viewer servers owned by the GUI, one per bundle the user opens.
+
+The viewer is a local web server (:mod:`meanap.viewer.server`) that renders a
+bundle's figures on demand. Launching it from the GUI means the GUI owns its
+lifetime: the server must outlive the click that started it, must not be
+started twice for the same bundle, and must be shut down when the window
+closes — a leaked ``ThreadingHTTPServer`` holds a port and a temporary
+extraction directory for as long as the process lives.
+
+Kept out of :mod:`meanap.gui.main_window` so it can be driven in tests without
+a window, and so nothing here needs Qt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from meanap.viewer.server import DEFAULT_PORT, serve
+
+__all__ = ["ViewerSessions", "Session"]
+
+
+@dataclass
+class Session:
+    """One running viewer: its URL and the objects that must be torn down."""
+
+    source: Path
+    url: str
+    httpd: object
+    service: object
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.service.close()
+
+
+class ViewerSessions:
+    """The set of viewers this window has open, keyed by resolved source path.
+
+    Opening the same bundle twice returns the URL already serving it rather
+    than paying to extract and parse it again — the user's intent in clicking
+    twice is "show me that page", not "give me a second copy of it".
+    """
+
+    def __init__(self, port: int = DEFAULT_PORT) -> None:
+        self._preferred_port = port
+        self._sessions: dict[Path, Session] = {}
+
+    def __len__(self) -> int:
+        return len(self._sessions)
+
+    def url_for(self, source: Path | str) -> str | None:
+        """The URL already serving *source*, or ``None``."""
+        session = self._sessions.get(Path(source).resolve())
+        return session.url if session is not None else None
+
+    def open(self, source: Path | str) -> str:
+        """Serve *source* (bundle or output folder) and return its URL.
+
+        Raises whatever the viewer raises on an unreadable source —
+        :class:`ValueError` with a message written to be shown to the user.
+        """
+        key = Path(source).resolve()
+        existing = self._sessions.get(key)
+        if existing is not None:
+            return existing.url
+
+        # The default port is the one a collaborator would be told to visit, so
+        # try it first; fall back to any free port when it is taken — by a
+        # second bundle open in this window, or by something else entirely.
+        try:
+            httpd, service = serve(key, port=self._preferred_port, background=True)
+        except OSError:
+            httpd, service = serve(key, port=0, background=True)
+
+        url = f"http://{httpd.server_address[0]}:{httpd.server_address[1]}/"
+        self._sessions[key] = Session(source=key, url=url, httpd=httpd, service=service)
+        return url
+
+    def close_all(self) -> None:
+        """Shut every viewer down. Safe to call twice."""
+        for session in list(self._sessions.values()):
+            try:
+                session.close()
+            except Exception:
+                # Teardown runs while the window is closing; a server that is
+                # already dead must not stop the rest from being reclaimed.
+                pass
+        self._sessions.clear()

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -112,6 +112,15 @@ class Params:
     raster_colormap: str = "parula"
     line_plot_shade_metric: str = "sem"
     custom_grp_order: list[str] = field(default_factory=list)
+    # Colours for the group-level (2B/4B) comparison plots. Ages take a
+    # sequential colormap, groups a categorical list; see
+    # meanap.pipeline.palette for the presets. An explicit list of colours
+    # (hex codes or names) overrides the preset, and cycles if it is shorter
+    # than the number of ages or groups. Defaults reproduce MATLAB's palettes.
+    age_color_scheme: str = "viridis"
+    group_color_scheme: str = "meanap"
+    age_colors: list[str] = field(default_factory=list)
+    group_colors: list[str] = field(default_factory=list)
     network_plot_edge_threshold_method: str = "percentile"
     network_plot_edge_threshold_percentile: float = 90.0
     network_plot_edge_threshold: float = 0.1

--- a/src/meanap/pipeline/palette.py
+++ b/src/meanap/pipeline/palette.py
@@ -1,0 +1,193 @@
+"""Colours for the group-level comparison plots: ages and groups.
+
+Two palettes run through every 2B/4B figure, and they are different kinds of
+thing. **Ages** are ordered, so they take a sequential colormap sampled across
+its range — a reader should be able to see which way time runs without reading
+the legend. **Groups** are not ordered, so they take a categorical list, where
+neighbouring colours being far apart is the whole point.
+
+Both are configurable, with the defaults reproducing what the pipeline has
+always drawn: ``flipud(viridis)`` for ages (``plotHalfViolinByX.m`` line 16) and
+MATLAB's ``groupColors`` for groups. That default matters beyond taste — the
+viewer's pixel-parity tests assert that an unstyled render equals the figure the
+pipeline wrote, so :class:`ColorScheme` with no arguments must be a no-op.
+
+A custom list always wins over a scheme, and cycles when it is shorter than the
+number of ages or groups — running out of colours should repeat, not crash a
+run twelve hours in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "AGE_SCHEMES", "GROUP_SCHEMES", "ColorScheme", "parse_colors",
+]
+
+RGB = tuple[float, float, float]
+
+#: Sequential colormaps offered for ages. Perceptually uniform ones only: an
+#: ordered variable read through a non-uniform map (jet, rainbow) invents
+#: structure that isn't in the data. ``_r`` reverses the direction.
+AGE_SCHEMES: dict[str, str] = {
+    "viridis": "viridis",
+    "viridis_r": "viridis_r",
+    "plasma": "plasma",
+    "plasma_r": "plasma_r",
+    "cividis": "cividis",
+    "magma": "magma",
+    "inferno": "inferno",
+    "grey": "Greys",
+}
+
+#: MATLAB's ``groupColors`` — the pipeline's historical default.
+_MEANAP_GROUPS: tuple[RGB, ...] = (
+    (0.996, 0.670, 0.318),
+    (0.780, 0.114, 0.114),
+    (0.459, 0.000, 0.376),
+    (0.027, 0.306, 0.659),
+    (0.5, 0.5, 0.5),
+)
+
+#: Okabe-Ito: eight hues distinguishable under all common colour-vision
+#: deficiencies. Worth offering because a genotype comparison printed in a
+#: paper will be read by someone who cannot separate the default red and green.
+_OKABE_ITO: tuple[RGB, ...] = (
+    (0.000, 0.447, 0.698),   # blue
+    (0.902, 0.624, 0.000),   # orange
+    (0.000, 0.620, 0.451),   # bluish green
+    (0.800, 0.475, 0.655),   # reddish purple
+    (0.337, 0.706, 0.914),   # sky blue
+    (0.835, 0.369, 0.000),   # vermillion
+    (0.941, 0.894, 0.259),   # yellow
+    (0.000, 0.000, 0.000),   # black
+)
+
+_TAB10: tuple[RGB, ...] = (
+    (0.122, 0.467, 0.706), (1.000, 0.498, 0.055), (0.173, 0.627, 0.173),
+    (0.839, 0.153, 0.157), (0.580, 0.404, 0.741), (0.549, 0.337, 0.294),
+    (0.890, 0.467, 0.761), (0.498, 0.498, 0.498), (0.737, 0.741, 0.133),
+    (0.090, 0.745, 0.812),
+)
+
+#: Greyscale, for a figure that has to survive a black-and-white print.
+_GREYS: tuple[RGB, ...] = (
+    (0.15, 0.15, 0.15), (0.45, 0.45, 0.45), (0.65, 0.65, 0.65),
+    (0.80, 0.80, 0.80), (0.30, 0.30, 0.30),
+)
+
+GROUP_SCHEMES: dict[str, tuple[RGB, ...]] = {
+    "meanap": _MEANAP_GROUPS,
+    "okabe-ito": _OKABE_ITO,
+    "tab10": _TAB10,
+    "grey": _GREYS,
+}
+
+
+def parse_colors(colors) -> list[RGB]:
+    """Turn user-supplied colours into RGB triples.
+
+    Accepts anything matplotlib names — ``#1f77b4``, ``#abc``, ``red``,
+    ``tab:blue`` — as a list, or as one comma/space-separated string, which is
+    how a query string and a text box deliver it.
+
+    Raises :class:`ValueError` naming the offending entry. A mistyped colour
+    should say so at the edge, not surface as a matplotlib traceback halfway
+    through a batch.
+    """
+    from matplotlib.colors import to_rgb
+
+    if colors is None:
+        return []
+    if isinstance(colors, str):
+        colors = [c for c in colors.replace(",", " ").split() if c]
+    out = []
+    for c in colors:
+        if isinstance(c, (tuple, list)):
+            if len(c) not in (3, 4):
+                raise ValueError(f"{c!r} is not a colour: expected 3 or 4 components")
+            out.append(tuple(float(v) for v in c[:3]))
+            continue
+        try:
+            out.append(tuple(to_rgb(c)))
+        except (ValueError, TypeError):
+            raise ValueError(
+                f"{c!r} is not a colour. Use a hex code like '#1f77b4' or a "
+                f"name like 'crimson'.") from None
+    return out
+
+
+def _sample(cmap_name: str, n: int, *, reverse_start: bool) -> list[RGB]:
+    """*n* colours spread across a colormap.
+
+    ``reverse_start`` samples 1→0, which is what ``flipud`` does in the MATLAB
+    original: the bright end lands on the first (youngest) age.
+    """
+    import numpy as np
+    from matplotlib import colormaps
+
+    if n <= 0:
+        return []
+    cmap = colormaps[cmap_name]
+    xs = np.linspace(1, 0, n) if reverse_start else np.linspace(0, 1, n)
+    return [tuple(cmap(float(x))[:3]) for x in xs]
+
+
+@dataclass(frozen=True)
+class ColorScheme:
+    """Which colours the age and group axes get.
+
+    The no-argument instance reproduces the pipeline's historical palettes
+    exactly, so passing one where none was passed before changes nothing.
+    """
+
+    age_scheme: str = "viridis"
+    group_scheme: str = "meanap"
+    #: Explicit colours, winning over the scheme when non-empty.
+    age_colors: tuple = ()
+    group_colors: tuple = ()
+
+    def __post_init__(self):
+        if self.age_scheme not in AGE_SCHEMES:
+            raise ValueError(
+                f"Unknown age colour scheme {self.age_scheme!r}; expected one of "
+                f"{sorted(AGE_SCHEMES)}")
+        if self.group_scheme not in GROUP_SCHEMES:
+            raise ValueError(
+                f"Unknown group colour scheme {self.group_scheme!r}; expected one "
+                f"of {sorted(GROUP_SCHEMES)}")
+        # Validate here rather than at draw time: the run should fail on the
+        # bad colour, not after an hour of computation.
+        object.__setattr__(self, "age_colors", tuple(parse_colors(self.age_colors)))
+        object.__setattr__(self, "group_colors", tuple(parse_colors(self.group_colors)))
+
+    @classmethod
+    def from_params(cls, params) -> "ColorScheme":
+        """Read the scheme off a :class:`~meanap.params.Params`."""
+        return cls(
+            age_scheme=getattr(params, "age_color_scheme", "viridis") or "viridis",
+            group_scheme=getattr(params, "group_color_scheme", "meanap") or "meanap",
+            age_colors=tuple(getattr(params, "age_colors", ()) or ()),
+            group_colors=tuple(getattr(params, "group_colors", ()) or ()),
+        )
+
+    def ages(self, n: int) -> list[RGB]:
+        """*n* colours for the ages, youngest first."""
+        if self.age_colors:
+            return _cycle(self.age_colors, n)
+        return _sample(AGE_SCHEMES[self.age_scheme], n, reverse_start=True)
+
+    def groups(self, n: int) -> list[RGB]:
+        """*n* colours for the groups, in the batch's group order."""
+        if self.group_colors:
+            return _cycle(self.group_colors, n)
+        return _cycle(GROUP_SCHEMES[self.group_scheme], n)
+
+
+def _cycle(colors, n: int) -> list[RGB]:
+    return [tuple(colors[i % len(colors)]) for i in range(n)]
+
+
+#: The default, shared so callers that were passed nothing don't each build one.
+DEFAULT_SCHEME = ColorScheme()

--- a/src/meanap/pipeline/plotting_step2.py
+++ b/src/meanap/pipeline/plotting_step2.py
@@ -402,24 +402,33 @@ def _plot_violin(df: pd.DataFrame, metric: str, group_col: str, out_path: Path, 
     savefig(fig, out_path, default_dpi=300, bbox_inches="tight")
     plt.close(fig)
 
-def plot_step2_group_comparisons(
+def ephys_comparison_frames(
     recordings: list,
     all_ephys: dict,
-    out_dir: Path,
     custom_grp_order: list[str] | None = None,
-    fmt: str = "png",
-) -> None:
-    """Generate group comparison plots for step 2."""
+) -> tuple["pd.DataFrame", "pd.DataFrame"]:
+    """The recording- and node-level tables every 2B comparison plot is drawn from.
+
+    The step-2 counterpart of
+    :func:`~meanap.pipeline.plotting_step4.netmet_comparison_frames`, and split
+    out for the same reason: so one figure can be drawn on its own by the same
+    code that draws the folder. There is no ``Lag`` column here — step-2
+    activity metrics do not depend on the STTC lag.
+
+    Returns empty frames when nothing matched, rather than raising.
+    """
+    from meanap.pipeline.plotting_step4 import _apply_group_order
+
     rec_rows = []
     node_rows = []
-    
+
     for rec in recordings:
         if rec.filename not in all_ephys:
             continue
-            
+
         ephys = all_ephys[rec.filename]
         base = {"FileName": rec.filename, "Grp": rec.group, "DIV": str(rec.div)}
-        
+
         # Recording-level
         rec_row = dict(base)
         for k in EPHYS_REC_METRICS:
@@ -429,7 +438,7 @@ def plot_step2_group_comparisons(
                     val = val[0]
                 rec_row[k] = val
         rec_rows.append(rec_row)
-        
+
         # Node-level
         num_nodes = len(ephys.get("FR", []))
         if num_nodes > 0:
@@ -440,24 +449,38 @@ def plot_step2_group_comparisons(
                     if k in ephys and len(ephys[k]) > ch:
                         node_row[k] = ephys[k][ch]
                 node_rows.append(node_row)
-                
-    if not rec_rows:
-        return
-        
+
     df_rec = pd.DataFrame(rec_rows)
     df_node = pd.DataFrame(node_rows)
-    
-    if custom_grp_order:
-        df_rec["Grp"] = pd.Categorical(df_rec["Grp"], categories=custom_grp_order, ordered=True)
-        df_node["Grp"] = pd.Categorical(df_node["Grp"], categories=custom_grp_order, ordered=True)
-    
+    _apply_group_order(df_rec, df_node, custom_grp_order)
+    return df_rec, df_node
+
+
+def plot_step2_group_comparisons(
+    recordings: list,
+    all_ephys: dict,
+    out_dir: Path,
+    custom_grp_order: list[str] | None = None,
+    fmt: str = "png",
+    colors=None,
+) -> None:
+    """Generate group comparison plots for step 2.
+
+    ``colors`` is a :class:`~meanap.pipeline.palette.ColorScheme` for the age
+    and group palettes; omitting it keeps the historical ones.
+    """
+    df_rec, df_node = ephys_comparison_frames(recordings, all_ephys, custom_grp_order)
+    if df_rec.empty:
+        return
+
     # 3_RecordingsByGroup
     grp_dir = out_dir / "2B_GroupComparisons" / "3_RecordingsByGroup" / "HalfViolinPlots"
     grp_dir.mkdir(parents=True, exist_ok=True)
     
     for k, name in EPHYS_REC_METRICS.items():
         plot_half_violin_by_x(df_rec, k, name, "group",
-                              grp_dir / f"{k}_byGroup.{fmt}", group_order=custom_grp_order)
+                              grp_dir / f"{k}_byGroup.{fmt}", group_order=custom_grp_order,
+                              colors=colors)
 
     # 1_NodeByGroup
     node_grp_dir = out_dir / "2B_GroupComparisons" / "1_NodeByGroup"
@@ -465,7 +488,8 @@ def plot_step2_group_comparisons(
 
     for k, name in EPHYS_NODE_METRICS.items():
         plot_half_violin_by_x(df_node, k, name, "group",
-                              node_grp_dir / f"{k}_byGroup_node.{fmt}", group_order=custom_grp_order)
+                              node_grp_dir / f"{k}_byGroup_node.{fmt}",
+                              group_order=custom_grp_order, colors=colors)
 
     # 4_RecordingsByAge
     age_dir = out_dir / "2B_GroupComparisons" / "4_RecordingsByAge" / "HalfViolinPlots"
@@ -473,7 +497,8 @@ def plot_step2_group_comparisons(
 
     for k, name in EPHYS_REC_METRICS.items():
         plot_half_violin_by_x(df_rec, k, name, "DIV",
-                              age_dir / f"{k}_byDIV.{fmt}", group_order=custom_grp_order)
+                              age_dir / f"{k}_byDIV.{fmt}", group_order=custom_grp_order,
+                              colors=colors)
 
     # 2_NodeByAge
     node_age_dir = out_dir / "2B_GroupComparisons" / "2_NodeByAge"
@@ -481,4 +506,5 @@ def plot_step2_group_comparisons(
 
     for k, name in EPHYS_NODE_METRICS.items():
         plot_half_violin_by_x(df_node, k, name, "DIV",
-                              node_age_dir / f"{k}_byDIV_node.{fmt}", group_order=custom_grp_order)
+                              node_age_dir / f"{k}_byDIV_node.{fmt}",
+                              group_order=custom_grp_order, colors=colors)

--- a/src/meanap/pipeline/plotting_step4.py
+++ b/src/meanap/pipeline/plotting_step4.py
@@ -1037,22 +1037,23 @@ _GROUP_COLORS = [
 ]
 
 
-def _div_colors(n: int) -> list:
-    """Per-DIV colours: ``flipud(viridis(n))`` (plotHalfViolinByX.m line 16).
+def _div_colors(n: int, colors=None) -> list:
+    """Per-DIV colours. Default ``flipud(viridis(n))`` (plotHalfViolinByX.m:16).
 
-    ``flipud`` puts the bright (yellow) end at the first DIV; sampling from 1→0
-    reproduces that for every ``n``, including the single-DIV case.
+    ``flipud`` puts the bright (yellow) end at the first DIV. *colors* is a
+    :class:`~meanap.pipeline.palette.ColorScheme`; omitting it keeps the
+    historical palette exactly.
     """
-    import matplotlib.cm as cm
-    if n <= 0:
-        return []
-    xs = np.linspace(1, 0, n)
-    return [tuple(cm.viridis(x)[:3]) for x in xs]
+    from meanap.pipeline.palette import DEFAULT_SCHEME
+
+    return (colors or DEFAULT_SCHEME).ages(n)
 
 
-def _group_colors(n: int) -> list:
-    """Per-group colours, cycling MATLAB's default groupColors palette."""
-    return [_GROUP_COLORS[i % len(_GROUP_COLORS)] for i in range(n)]
+def _group_colors(n: int, colors=None) -> list:
+    """Per-group colours, by default cycling MATLAB's ``groupColors``."""
+    from meanap.pipeline.palette import DEFAULT_SCHEME
+
+    return (colors or DEFAULT_SCHEME).groups(n)
 
 
 def _tick_label(v) -> str:
@@ -1079,8 +1080,12 @@ def plot_half_violin_by_x(
     series_col: str | None = None,
     series_order: list | None = None,
     series_colors: list | None = None,
+    colors=None,
 ) -> None:
     """Group-comparison half-violin plot, port of ``plotHalfViolinByX.m``.
+
+    ``colors`` is a :class:`~meanap.pipeline.palette.ColorScheme` choosing the
+    age and group palettes; omitting it keeps the pipeline's historical ones.
 
     ``x_kind='group'``  → one subplot per group, x-axis = DIVs (viridis-coloured),
     title = group name, xlabel "Age".
@@ -1134,13 +1139,13 @@ def plot_half_violin_by_x(
     if x_kind == "group":
         subplot_items, sub_col = groups, "Grp"
         within_items, within_col = divs, "DIV"
-        within_colors = _div_colors(len(divs))
+        within_colors = _div_colors(len(divs), colors)
         xlabel = "Age"
         titles = [str(g) for g in groups]
     elif x_kind == "DIV":
         subplot_items, sub_col = divs, "DIV"
         within_items, within_col = groups, "Grp"
-        within_colors = _group_colors(len(groups))
+        within_colors = _group_colors(len(groups), colors)
         xlabel = "Group"
         # _tick_label so the title reads "Age 14", matching the tick labels on
         # the other layout rather than the raw float DIV ("Age 14.0").
@@ -1159,7 +1164,7 @@ def plot_half_violin_by_x(
     series_mean_colors: list = []
     if n_series:
         if series_colors is None:
-            series_colors = _group_colors(n_series)
+            series_colors = _group_colors(n_series, colors)
         # Split the unit-wide x slot between the series. A violin spans
         # pos ± (width + gap), so keeping 2*(width + gap) safely under one
         # slot is what stops one series' scatter dots landing on top of the
@@ -1277,20 +1282,27 @@ def plot_node_cartography_by_lag(
     df: "pd.DataFrame",
     out_dir: Path,
     group_order: list | None = None,
-) -> None:
+    only: int | None = None,
+    fmt: str = "png",
+) -> list[Path]:
     """Node-cartography role proportions vs DIV, port of ``plotNetMetNodeCartography.m``.
 
-    One figure per STTC lag (``NodeCartography<lag>mslag.png``): a vertical stack
-    of subplots (one per group), each overlaying the six role proportions
-    (``NCpn1``-``NCpn6``) as lines vs DIV with mean ± SEM bands and a role legend.
-    Requires ``df`` with ``Grp``/``DIV``/``Lag`` columns plus ``NCpn1``-``NCpn6``.
+    One figure per STTC lag (``NodeCartography<lag>mslag.<fmt>``): a vertical
+    stack of subplots (one per group), each overlaying the six role proportions
+    (``NCpn1``-``NCpn6``) as lines vs DIV with mean ± SEM bands and a role
+    legend. Requires ``df`` with ``Grp``/``DIV``/``Lag`` columns plus
+    ``NCpn1``-``NCpn6``.
+
+    ``only`` restricts the run to a single lag (in ms), for a viewer redrawing
+    one figure. Returns the files written.
     """
     if df.empty:
-        return
+        return []
     metrics = [f"NCpn{i}" for i in range(1, 7)]
     if not all(m in df.columns for m in metrics):
-        return
+        return []
     out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
 
     groups = list(group_order) if group_order else sorted(df["Grp"].dropna().unique())
     lags = sorted(df["Lag"].unique(), key=_lag_num)
@@ -1304,6 +1316,8 @@ def plot_node_cartography_by_lag(
     xt = np.arange(1, len(divs) + 1)
 
     for lag in lags:
+        if only is not None and _lag_num(lag) != only:
+            continue
         ldf = df[df["Lag"] == lag]
         n_grp = len(groups)
         fig, axes = plt.subplots(n_grp, 1, figsize=(8.0, max(3.0, 3.0 * n_grp)),
@@ -1345,9 +1359,11 @@ def plot_node_cartography_by_lag(
                       bbox_to_anchor=(1.01, 0.5), fontsize=8, frameon=False)
 
         fig.tight_layout()
-        savefig(fig, out_dir / f"NodeCartography{_lag_num(lag)}mslag.png",
-                default_dpi=300, bbox_inches="tight")
+        dest = out_dir / f"NodeCartography{_lag_num(lag)}mslag.{fmt}"
+        savefig(fig, dest, default_dpi=300, bbox_inches="tight")
         plt.close(fig)
+        written.append(dest)
+    return written
 
 
 def plot_density_landscape(
@@ -1395,19 +1411,26 @@ def plot_graph_metrics_by_lag(
     df: "pd.DataFrame",
     out_dir: Path,
     group_order: list | None = None,
-) -> None:
+    only: str | None = None,
+    fmt: str = "png",
+    colors=None,
+) -> list[Path]:
     """Network metric vs. STTC lag line plots, port of ``plotGraphMetricsByLag.m``.
 
     One figure per recording-level metric: a vertical stack of subplots (one per
     group), each plotting mean ± SEM across recordings as a function of STTC lag,
     with one line per DIV (viridis-coloured, DIV1 = yellow end) and a DIV legend.
     Requires ``df`` with ``Grp``/``DIV``/``Lag`` columns plus the metric columns.
-    Files are named ``<metric>.png`` so they pair with MATLAB's
+    Files are named ``<metric>.<fmt>`` so they pair with MATLAB's
     ``<n>_<label>.png`` via the report's label→code map.
+
+    ``only`` restricts the run to a single metric, for a viewer redrawing the
+    one figure it is showing rather than all 31. Returns the files written.
     """
     if df.empty:
-        return
+        return []
     out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
 
     groups = list(group_order) if group_order else sorted(df["Grp"].dropna().unique())
     lags = sorted(df["Lag"].unique(), key=_lag_num)
@@ -1419,11 +1442,11 @@ def plot_graph_metrics_by_lag(
         except ValueError:
             return str(d)
     divs = sorted(df["DIV"].dropna().unique(), key=_divkey)
-    div_colors = _div_colors(len(divs))
+    div_colors = _div_colors(len(divs), colors)
     xt = np.arange(1, len(lags) + 1)
 
     for metric, label in NETMET_REC_METRICS.items():
-        if metric not in df.columns:
+        if metric not in df.columns or (only is not None and metric != only):
             continue
 
         n_grp = len(groups)
@@ -1478,8 +1501,11 @@ def plot_graph_metrics_by_lag(
             plt.close(fig)
             continue
         fig.tight_layout()
-        savefig(fig, out_dir / f"{metric}.png", default_dpi=300, bbox_inches="tight")
+        dest = out_dir / f"{metric}.{fmt}"
+        savefig(fig, dest, default_dpi=300, bbox_inches="tight")
         plt.close(fig)
+        written.append(dest)
+    return written
 
 
 # ── Public plot function ──────────────────────────────────────────────────────
@@ -1719,25 +1745,37 @@ def _plot_violin(df: pd.DataFrame, metric: str, group_col: str, out_path: Path, 
     savefig(fig, out_path, default_dpi=300, bbox_inches="tight")
     plt.close(fig)
 
-def plot_step4_group_comparisons(
+def netmet_comparison_frames(
     recordings: list,
     all_results: dict,
-    out_dir: Path,
     custom_grp_order: list[str] | None = None,
-    fmt: str = "png",
-) -> None:
-    """Generate group comparison plots for step 4."""
+) -> tuple["pd.DataFrame", "pd.DataFrame"]:
+    """The recording- and node-level tables every 4B comparison plot is drawn from.
+
+    One row per (recording, lag) at the recording level, and per
+    (recording, lag, channel) at the node level, carrying ``FileName``/``Grp``/
+    ``DIV``/``Lag`` plus whichever of :data:`NETMET_REC_METRICS` /
+    :data:`NETMET_NODE_METRICS` the results hold.
+
+    Separated from :func:`plot_step4_group_comparisons` so a caller can draw
+    *one* comparison figure — the viewer redraws a single metric at a single lag
+    on demand, and rebuilding these frames is the only part of that work it
+    cannot skip. Both callers share this function, so a figure drawn one at a
+    time cannot drift from the same figure drawn as part of the folder.
+
+    Returns empty frames when nothing matched, rather than raising.
+    """
     rec_rows = []
     node_rows = []
-    
+
     for rec in recordings:
         if rec.filename not in all_results:
             continue
-            
+
         rec_results = all_results[rec.filename]
         for lag, metrics in rec_results.items():
             base = {"FileName": rec.filename, "Grp": rec.group, "DIV": str(rec.div), "Lag": lag}
-            
+
             # Recording-level
             rec_row = dict(base)
             for k in NETMET_REC_METRICS:
@@ -1748,7 +1786,7 @@ def plot_step4_group_comparisons(
                     if not isinstance(val, (list, np.ndarray)):
                         rec_row[k] = val
             rec_rows.append(rec_row)
-            
+
             # Node-level
             # Determine number of nodes from one of the arrays (e.g. ND)
             node_metrics = {k: v for k, v in metrics.items() if k in NETMET_NODE_METRICS and isinstance(v, (list, np.ndarray)) and len(v) > 1}
@@ -1761,17 +1799,45 @@ def plot_step4_group_comparisons(
                         if len(v_arr) == num_nodes:
                             node_row[k] = v_arr[ch]
                     node_rows.append(node_row)
-                
-    if not rec_rows:
-        return
-        
+
     df_rec = pd.DataFrame(rec_rows)
     df_node = pd.DataFrame(node_rows)
-    
-    if custom_grp_order:
-        df_rec["Grp"] = pd.Categorical(df_rec["Grp"], categories=custom_grp_order, ordered=True)
-        df_node["Grp"] = pd.Categorical(df_node["Grp"], categories=custom_grp_order, ordered=True)
-    
+    _apply_group_order(df_rec, df_node, custom_grp_order)
+    return df_rec, df_node
+
+
+def _apply_group_order(df_rec, df_node, custom_grp_order: list[str] | None) -> None:
+    """Make ``Grp`` an ordered categorical in place, so plots honour the order.
+
+    The ``Grp in columns`` guard matters for the node frame: a batch whose
+    recordings all have a single node produces no node rows at all, and a
+    column assignment on that empty frame is a ``KeyError`` rather than a
+    no-op.
+    """
+    if not custom_grp_order:
+        return
+    for df in (df_rec, df_node):
+        if "Grp" in df.columns:
+            df["Grp"] = pd.Categorical(df["Grp"], categories=custom_grp_order, ordered=True)
+
+
+def plot_step4_group_comparisons(
+    recordings: list,
+    all_results: dict,
+    out_dir: Path,
+    custom_grp_order: list[str] | None = None,
+    fmt: str = "png",
+    colors=None,
+) -> None:
+    """Generate group comparison plots for step 4.
+
+    ``colors`` is a :class:`~meanap.pipeline.palette.ColorScheme` for the age
+    and group palettes; omitting it keeps the historical ones.
+    """
+    df_rec, df_node = netmet_comparison_frames(recordings, all_results, custom_grp_order)
+    if df_rec.empty:
+        return
+
     # 3_RecordingsByGroup and 1_NodeByGroup
     grp_dir = out_dir / "4B_GroupComparisons" / "3_RecordingsByGroup" / "HalfViolinPlots"
     node_grp_dir = out_dir / "4B_GroupComparisons" / "1_NodeByGroup"
@@ -1787,7 +1853,7 @@ def plot_step4_group_comparisons(
         for k, name in NETMET_REC_METRICS.items():
             plot_half_violin_by_x(df_rec_lag, k, name, "group",
                                   lag_grp_dir / f"{k}_byGroup.{fmt}",
-                                  group_order=custom_grp_order)
+                                  group_order=custom_grp_order, colors=colors)
 
         lag_node_grp_dir = node_grp_dir / f"Lag{lag_str}ms" if "ms" not in str(lag_str) else node_grp_dir / f"Lag{lag_str}"
         lag_node_grp_dir.mkdir(parents=True, exist_ok=True)
@@ -1796,7 +1862,7 @@ def plot_step4_group_comparisons(
         for k, name in NETMET_NODE_METRICS.items():
             plot_half_violin_by_x(df_node_lag, k, name, "group",
                                   lag_node_grp_dir / f"{k}_byGroup_node.{fmt}",
-                                  group_order=custom_grp_order)
+                                  group_order=custom_grp_order, colors=colors)
         
     # 4_RecordingsByAge and 2_NodeByAge
     age_dir = out_dir / "4B_GroupComparisons" / "4_RecordingsByAge" / "HalfViolinPlots"
@@ -1812,7 +1878,7 @@ def plot_step4_group_comparisons(
         for k, name in NETMET_REC_METRICS.items():
             plot_half_violin_by_x(df_rec_lag, k, name, "DIV",
                                   lag_age_dir / f"{k}_byDIV.{fmt}",
-                                  group_order=custom_grp_order)
+                                  group_order=custom_grp_order, colors=colors)
 
         lag_node_age_dir = node_age_dir / f"Lag{lag_str}ms" if "ms" not in str(lag_str) else node_age_dir / f"Lag{lag_str}"
         lag_node_age_dir.mkdir(parents=True, exist_ok=True)
@@ -1821,12 +1887,13 @@ def plot_step4_group_comparisons(
         for k, name in NETMET_NODE_METRICS.items():
             plot_half_violin_by_x(df_node_lag, k, name, "DIV",
                                   lag_node_age_dir / f"{k}_byDIV_node.{fmt}",
-                                  group_order=custom_grp_order)
+                                  group_order=custom_grp_order, colors=colors)
 
     # 5_GraphMetricsByLag — network metric vs. STTC lag, one figure per metric
     gmbl_dir = out_dir / "4B_GroupComparisons" / "5_GraphMetricsByLag"
-    plot_graph_metrics_by_lag(df_rec, gmbl_dir, group_order=custom_grp_order)
+    plot_graph_metrics_by_lag(df_rec, gmbl_dir, group_order=custom_grp_order,
+                              fmt=fmt, colors=colors)
 
     # 6_NodeCartographyByLag — role proportions vs DIV, one figure per lag
     ncbl_dir = out_dir / "4B_GroupComparisons" / "6_NodeCartographyByLag"
-    plot_node_cartography_by_lag(df_rec, ncbl_dir, group_order=custom_grp_order)
+    plot_node_cartography_by_lag(df_rec, ncbl_dir, group_order=custom_grp_order, fmt=fmt)

--- a/src/meanap/pipeline/render.py
+++ b/src/meanap/pipeline/render.py
@@ -40,6 +40,7 @@ import numpy as np
 
 from meanap.params import Params
 from meanap.pipeline.bundle import RunBundle
+from meanap.pipeline.palette import ColorScheme
 from meanap.pipeline.resume import ADJM_SUFFIX, CATNAP_SUFFIX
 from meanap.pipeline.spreadsheet import RecordingInfo
 
@@ -60,6 +61,26 @@ __all__ = [
     "gallery",
     "cached_figure",
     "style_from_overrides",
+    "COMPARISON_FAMILIES",
+    "COMPARISON_LEVELS",
+    "COMPARISON_SPLITS",
+    "Choice",
+    "ComparisonAxes",
+    "ComparisonFamily",
+    "LAG_SERIES",
+    "LagSeries",
+    "LevelAxis",
+    "available_comparison_families",
+    "available_lag_series",
+    "cached_lag_series_figure",
+    "lag_series",
+    "render_lag_series_figure",
+    "cached_comparison_figure",
+    "comparison_axes",
+    "comparison_family",
+    "comparison_lags",
+    "comparison_metrics",
+    "render_comparison_figure",
 ]
 
 #: Formats that produce editable vector output rather than pixels.
@@ -528,6 +549,7 @@ def render_group_family(
 
     params, _ = _apply_overrides(ctx.params, overrides)
     order = params.custom_grp_order or None
+    scheme = ColorScheme.from_params(params)
     out_root = Path(out_root)
     out_dir = out_root / fam.out_subdir
     recordings = list(ctx.recordings.values())
@@ -535,7 +557,8 @@ def render_group_family(
 
     with figure_dpi(dpi):
         if fam.key == "network":
-            plot_step4_group_comparisons(recordings, ctx.results, out_dir, order, fmt=fmt)
+            plot_step4_group_comparisons(recordings, ctx.results, out_dir, order,
+                                         fmt=fmt, colors=scheme)
         elif fam.key == "activity":
             gp.plot_twop_group_comparisons(
                 recordings, _all_stats(ctx), out_dir, custom_grp_order=order,
@@ -553,13 +576,479 @@ def render_group_family(
         elif fam.key == "ephys_activity":
             from meanap.pipeline.plotting_step2 import plot_step2_group_comparisons
             plot_step2_group_comparisons(
-                recordings, _ephys_stats(ctx), out_dir, order, fmt=fmt)
+                recordings, _ephys_stats(ctx), out_dir, order, fmt=fmt, colors=scheme)
         else:  # subnetwork
             summary, node = _subnetwork_rows(ctx)
             gp.plot_subnetwork_group_comparisons(summary, node, out_dir, order, fmt=fmt)
 
     return sorted(p for p in out_dir.rglob(f"*.{fmt}")
                   if p.is_file() and p not in before)
+
+
+# ── One comparison figure at a time ───────────────────────────────────────────
+#
+# The half-violin families (4B network metrics, 2B neuronal activity) are the
+# ones that hurt as galleries: on a three-lag run the network family alone is
+# 274 small multiples in a single scroll. But every one of them is one metric
+# at one lag, so each has an address — (level, split, lag, metric) — and can be
+# drawn on its own, exactly as a 4A figure can. That is what makes the viewer's
+# comparison tab selectable rather than a wall.
+#
+# The families below draw *nothing new*: same function, same arguments, same
+# filenames as the folder-at-a-time path. Only the reaching is different.
+
+
+@dataclass(frozen=True)
+class ComparisonFamily:
+    """A family whose figures are one metric each, and so individually addressable."""
+
+    key: str
+    #: Output subfolder for the whole step, relative to the run root.
+    out_subdir: str
+    #: The comparisons folder inside it, as the pipeline names it.
+    comparisons_dir: str
+    #: Whether its figures are per-STTC-lag. Step-2 activity metrics are not.
+    has_lag: bool
+
+
+COMPARISON_FAMILIES: tuple[ComparisonFamily, ...] = (
+    ComparisonFamily("network", "4_NetworkActivity", "4B_GroupComparisons", True),
+    ComparisonFamily("ephys_activity", "2_NeuronalActivity", "2B_GroupComparisons", False),
+)
+
+#: ``split`` → the ``x_kind`` passed to ``plot_half_violin_by_x`` and the
+#: filename stem the pipeline uses. ``group`` gives one panel per group with age
+#: along x; ``age`` gives one panel per age with group along x.
+COMPARISON_SPLITS: dict[str, tuple[str, str]] = {
+    "group": ("group", "byGroup"),
+    "age": ("DIV", "byDIV"),
+}
+
+COMPARISON_LEVELS = ("recording", "node")
+
+#: ``(level, split)`` → the folder the pipeline writes that combination to.
+_COMPARISON_DIRS: dict[tuple[str, str], str] = {
+    ("recording", "group"): "3_RecordingsByGroup/HalfViolinPlots",
+    ("node", "group"): "1_NodeByGroup",
+    ("recording", "age"): "4_RecordingsByAge/HalfViolinPlots",
+    ("node", "age"): "2_NodeByAge",
+}
+
+
+def comparison_family(key: str) -> ComparisonFamily:
+    """Look up a comparison family, or say which ones exist."""
+    fam = next((f for f in COMPARISON_FAMILIES if f.key == key), None)
+    if fam is None:
+        raise ValueError(
+            f"Unknown comparison family {key!r}; expected one of "
+            f"{[f.key for f in COMPARISON_FAMILIES]}")
+    return fam
+
+
+def comparison_metrics(family: str, level: str) -> dict[str, str]:
+    """Metric key → axis label, for one family and level.
+
+    These are the same maps the pipeline plots from, so the list a viewer offers
+    and the figures it can actually draw are one thing.
+    """
+    from meanap.pipeline.plotting_step2 import EPHYS_NODE_METRICS, EPHYS_REC_METRICS
+    from meanap.pipeline.plotting_step4 import NETMET_NODE_METRICS, NETMET_REC_METRICS
+
+    comparison_family(family)
+    if level not in COMPARISON_LEVELS:
+        raise ValueError(f"Unknown level {level!r}; expected one of {list(COMPARISON_LEVELS)}")
+    by_level = {
+        ("network", "recording"): NETMET_REC_METRICS,
+        ("network", "node"): NETMET_NODE_METRICS,
+        ("ephys_activity", "recording"): EPHYS_REC_METRICS,
+        ("ephys_activity", "node"): EPHYS_NODE_METRICS,
+    }
+    return dict(by_level[(family, level)])
+
+
+def _comparison_frames(ctx: RenderContext, family: str, order: list | None):
+    """``(df_rec, df_node)`` for a family, built once and cached on the context.
+
+    Rebuilding these means walking every recording's metrics again, which is
+    most of the cost of drawing a single comparison figure — and a viewer draws
+    a great many of them against the same bundle.
+    """
+    cache = getattr(ctx, "_comparison_frames_cache", None)
+    if cache is None:
+        cache = {}
+        object.__setattr__(ctx, "_comparison_frames_cache", cache)
+    key = (family, tuple(order) if order else None)
+    if key in cache:
+        return cache[key]
+
+    if family == "network":
+        from meanap.pipeline.plotting_step4 import netmet_comparison_frames
+        frames = netmet_comparison_frames(
+            list(ctx.recordings.values()), ctx.results, order)
+    else:
+        from meanap.pipeline.plotting_step2 import ephys_comparison_frames
+        frames = ephys_comparison_frames(
+            list(ctx.recordings.values()), _ephys_stats(ctx), order)
+    cache[key] = frames
+    return frames
+
+
+@dataclass(frozen=True)
+class Choice:
+    """One selectable value on a facet, and how to name it in a UI."""
+
+    key: str
+    label: str
+
+
+@dataclass(frozen=True)
+class LevelAxis(Choice):
+    """A level (recording or node) and the metrics it can plot."""
+
+    metrics: tuple[Choice, ...] = ()
+
+
+@dataclass(frozen=True)
+class ComparisonAxes:
+    """Everything selectable for one comparison family.
+
+    This is what turns a wall of small multiples into a set of controls: the
+    facets are the address :func:`render_comparison_figure` takes, enumerated
+    for the run in hand rather than assumed.
+    """
+
+    family: str
+    label: str
+    #: Empty for a family whose figures don't depend on the STTC lag.
+    lags: tuple[int, ...]
+    levels: tuple[LevelAxis, ...]
+    splits: tuple[Choice, ...]
+
+
+_LEVEL_LABELS = {"recording": "Recording level", "node": "Node level"}
+_SPLIT_LABELS = {"group": "By group", "age": "By age"}
+
+
+def available_comparison_families(ctx: RenderContext) -> list[ComparisonFamily]:
+    """Which comparison families this run has the numbers for.
+
+    The same availability test :func:`available_group_families` applies — a
+    family with no data behind it must not be offered as a tab that renders
+    nothing.
+    """
+    out = []
+    for fam in COMPARISON_FAMILIES:
+        if fam.key == "network" and ctx.results:
+            out.append(fam)
+        elif fam.key == "ephys_activity" and _ephys_stats(ctx):
+            out.append(fam)
+    return out
+
+
+def comparison_axes(ctx: RenderContext, family: str) -> ComparisonAxes:
+    """The facets a viewer should offer for *family*, for this run.
+
+    Every metric the family defines is listed, present in the data or not,
+    because the pipeline writes a figure for each either way — an absent metric
+    gets the same "no data" placeholder here that it gets in the output folder.
+    A *level* with no rows at all is dropped, since nothing there can be drawn.
+    """
+    fam = comparison_family(family)
+    label = next((f.label for f in GROUP_FAMILIES if f.key == family), family)
+    frames = dict(zip(COMPARISON_LEVELS, _comparison_frames(
+        ctx, family, ctx.params.custom_grp_order or None)))
+
+    levels = tuple(
+        LevelAxis(
+            key=level, label=_LEVEL_LABELS[level],
+            metrics=tuple(Choice(key=k, label=v)
+                          for k, v in comparison_metrics(family, level).items()),
+        )
+        for level in COMPARISON_LEVELS if not frames[level].empty
+    )
+    return ComparisonAxes(
+        family=family, label=label,
+        lags=tuple(comparison_lags(ctx, family)),
+        levels=levels,
+        splits=tuple(Choice(key=k, label=_SPLIT_LABELS[k]) for k in COMPARISON_SPLITS),
+    )
+
+
+def comparison_lags(ctx: RenderContext, family: str = "network") -> list[int]:
+    """The lags this family's figures exist at, in ms. Empty for a lagless family."""
+    from meanap.pipeline.plotting_step4 import _lag_num
+
+    fam = comparison_family(family)
+    if not fam.has_lag:
+        return []
+    df_rec, _ = _comparison_frames(ctx, family, None)
+    if df_rec.empty or "Lag" not in df_rec.columns:
+        return []
+    return sorted({_lag_num(v) for v in df_rec["Lag"].unique()})
+
+
+def render_comparison_figure(
+    ctx: RenderContext,
+    family: str,
+    level: str,
+    split: str,
+    metric: str,
+    out_dir: Path | str,
+    *,
+    lag: int | None = None,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> Path:
+    """Redraw one comparison figure and return the file written.
+
+    The address is ``(family, level, split, lag, metric)``: which comparison set
+    (4B network metrics or 2B neuronal activity), whether the points are
+    recordings or nodes, whether groups or ages are the panels, which STTC lag,
+    and which metric.
+
+    The file is written to the same relative path, under the same name, that
+    :func:`render_group_family` would have written it to — so the two paths are
+    directly comparable, and the pixel-parity test can hold them to it.
+
+    Raises :class:`ValueError` on any address the bundle cannot draw, naming
+    what is available instead.
+    """
+    from meanap.pipeline.figure_output import figure_dpi
+    from meanap.pipeline.plotting_step4 import _lag_num, plot_half_violin_by_x
+
+    fam = comparison_family(family)
+    if split not in COMPARISON_SPLITS:
+        raise ValueError(
+            f"Unknown split {split!r}; expected one of {list(COMPARISON_SPLITS)}")
+    metrics = comparison_metrics(family, level)  # also validates level
+    if metric not in metrics:
+        raise ValueError(
+            f"Unknown {level}-level metric {metric!r} for the {family} family. "
+            f"Use comparison_metrics() to list them.")
+
+    # Everything decidable from the address alone is settled before any data is
+    # touched, so a malformed request gets the error about the request rather
+    # than one about the bundle being empty.
+    if not fam.has_lag and lag is not None:
+        raise ValueError(
+            f"The {family} comparison figures do not depend on the STTC lag, so "
+            f"lag={lag} has no meaning here; omit it.")
+
+    params, _ = _apply_overrides(ctx.params, overrides)
+    order = params.custom_grp_order or None
+    df_rec, df_node = _comparison_frames(ctx, family, order)
+    df = df_rec if level == "recording" else df_node
+    if df.empty:
+        raise ValueError(
+            f"This bundle has no {level}-level data for the {family} comparison "
+            f"family, so there is nothing to draw.")
+
+    x_kind, stem = COMPARISON_SPLITS[split]
+    dest_dir = Path(out_dir) / fam.out_subdir / fam.comparisons_dir / _COMPARISON_DIRS[
+        (level, split)]
+
+    if fam.has_lag:
+        available = sorted({_lag_num(v) for v in df["Lag"].unique()})
+        if lag is None:
+            raise ValueError(
+                f"The {family} comparison figures are per-lag; pass one of "
+                f"{available} ms.")
+        if lag not in available:
+            raise ValueError(
+                f"No {family} results at {lag} ms lag; this run has {available} ms.")
+        df = df[df["Lag"].map(_lag_num) == lag]
+        dest_dir = dest_dir / f"Lag{lag}ms"
+
+    suffix = "_node" if level == "node" else ""
+    dest = dest_dir / f"{metric}_{stem}{suffix}.{fmt}"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    with figure_dpi(dpi):
+        plot_half_violin_by_x(df, metric, metrics[metric], x_kind, dest,
+                              group_order=order, colors=ColorScheme.from_params(params))
+
+    if not dest.is_file():
+        raise ValueError(
+            f"Nothing was drawn for {metric} ({level}, by {split}) — the "
+            f"selection matched no recordings.")
+    return dest
+
+
+# ── Across-lag figures ────────────────────────────────────────────────────────
+#
+# Two sets whose subject is the lag itself rather than a slice at one lag, so
+# neither belongs under the comparison facets: graph metrics *against* lag (one
+# figure per metric), and cartography role proportions per lag (one per lag).
+
+
+@dataclass(frozen=True)
+class LagSeries:
+    """An across-lag figure set: what it is keyed by, and where it lands."""
+
+    key: str
+    label: str
+    out_subdir: str
+    #: What one figure is addressed by — a metric name, or a lag in ms.
+    keyed_by: str
+
+
+LAG_SERIES: tuple[LagSeries, ...] = (
+    LagSeries("graph_metrics", "Graph metrics by lag",
+              "4_NetworkActivity/4B_GroupComparisons/5_GraphMetricsByLag", "metric"),
+    LagSeries("cartography", "Node cartography by lag",
+              "4_NetworkActivity/4B_GroupComparisons/6_NodeCartographyByLag", "lag"),
+)
+
+
+def lag_series(key: str) -> LagSeries:
+    """Look up an across-lag set, or say which ones exist."""
+    series = next((s for s in LAG_SERIES if s.key == key), None)
+    if series is None:
+        raise ValueError(
+            f"Unknown across-lag set {key!r}; expected one of "
+            f"{[s.key for s in LAG_SERIES]}")
+    return series
+
+
+def available_lag_series(ctx: RenderContext) -> list[tuple[LagSeries, tuple[Choice, ...]]]:
+    """The across-lag sets this run can draw, each with its selectable keys.
+
+    Both need more than one lag to say anything, and cartography additionally
+    needs the ``NCpn1``-``NCpn6`` role proportions, which a run without node
+    cartography does not have. Offering either without its inputs would be a
+    control that renders an empty page.
+    """
+    lags = comparison_lags(ctx, "network")
+    if len(lags) < 2:
+        return []
+    df_rec, _ = _comparison_frames(ctx, "network", ctx.params.custom_grp_order or None)
+    out = []
+    for series in LAG_SERIES:
+        if series.keyed_by == "metric":
+            present = [Choice(key=k, label=v)
+                       for k, v in comparison_metrics("network", "recording").items()
+                       if k in df_rec.columns and df_rec[k].notna().any()]
+        else:
+            has_roles = all(f"NCpn{i}" in df_rec.columns for i in range(1, 7))
+            present = ([Choice(key=str(lag), label=f"{lag} ms") for lag in lags]
+                       if has_roles else [])
+        if present:
+            out.append((series, tuple(present)))
+    return out
+
+
+def render_lag_series_figure(
+    ctx: RenderContext,
+    series: str,
+    key: str,
+    out_dir: Path | str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> Path:
+    """Redraw one across-lag figure — a metric's lag curve, or one lag's roles.
+
+    Written to the same relative path and name the pipeline uses, as
+    :func:`render_comparison_figure` is.
+    """
+    from meanap.pipeline.figure_output import figure_dpi
+    from meanap.pipeline.plotting_step4 import (
+        plot_graph_metrics_by_lag, plot_node_cartography_by_lag,
+    )
+
+    spec = lag_series(series)
+    params, _ = _apply_overrides(ctx.params, overrides)
+    order = params.custom_grp_order or None
+    scheme = ColorScheme.from_params(params)
+    df_rec, _ = _comparison_frames(ctx, "network", order)
+    if df_rec.empty:
+        raise ValueError("This bundle has no network metrics, so there is nothing "
+                         "to plot against lag.")
+
+    dest_dir = Path(out_dir) / spec.out_subdir
+    with figure_dpi(dpi):
+        if spec.keyed_by == "metric":
+            if key not in comparison_metrics("network", "recording"):
+                raise ValueError(
+                    f"Unknown recording-level metric {key!r}. Use "
+                    f"available_lag_series() to list what this run can plot.")
+            written = plot_graph_metrics_by_lag(
+                df_rec, dest_dir, group_order=order, only=key, fmt=fmt, colors=scheme)
+        else:
+            try:
+                lag = int(key)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"The {series} set is keyed by lag in ms; {key!r} is not a "
+                    f"number.") from None
+            available = comparison_lags(ctx, "network")
+            if lag not in available:
+                raise ValueError(
+                    f"No results at {lag} ms lag; this run has {available} ms.")
+            written = plot_node_cartography_by_lag(
+                df_rec, dest_dir, group_order=order, only=lag, fmt=fmt)
+
+    if not written:
+        raise ValueError(
+            f"Nothing was drawn for {key!r} in the {series} set — this run has no "
+            f"finite values for it.")
+    return written[0]
+
+
+def cached_lag_series_figure(
+    ctx: RenderContext,
+    cache,
+    series: str,
+    key: str,
+    *,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> tuple[Path, bool]:
+    """One across-lag figure, rendered once per address and cached."""
+    from meanap.pipeline.render_cache import bundle_identity, cache_key
+
+    cache_id = cache_key(bundle_identity(ctx.root), f"lag:{series}:{key}",
+                         fmt=fmt, dpi=dpi, overrides=overrides)
+    files, was_cached = cache.get_or_render(
+        cache_id,
+        lambda dest: [render_lag_series_figure(
+            ctx, series, key, dest, fmt=fmt, dpi=dpi, overrides=overrides)],
+    )
+    return files[0], was_cached
+
+
+def cached_comparison_figure(
+    ctx: RenderContext,
+    cache,
+    family: str,
+    level: str,
+    split: str,
+    metric: str,
+    *,
+    lag: int | None = None,
+    fmt: str = "png",
+    dpi: int | None = None,
+    overrides: dict | None = None,
+) -> tuple[Path, bool]:
+    """One comparison figure, rendered once per address and cached.
+
+    Returns ``(path, was_cached)``, like :func:`cached_figure`.
+    """
+    from meanap.pipeline.render_cache import bundle_identity, cache_key
+
+    key = cache_key(bundle_identity(ctx.root),
+                    f"cmp:{family}:{level}:{split}:{lag}:{metric}",
+                    fmt=fmt, dpi=dpi, overrides=overrides)
+    files, was_cached = cache.get_or_render(
+        key,
+        lambda dest: [render_comparison_figure(
+            ctx, family, level, split, metric, dest,
+            lag=lag, fmt=fmt, dpi=dpi, overrides=overrides)],
+    )
+    return files[0], was_cached
 
 
 def cached_figure(

--- a/src/meanap/viewer/controls.py
+++ b/src/meanap/viewer/controls.py
@@ -20,7 +20,18 @@ from meanap.network_plot import (
     EDGE_THRESHOLD_METHODS, LAYOUT_OPTIONS, NetworkStyle,
 )
 
-__all__ = ["CONTROLS", "Control", "control_schema", "parse_overrides"]
+__all__ = [
+    "COMPARISON_CONTROLS", "CONTROLS", "Control", "comparison_control_schema",
+    "control_schema", "parse_comparison_overrides", "parse_overrides",
+]
+
+#: Imported lazily-by-value so this module stays importable without matplotlib
+#: being touched at import time; the names are a closed set either way.
+_AGE_SCHEME_NAMES = (
+    "viridis", "viridis_r", "plasma", "plasma_r", "cividis", "magma",
+    "inferno", "grey",
+)
+_GROUP_SCHEME_NAMES = ("meanap", "okabe-ito", "tab10", "grey")
 
 #: Colormaps offered for the node-colour metric. Perceptually uniform ones
 #: first — they are the defensible choice for a continuous metric — with the
@@ -55,6 +66,16 @@ class Control:
                 raise ValueError(
                     f"{self.key}: {raw!r} is not one of {self.options}")
             return raw
+        if self.kind == "colors":
+            # A list of colours, however the user typed it. Validated here so a
+            # typo comes back as a 400 naming it, not a matplotlib traceback.
+            from meanap.pipeline.palette import parse_colors
+
+            try:
+                parse_colors(raw)
+            except ValueError as e:
+                raise ValueError(f"{self.key}: {e}") from None
+            return [c for c in raw.replace(",", " ").split() if c]
         value = float(raw)
         if self.minimum is not None and value < self.minimum:
             raise ValueError(f"{self.key}: {value} is below {self.minimum}")
@@ -98,16 +119,65 @@ CONTROLS: tuple[Control, ...] = (
 )
 
 
+#: Controls for the group-level (2B/4B) comparison figures. A separate set from
+#: :data:`CONTROLS` because they map onto ``Params`` fields the violin and line
+#: plots read, not onto ``NetworkStyle`` — the two panels are never shown at
+#: once, and mixing them would offer node-size knobs on a violin plot.
+COMPARISON_CONTROLS: tuple[Control, ...] = (
+    Control("age_color_scheme", "Age colours", "select", "viridis",
+            options=list(_AGE_SCHEME_NAMES),
+            help="Ages are ordered, so they take a sequential colormap. "
+                 "'_r' reverses which end is oldest."),
+    Control("age_colors", "Custom age colours", "colors", [],
+            help="Overrides the scheme. Hex codes or names, comma-separated, "
+                 "oldest last. Cycles if you give fewer than there are ages."),
+    Control("group_color_scheme", "Group colours", "select", "meanap",
+            options=list(_GROUP_SCHEME_NAMES),
+            help="Groups are unordered, so they take a categorical palette. "
+                 "'okabe-ito' stays distinguishable with colour-vision deficiency."),
+    Control("group_colors", "Custom group colours", "colors", [],
+            help="Overrides the scheme, in the group order on the Paths tab."),
+)
+
+
 def control_schema() -> list[dict]:
     """The controls as plain data, for the page to build its form from."""
+    return _schema(CONTROLS)
+
+
+def comparison_control_schema() -> list[dict]:
+    """The comparison-figure controls, as plain data."""
+    return _schema(COMPARISON_CONTROLS)
+
+
+def _schema(controls) -> list[dict]:
     return [
         {
             "key": c.key, "label": c.label, "kind": c.kind, "default": c.default,
             "options": c.options, "min": c.minimum, "max": c.maximum,
             "step": c.step, "help": c.help,
         }
-        for c in CONTROLS
+        for c in controls
     ]
+
+
+def parse_comparison_overrides(query: dict[str, list[str]]) -> dict:
+    """Extract the colour overrides for a comparison or across-lag figure.
+
+    Same contract as :func:`parse_overrides`: only non-default values come
+    back, so an unstyled request builds no override at all and stays
+    byte-identical to the pipeline's figure.
+    """
+    overrides: dict = {}
+    for control in COMPARISON_CONTROLS:
+        raw = query.get(control.key, [None])[0]
+        if raw is None or raw == "":
+            continue
+        value = control.coerce(raw)
+        if value == control.default:
+            continue
+        overrides[control.key] = value
+    return overrides
 
 
 def parse_overrides(query: dict[str, list[str]]) -> dict:

--- a/src/meanap/viewer/page.py
+++ b/src/meanap/viewer/page.py
@@ -4,16 +4,26 @@ Kept as one self-contained string — no build step, no external assets, no CDN.
 A bundle gets shared with people who will run one command and expect a page;
 anything that needs npm or a network fetch fails that test.
 
-Two views, and the difference between them is the point:
+Three tabs, because a run holds three different kinds of question:
 
-* **A recording's figure** — one spatial network plot at a time, with the full
-  Network Viewer control set live beside it. Every change re-requests the
-  figure from Python, so what is on screen is always something the pipeline
-  could have drawn.
-* **A comparison family** — a gallery of small multiples. The controls are
-  *hidden* here, not disabled: they style spatial network plots, and none of
-  the violin plots in these families read them. A greyed-out panel would still
-  imply the knobs mean something for this view.
+* **Recordings** — one spatial network plot at a time, with the full Network
+  Viewer control set live beside it. Every change re-requests the figure from
+  Python, so what is on screen is always something the pipeline could have
+  drawn.
+* **Comparisons** — the 2B/4B half-violin sets. These used to be a gallery of
+  every small multiple at once: 274 of them on a three-lag run, in one scroll,
+  with the only organisation in the caption text. They are now selected by the
+  address each figure actually has — lag, level, split, metric — and drawn one
+  at a time. The CAT-NAP families that have no such address stay galleries,
+  listed separately so the difference is visible rather than surprising.
+* **Across lags** — the two sets whose subject is the lag itself: each metric's
+  curve against lag, and the cartography roles at each lag. They answer a
+  different question from anything sliced at one lag, so they get their own
+  tab rather than sitting among figures that are all one lag deep.
+
+The styling controls are *hidden* outside the Recordings tab, not disabled:
+they style spatial network plots, and no violin or line plot reads them. A
+greyed-out panel would still imply the knobs mean something there.
 """
 
 PAGE_HTML = r"""<!doctype html>
@@ -37,19 +47,40 @@ PAGE_HTML = r"""<!doctype html>
   body {
     margin: 0; background: var(--bg); color: var(--fg);
     font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    display: grid; grid-template-columns: 260px 1fr 280px; height: 100vh;
+    display: grid; height: 100vh;
+    grid-template-columns: 260px 1fr 280px;
+    grid-template-rows: auto 1fr;
+    grid-template-areas: "tabs tabs tabs" "left main right";
   }
-  @media (max-width: 900px) { body { grid-template-columns: 1fr; height: auto; } }
+  @media (max-width: 900px) {
+    body { grid-template-columns: 1fr; grid-template-rows: auto auto auto auto;
+           grid-template-areas: "tabs" "left" "main" "right"; height: auto; }
+  }
 
-  aside { border-right: 1px solid var(--line); overflow-y: auto; padding: 16px; }
-  aside.right { border-right: none; border-left: 1px solid var(--line); }
-  main { overflow-y: auto; padding: 20px 24px; min-width: 0; }
+  #tabs { grid-area: tabs; display: flex; gap: 4px; align-items: center;
+    border-bottom: 1px solid var(--line); padding: 0 14px; background: var(--panel); }
+  #tabs .brand { font-size: 13px; font-weight: 600; margin-right: 14px;
+    padding: 10px 0; letter-spacing: -0.01em; }
+  #tabs button { width: auto; background: transparent; border: none;
+    border-bottom: 2px solid transparent; border-radius: 0; padding: 11px 14px;
+    color: var(--muted); font-weight: 500; }
+  #tabs button:hover { color: var(--fg); }
+  #tabs button[aria-selected="true"] {
+    color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+  #tabs .spacer { flex: 1; }
+  #tabs .src { color: var(--muted); font-size: 12px; padding-right: 4px;
+    overflow-wrap: anywhere; max-width: 40ch; text-align: right; }
 
-  h1 { font-size: 15px; margin: 0 0 2px; letter-spacing: -0.01em; }
-  .sub { color: var(--muted); font-size: 12px; margin-bottom: 18px;
+  aside { overflow-y: auto; padding: 16px; }
+  aside.left { grid-area: left; border-right: 1px solid var(--line); }
+  aside.right { grid-area: right; border-left: 1px solid var(--line); }
+  main { grid-area: main; overflow-y: auto; padding: 20px 24px; min-width: 0; }
+
+  .sub { color: var(--muted); font-size: 12px; margin-bottom: 14px;
          overflow-wrap: anywhere; }
   h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
        color: var(--muted); margin: 18px 0 8px; font-weight: 600; }
+  h2:first-child { margin-top: 0; }
 
   select, input, button { font: inherit; color: inherit; background: var(--bg);
     border: 1px solid var(--line); border-radius: 6px; padding: 5px 7px; width: 100%; }
@@ -66,9 +97,10 @@ PAGE_HTML = r"""<!doctype html>
   .list button[aria-current="true"] {
     background: var(--accent-soft); border-color: var(--accent); font-weight: 600; }
 
-  figure { margin: 0; }
+  figure { margin: 0 0 20px; }
   figure img { max-width: 100%; height: auto; display: block;
     border: 1px solid var(--line); border-radius: 8px; background: #fff; }
+  figure figcaption { font-size: 12px; color: var(--muted); margin-top: 6px; }
   .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
          margin-bottom: 14px; }
   .row button { width: auto; }
@@ -78,7 +110,7 @@ PAGE_HTML = r"""<!doctype html>
   .gallery { display: grid; gap: 14px;
     grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); }
   .gallery figure { border: 1px solid var(--line); border-radius: 8px;
-    padding: 8px; background: var(--panel); }
+    padding: 8px; background: var(--panel); margin: 0; }
   .gallery img { border: none; border-radius: 4px; }
   .gallery figcaption { font-size: 11px; color: var(--muted); margin-top: 6px;
     overflow-wrap: anywhere; }
@@ -89,23 +121,45 @@ PAGE_HTML = r"""<!doctype html>
 </head>
 <body>
 
-<aside>
-  <h1>MEA-NAP viewer</h1>
-  <div class="sub" id="source">loading…</div>
+<nav id="tabs">
+  <span class="brand">MEA-NAP viewer</span>
+  <button id="tab-recordings" data-tab="recordings" aria-selected="true">Recordings</button>
+  <button id="tab-comparisons" data-tab="comparisons" aria-selected="false">Comparisons</button>
+  <button id="tab-lags" data-tab="lags" aria-selected="false">Across lags</button>
+  <span class="spacer"></span>
+  <span class="src" id="source">loading…</span>
+</nav>
 
-  <h2>Recording</h2>
-  <select id="recording"></select>
-  <h2>Lag</h2>
-  <select id="lag"></select>
+<aside class="left">
+  <div id="side-recordings">
+    <h2>Recording</h2>
+    <select id="recording"></select>
+    <h2>Lag</h2>
+    <select id="lag"></select>
 
-  <h2>Network figures</h2>
-  <div class="list" id="figures"></div>
+    <h2>Network figures</h2>
+    <div class="list" id="figures"></div>
 
-  <h2>Activity figures</h2>
-  <div class="list" id="activity"></div>
+    <h2>Activity figures</h2>
+    <div class="list" id="activity"></div>
+  </div>
 
-  <h2>Comparisons</h2>
-  <div class="list" id="families"></div>
+  <div id="side-comparisons" class="hidden">
+    <h2>Comparison set</h2>
+    <select id="cmp-family"></select>
+    <h2>Metric</h2>
+    <div class="list" id="cmp-metrics"></div>
+    <h2>Galleries</h2>
+    <p class="sub">Sets that have no per-figure address — shown all at once.</p>
+    <div class="list" id="families"></div>
+  </div>
+
+  <div id="side-lags" class="hidden">
+    <h2>Figure set</h2>
+    <div class="list" id="lag-series"></div>
+    <h2 id="lag-options-head">Figures</h2>
+    <div class="list" id="lag-options"></div>
+  </div>
 </aside>
 
 <main>
@@ -118,6 +172,7 @@ PAGE_HTML = r"""<!doctype html>
   </div>
   <div class="err" id="error"></div>
   <figure id="single"><img id="figure-img" alt=""></figure>
+  <div id="pair" class="hidden"></div>
   <div class="gallery hidden" id="gallery"></div>
 </main>
 
@@ -130,14 +185,47 @@ PAGE_HTML = r"""<!doctype html>
   </p>
 </aside>
 
+<aside class="right hidden" id="facets-panel">
+  <h2 id="facets-head">Facets</h2>
+  <label id="cmp-lag-label"><span class="l">Lag</span>
+    <select id="cmp-lag"></select></label>
+  <label id="cmp-level-label"><span class="l">Level</span>
+    <select id="cmp-level"></select>
+    <small>Each point is one recording, or one node.</small></label>
+  <label id="cmp-split-label"><span class="l">Split</span>
+    <select id="cmp-split"></select>
+    <small>Which factor becomes the panels.</small></label>
+  <h2>Colours</h2>
+  <div id="cmp-controls"></div>
+  <button id="cmp-reset">Reset to pipeline defaults</button>
+  <p class="sub" style="margin-top:12px">
+    These are the figures the pipeline writes to 4B/2B, drawn one at a time.
+    Defaults reproduce them exactly.
+  </p>
+</aside>
+
 <script>
 const $ = (id) => document.getElementById(id);
 let MANIFEST = null;
-let VIEW = { kind: "figure", rec: null, lag: null, name: null, family: null };
-// "figure"   — a network plot, per recording + lag, restylable
-// "activity" — a step-2 plot, per recording only; the network controls don't
-//              apply to a raster or a heatmap, so they are hidden for it
-// "family"   — a gallery of small multiples
+let TAB = "recordings";
+// One selection per tab, never a shared field: the tabs are filled before any
+// of them is shown, so a name that means "network figure" on one tab and
+// "metric" on another gets overwritten during startup and the first render
+// asks for a figure that doesn't exist.
+let VIEW = {
+  kind: "figure",
+  rec: null, lag: null, name: null,   // Recordings
+  family: null, metric: null,         // Comparisons
+  series: null, key: null,            // Across lags
+  gallery: null,                      // a family shown as a gallery
+};
+// "figure"     — a network plot, per recording + lag, restylable
+// "activity"   — a step-2 plot, per recording only; the network controls don't
+//                apply to a raster or a heatmap, so they are hidden for it
+// "comparison" — one 2B/4B half-violin, addressed by lag/level/split/metric
+// "both"       — the same metric drawn by group and by age, stacked
+// "lagseries"  — one across-lag figure
+// "family"     — a gallery of small multiples, for sets with no address
 
 async function getJSON(url) {
   const r = await fetch(url);
@@ -145,6 +233,8 @@ async function getJSON(url) {
   if (!r.ok) throw new Error(j.error || r.statusText);
   return j;
 }
+
+/* ── Recordings tab ─────────────────────────────────────────────────────── */
 
 function overrideParams() {
   const p = new URLSearchParams();
@@ -161,6 +251,15 @@ function figureURL(extra = {}) {
     const p = new URLSearchParams({rec: VIEW.rec, name: VIEW.name});
     for (const [k, v] of Object.entries(extra)) p.set(k, v);
     return "/api/activity?" + p.toString();
+  }
+  if (VIEW.kind === "lagseries") {
+    const p = colorParams();
+    p.set("series", VIEW.series); p.set("key", VIEW.key);
+    for (const [k, v] of Object.entries(extra)) p.set(k, v);
+    return "/api/lagseries?" + p.toString();
+  }
+  if (VIEW.kind === "comparison" || VIEW.kind === "both") {
+    return comparisonURL(extra.split || $("cmp-split").value, extra);
   }
   const p = overrideParams();
   p.set("rec", VIEW.rec); p.set("lag", VIEW.lag); p.set("name", VIEW.name);
@@ -199,6 +298,68 @@ function buildControls() {
                   label.appendChild(s); }
     box.appendChild(label);
   }
+}
+
+function buildComparisonControls() {
+  const box = $("cmp-controls");
+  box.innerHTML = "";
+  for (const c of (MANIFEST.comparison_controls || [])) {
+    const label = document.createElement("label");
+    const name = document.createElement("span");
+    name.className = "l"; name.textContent = c.label;
+    label.appendChild(name);
+
+    let el;
+    if (c.kind === "select") {
+      el = document.createElement("select");
+      for (const opt of c.options) {
+        const o = document.createElement("option");
+        o.value = opt; o.textContent = opt; el.appendChild(o);
+      }
+      el.value = c.default;
+    } else {
+      // A free-text list of colours. Applied on change rather than per
+      // keystroke, so a half-typed hex code doesn't render as an error.
+      el = document.createElement("input");
+      el.type = "text";
+      el.placeholder = "#1f77b4, crimson, …";
+      el.value = "";
+    }
+    el.id = "cmp-ctl-" + c.key;
+    el.addEventListener("change", showComparisonOrLagSeries);
+    label.appendChild(el);
+    if (c.help) { const s = document.createElement("small"); s.textContent = c.help;
+                  label.appendChild(s); }
+    box.appendChild(label);
+  }
+}
+
+function colorParams() {
+  const p = new URLSearchParams();
+  for (const c of (MANIFEST.comparison_controls || [])) {
+    const el = $("cmp-ctl-" + c.key);
+    if (!el) continue;
+    const value = String(el.value).trim();
+    if (!value || value === String(c.default)) continue;
+    p.set(c.key, value);
+  }
+  return p;
+}
+
+function resetComparisonControls() {
+  for (const c of (MANIFEST.comparison_controls || [])) {
+    const el = $("cmp-ctl-" + c.key);
+    if (el) el.value = c.kind === "select" ? c.default : "";
+  }
+  showComparisonOrLagSeries();
+}
+
+// The colours apply to both the faceted comparisons and the across-lag
+// figures, and the panel is reachable from either, so one handler re-renders
+// whichever is on screen.
+function showComparisonOrLagSeries() {
+  if (VIEW.kind === "lagseries") showLagSeries();
+  else showComparison();
 }
 
 function resetControls() {
@@ -252,7 +413,7 @@ function fillActivity() {
     b.textContent = f.label;
     b.dataset.activity = f.name;
     b.addEventListener("click", () => {
-      VIEW = { kind: "activity", rec: rec.name, lag: null, name: f.name, family: null };
+      VIEW.kind = "activity"; VIEW.rec = rec.name; VIEW.name = f.name;
       showFigure();
     });
     box.appendChild(b);
@@ -274,29 +435,241 @@ function fillFigures() {
     b.textContent = f.label;
     b.dataset.name = f.name;
     b.addEventListener("click", () => {
-      VIEW = { kind: "figure", rec: rec.name, lag: lag, name: f.name, family: null };
+      VIEW.kind = "figure"; VIEW.rec = rec.name; VIEW.lag = lag; VIEW.name = f.name;
       showFigure();
     });
     box.appendChild(b);
   }
-  // Open the first figure so the page is never blank.
+  // Open the first figure so the tab is never blank.
   if (!VIEW.name || VIEW.kind !== "figure" ||
       !figs.some((f) => f.name === VIEW.name)) {
-    VIEW = { kind: "figure", rec: rec.name, lag: lag, name: figs[0].name, family: null };
+    VIEW.kind = "figure"; VIEW.rec = rec.name; VIEW.lag = lag;
+    VIEW.name = figs[0].name;
   } else {
     VIEW.rec = rec.name; VIEW.lag = lag;
   }
-  showFigure();
+  if (TAB === "recordings") showFigure();
 }
+
+/* ── Comparisons tab ────────────────────────────────────────────────────── */
+
+function currentComparison() {
+  return (MANIFEST.comparisons || []).find((c) => c.key === $("cmp-family").value);
+}
+
+function currentLevel() {
+  const fam = currentComparison();
+  if (!fam) return null;
+  return fam.levels.find((l) => l.key === $("cmp-level").value) || fam.levels[0];
+}
+
+function fillComparisonFamilies() {
+  const sel = $("cmp-family");
+  sel.innerHTML = "";
+  for (const fam of (MANIFEST.comparisons || [])) {
+    const o = document.createElement("option");
+    o.value = fam.key; o.textContent = fam.label;
+    sel.appendChild(o);
+  }
+  fillComparisonFacets();
+}
+
+function fillComparisonFacets() {
+  const fam = currentComparison();
+  if (!fam) {
+    $("cmp-metrics").innerHTML = '<div class="sub">Nothing to compare in this bundle.</div>';
+    return;
+  }
+  // A lagless family (step-2 activity) hides the control rather than showing
+  // one with nothing in it.
+  const lagSel = $("cmp-lag");
+  const keepLag = lagSel.value;
+  lagSel.innerHTML = "";
+  for (const lag of fam.lags) {
+    const o = document.createElement("option");
+    o.value = lag; o.textContent = lag + " ms";
+    lagSel.appendChild(o);
+  }
+  if (fam.lags.map(String).includes(keepLag)) lagSel.value = keepLag;
+  $("cmp-lag-label").classList.toggle("hidden", !fam.lags.length);
+
+  const levelSel = $("cmp-level");
+  const keepLevel = levelSel.value;
+  levelSel.innerHTML = "";
+  for (const level of fam.levels) {
+    const o = document.createElement("option");
+    o.value = level.key; o.textContent = level.label;
+    levelSel.appendChild(o);
+  }
+  if (fam.levels.some((l) => l.key === keepLevel)) levelSel.value = keepLevel;
+
+  const splitSel = $("cmp-split");
+  const keepSplit = splitSel.value;
+  splitSel.innerHTML = "";
+  for (const split of fam.splits) {
+    const o = document.createElement("option");
+    o.value = split.key; o.textContent = split.label;
+    splitSel.appendChild(o);
+  }
+  const both = document.createElement("option");
+  both.value = "both"; both.textContent = "Both";
+  splitSel.appendChild(both);
+  if (keepSplit) splitSel.value = keepSplit;
+
+  fillComparisonMetrics();
+}
+
+function fillComparisonMetrics() {
+  const level = currentLevel();
+  const box = $("cmp-metrics");
+  box.innerHTML = "";
+  if (!level) return;
+  for (const m of level.metrics) {
+    const b = document.createElement("button");
+    b.textContent = m.label;
+    b.title = m.name;
+    b.dataset.metric = m.name;
+    b.addEventListener("click", () => { VIEW.metric = m.name; showComparison(); });
+    box.appendChild(b);
+  }
+  // Keep the chosen metric across a level change when it exists at both
+  // levels; otherwise fall back to the first, so the pane is never blank.
+  if (!level.metrics.some((m) => m.name === VIEW.metric)) {
+    VIEW.metric = level.metrics.length ? level.metrics[0].name : null;
+  }
+  if (TAB === "comparisons") showComparison();
+}
+
+function comparisonURL(split, extra = {}) {
+  const fam = currentComparison();
+  const p = colorParams();
+  p.set("family", fam.key); p.set("level", $("cmp-level").value);
+  p.set("split", split); p.set("metric", VIEW.metric);
+  if (fam.lags.length) p.set("lag", $("cmp-lag").value);
+  for (const [k, v] of Object.entries(extra)) if (k !== "split") p.set(k, v);
+  return "/api/comparison?" + p.toString();
+}
+
+function showComparison() {
+  const fam = currentComparison();
+  if (!fam || !VIEW.metric) return;
+  const split = $("cmp-split").value;
+  VIEW.kind = split === "both" ? "both" : "comparison";
+  VIEW.family = fam.key;
+  setMode(VIEW.kind); markCurrent();
+  $("error").textContent = "";
+
+  const splits = split === "both" ? fam.splits.map((s) => s.key) : [split];
+  const labels = Object.fromEntries(fam.splits.map((s) => [s.key, s.label]));
+  const box = $("pair");
+  box.innerHTML = "";
+  $("status").textContent = "rendering…";
+  let pending = splits.length;
+
+  for (const s of splits) {
+    const fig = document.createElement("figure");
+    const img = document.createElement("img");
+    img.alt = `${VIEW.metric} — ${labels[s]}`;
+    img.src = comparisonURL(s);
+    img.onload = () => {
+      if (--pending === 0) {
+        $("status").textContent = split === "both"
+          ? `${VIEW.metric} — both splits (pick one to download)`
+          : `${VIEW.metric} — ${labels[s]}`;
+      }
+    };
+    img.onerror = () => {
+      $("status").textContent = "";
+      $("error").textContent = "Could not render this comparison.";
+    };
+    const cap = document.createElement("figcaption");
+    cap.textContent = labels[s];
+    fig.appendChild(img); fig.appendChild(cap);
+    box.appendChild(fig);
+  }
+}
+
+/* ── Across-lags tab ────────────────────────────────────────────────────── */
+
+function currentSeries() {
+  return (MANIFEST.lag_series || []).find((s) => s.key === VIEW.series);
+}
+
+function fillLagSeries() {
+  const box = $("lag-series");
+  box.innerHTML = "";
+  const sets = MANIFEST.lag_series || [];
+  if (!sets.length) {
+    box.innerHTML = '<div class="sub">This run has one lag, so there is ' +
+                    'nothing to plot against lag.</div>';
+    $("lag-options").innerHTML = "";
+    return;
+  }
+  for (const s of sets) {
+    const b = document.createElement("button");
+    b.textContent = s.label;
+    b.dataset.series = s.key;
+    b.addEventListener("click", () => { VIEW.series = s.key; VIEW.key = null;
+                                        fillLagOptions(); });
+    box.appendChild(b);
+  }
+  if (!sets.some((s) => s.key === VIEW.series)) VIEW.series = sets[0].key;
+  fillLagOptions();
+}
+
+function fillLagOptions() {
+  const series = currentSeries();
+  const box = $("lag-options");
+  box.innerHTML = "";
+  if (!series) return;
+  $("lag-options-head").textContent = series.keyed_by === "lag" ? "Lag" : "Metric";
+  for (const opt of series.options) {
+    const b = document.createElement("button");
+    b.textContent = opt.label;
+    b.dataset.key = opt.key;
+    b.addEventListener("click", () => { VIEW.key = opt.key; showLagSeries(); });
+    box.appendChild(b);
+  }
+  if (!series.options.some((o) => o.key === VIEW.key)) {
+    VIEW.key = series.options.length ? series.options[0].key : null;
+  }
+  if (TAB === "lags") showLagSeries();
+}
+
+function showLagSeries() {
+  if (!VIEW.series || !VIEW.key) return;
+  VIEW.kind = "lagseries";
+  setMode("lagseries"); markCurrent();
+  $("error").textContent = "";
+  $("status").textContent = "rendering…";
+  const series = currentSeries();
+  const chosen = series.options.find((o) => o.key === VIEW.key);
+  const img = $("figure-img");
+  img.onload = () => {
+    $("status").textContent = `${series.label} — ${chosen ? chosen.label : VIEW.key}`;
+  };
+  img.onerror = () => {
+    $("status").textContent = "";
+    $("error").textContent = "Could not render this figure.";
+  };
+  img.src = figureURL();
+  img.alt = VIEW.key;
+}
+
+/* ── Galleries (families with no per-figure address) ────────────────────── */
 
 function fillFamilies() {
   const box = $("families");
   box.innerHTML = "";
-  if (!MANIFEST.families.length) {
+  // Anything already selectable in the Comparisons facets is not also offered
+  // as a gallery — one route to a figure, not two that disagree.
+  const faceted = new Set((MANIFEST.comparisons || []).map((c) => c.key));
+  const galleries = (MANIFEST.families || []).filter((f) => !faceted.has(f.key));
+  if (!galleries.length) {
     box.innerHTML = '<div class="sub">None in this bundle.</div>';
     return;
   }
-  for (const fam of MANIFEST.families) {
+  for (const fam of galleries) {
     const b = document.createElement("button");
     b.textContent = fam.label;
     b.dataset.family = fam.key;
@@ -305,44 +678,8 @@ function fillFamilies() {
   }
 }
 
-function markCurrent() {
-  for (const b of document.querySelectorAll("#figures button"))
-    b.setAttribute("aria-current", String(VIEW.kind === "figure" && b.dataset.name === VIEW.name));
-  for (const b of document.querySelectorAll("#activity button"))
-    b.setAttribute("aria-current", String(VIEW.kind === "activity" && b.dataset.activity === VIEW.name));
-  for (const b of document.querySelectorAll("#families button"))
-    b.setAttribute("aria-current", String(VIEW.kind === "family" && b.dataset.family === VIEW.family));
-}
-
-function setMode(kind) {
-  const single = kind === "figure" || kind === "activity";
-  // Hidden, not disabled: the controls style spatial network plots. A raster,
-  // a heatmap and a violin gallery read none of them, so offering the knobs
-  // there would imply they do something.
-  $("controls-panel").classList.toggle("hidden", kind !== "figure");
-  $("single").classList.toggle("hidden", !single);
-  $("gallery").classList.toggle("hidden", single);
-  for (const id of ["dl-png", "dl-svg", "dl-pdf"])
-    $(id).classList.toggle("hidden", !single);
-}
-
-function showFigure() {
-  if (VIEW.kind !== "activity") VIEW.kind = "figure";
-  setMode(VIEW.kind); markCurrent();
-  $("error").textContent = "";
-  $("status").textContent = "rendering…";
-  const img = $("figure-img");
-  img.onload = () => { $("status").textContent = VIEW.name; };
-  img.onerror = () => {
-    $("status").textContent = "";
-    $("error").textContent = "Could not render this figure.";
-  };
-  img.src = figureURL();
-  img.alt = VIEW.name;
-}
-
 async function showFamily(fam) {
-  VIEW = { kind: "family", rec: null, lag: null, name: null, family: fam.key };
+  VIEW.kind = "family"; VIEW.gallery = fam.key;
   setMode("family"); markCurrent();
   $("error").textContent = "";
   $("status").textContent = "rendering gallery — this can take a few seconds the first time…";
@@ -375,8 +712,79 @@ async function showFamily(fam) {
   }
 }
 
+/* ── Shared chrome ──────────────────────────────────────────────────────── */
+
+function markCurrent() {
+  for (const b of document.querySelectorAll("#figures button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "figure" && b.dataset.name === VIEW.name));
+  for (const b of document.querySelectorAll("#activity button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "activity" && b.dataset.activity === VIEW.name));
+  for (const b of document.querySelectorAll("#families button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "family" && b.dataset.family === VIEW.gallery));
+  const cmp = VIEW.kind === "comparison" || VIEW.kind === "both";
+  for (const b of document.querySelectorAll("#cmp-metrics button"))
+    b.setAttribute("aria-current", String(cmp && b.dataset.metric === VIEW.metric));
+  for (const b of document.querySelectorAll("#lag-series button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "lagseries" && b.dataset.series === VIEW.series));
+  for (const b of document.querySelectorAll("#lag-options button"))
+    b.setAttribute("aria-current", String(VIEW.kind === "lagseries" && b.dataset.key === VIEW.key));
+}
+
+function setMode(kind) {
+  const one = kind === "figure" || kind === "activity" || kind === "lagseries";
+  // Hidden, not disabled: the styling controls describe spatial network plots.
+  // A raster, a violin and a line plot read none of them, so offering the
+  // knobs there would imply they do something.
+  $("controls-panel").classList.toggle("hidden", kind !== "figure");
+  const faceted = kind === "comparison" || kind === "both";
+  $("facets-panel").classList.toggle("hidden", !(faceted || kind === "lagseries"));
+  // The across-lag figures read the colours but have no lag/level/split of
+  // their own, so those rows go away rather than sitting there inert.
+  for (const id of ["facets-head", "cmp-level-label", "cmp-split-label"])
+    $(id).classList.toggle("hidden", !faceted);
+  // Lag stays hidden for a lagless family even while faceted, so this cannot
+  // just follow `faceted` — fillComparisonFacets owns that decision.
+  const fam = faceted ? currentComparison() : null;
+  $("cmp-lag-label").classList.toggle("hidden", !(fam && fam.lags.length));
+  $("single").classList.toggle("hidden", !one);
+  $("pair").classList.toggle("hidden", !(kind === "comparison" || kind === "both"));
+  $("gallery").classList.toggle("hidden", kind !== "family");
+  // "Both" shows two figures; a single download button cannot mean both, so
+  // the buttons go away rather than silently picking one.
+  const downloadable = one || kind === "comparison";
+  for (const id of ["dl-png", "dl-svg", "dl-pdf"])
+    $(id).classList.toggle("hidden", !downloadable);
+}
+
+function showFigure() {
+  if (VIEW.kind !== "activity") VIEW.kind = "figure";
+  setMode(VIEW.kind); markCurrent();
+  $("error").textContent = "";
+  $("status").textContent = "rendering…";
+  const img = $("figure-img");
+  img.onload = () => { $("status").textContent = VIEW.name; };
+  img.onerror = () => {
+    $("status").textContent = "";
+    $("error").textContent = "Could not render this figure.";
+  };
+  img.src = figureURL();
+  img.alt = VIEW.name;
+}
+
+function selectTab(tab) {
+  TAB = tab;
+  for (const b of document.querySelectorAll("#tabs button"))
+    b.setAttribute("aria-selected", String(b.dataset.tab === tab));
+  $("side-recordings").classList.toggle("hidden", tab !== "recordings");
+  $("side-comparisons").classList.toggle("hidden", tab !== "comparisons");
+  $("side-lags").classList.toggle("hidden", tab !== "lags");
+  if (tab === "recordings") showFigure();
+  else if (tab === "comparisons") showComparison();
+  else showLagSeries();
+}
+
 function download(fmt) {
-  if (VIEW.kind === "family") return;
+  if (VIEW.kind === "family" || VIEW.kind === "both") return;
   window.location = figureURL({ fmt: fmt, download: "1" });
 }
 
@@ -391,14 +799,33 @@ function download(fmt) {
   }
   $("source").textContent = `${MANIFEST.source} · ${MANIFEST.mode}`;
   buildControls();
+  buildComparisonControls();
   fillRecordings();
+  fillComparisonFamilies();
   fillFamilies();
+  fillLagSeries();
+
+  // A tab with nothing behind it is removed, not shown empty.
+  if (!(MANIFEST.comparisons || []).length && !(MANIFEST.families || []).length)
+    $("tab-comparisons").classList.add("hidden");
+  if (!(MANIFEST.lag_series || []).length)
+    $("tab-lags").classList.add("hidden");
+
   $("recording").addEventListener("change", fillLags);
   $("lag").addEventListener("change", fillFigures);
+  $("cmp-family").addEventListener("change", fillComparisonFacets);
+  $("cmp-level").addEventListener("change", fillComparisonMetrics);
+  $("cmp-split").addEventListener("change", showComparison);
+  $("cmp-lag").addEventListener("change", showComparison);
   $("reset").addEventListener("click", resetControls);
+  $("cmp-reset").addEventListener("click", resetComparisonControls);
   $("dl-png").addEventListener("click", () => download("png"));
   $("dl-svg").addEventListener("click", () => download("svg"));
   $("dl-pdf").addEventListener("click", () => download("pdf"));
+  for (const b of document.querySelectorAll("#tabs button"))
+    b.addEventListener("click", () => selectTab(b.dataset.tab));
+
+  selectTab("recordings");
 })();
 </script>
 </body>

--- a/src/meanap/viewer/server.py
+++ b/src/meanap/viewer/server.py
@@ -15,11 +15,19 @@ anyone.
 Endpoints
 ---------
 ``GET /``                     the page
-``GET /api/manifest``         recordings, lags, figures, families, controls
+``GET /api/manifest``         recordings, lags, figures, families, comparisons, controls
 ``GET /api/figure``           one network figure, restyled per the query string
 ``GET /api/activity``         one step-2 activity figure (raster, heatmap, …)
+``GET /api/comparison``       one 2B/4B comparison figure, by facet
+``GET /api/lagseries``        one across-lag figure (metric vs lag, roles per lag)
 ``GET /api/family``           a family's thumbnails (renders once, then cached)
 ``GET /api/asset``            a file from the render cache
+
+``/api/comparison`` is what makes the batch comparisons navigable. A three-lag
+run's 4B set is 274 small multiples, and ``/api/family`` can only hand over all
+of them at once; each is one metric at one lag, so it has an address —
+``family``, ``level``, ``split``, ``lag``, ``metric`` — and the page asks for
+the one it is showing.
 
 The styling controls apply to the spatial network plots only, so ``/api/family``
 ignores them and the page hides the panel for gallery views rather than
@@ -39,11 +47,16 @@ from urllib.parse import parse_qs, urlparse
 from meanap.pipeline.bundle import is_bundle, open_bundle
 from meanap.pipeline.figure_output import DEFAULT_THUMBNAIL_DPI
 from meanap.pipeline.render import (
-    available_activity_figures, available_figures, available_group_families,
-    cached_figure, gallery, load_context, render_activity_figure,
+    available_activity_figures, available_comparison_families, available_figures,
+    available_group_families, available_lag_series, cached_comparison_figure,
+    cached_figure, cached_lag_series_figure, comparison_axes, gallery, load_context,
+    render_activity_figure,
 )
 from meanap.pipeline.render_cache import RenderCache
-from meanap.viewer.controls import control_schema, parse_overrides
+from meanap.viewer.controls import (
+    comparison_control_schema, control_schema, parse_comparison_overrides,
+    parse_overrides,
+)
 from meanap.viewer.page import PAGE_HTML
 
 __all__ = ["ViewerService", "serve"]
@@ -98,9 +111,75 @@ class ViewerService:
             "recordings": recordings,
             "families": [{"key": f.key, "label": f.label}
                          for f in available_group_families(self.ctx)],
+            "comparisons": self.comparisons(),
+            "lag_series": self.lag_series(),
             "controls": control_schema(),
+            "comparison_controls": comparison_control_schema(),
             "formats": list(ALLOWED_FORMATS),
         }
+
+    def comparisons(self) -> list[dict]:
+        """The facets behind the comparison tab: one entry per family.
+
+        These families are the half-violin sets (4B network metrics, 2B
+        neuronal activity), which are one metric per figure and therefore
+        selectable. The gallery families in ``families`` above stay as they
+        are — nothing there has an address to select by.
+        """
+        out = []
+        for fam in available_comparison_families(self.ctx):
+            axes = comparison_axes(self.ctx, fam.key)
+            out.append({
+                "key": axes.family,
+                "label": axes.label,
+                "lags": list(axes.lags),
+                "levels": [
+                    {"key": level.key, "label": level.label,
+                     "metrics": [{"name": m.key, "label": m.label}
+                                 for m in level.metrics]}
+                    for level in axes.levels
+                ],
+                "splits": [{"key": s.key, "label": s.label} for s in axes.splits],
+            })
+        return out
+
+    def lag_series(self) -> list[dict]:
+        """The across-lag sets: graph metrics vs lag, and cartography per lag.
+
+        Empty on a single-lag run — a curve through one point says nothing, so
+        the tab is not offered rather than shown empty.
+        """
+        return [
+            {"key": series.key, "label": series.label, "keyed_by": series.keyed_by,
+             "options": [{"key": c.key, "label": c.label} for c in choices]}
+            for series, choices in available_lag_series(self.ctx)
+        ]
+
+    def lag_series_figure(self, series: str, key: str, *,
+                          fmt: str, thumbnail: bool, overrides: dict) -> Path:
+        """One across-lag figure, by set and key. Cached like the rest."""
+        path, _ = cached_lag_series_figure(
+            self.ctx, self.cache, series, key, fmt=fmt,
+            dpi=DEFAULT_THUMBNAIL_DPI if thumbnail else None,
+            overrides=overrides or None,
+        )
+        return path
+
+    def comparison(self, family: str, level: str, split: str, metric: str, *,
+                   lag: int | None, fmt: str, thumbnail: bool,
+                   overrides: dict) -> Path:
+        """One comparison figure, by address. Cached like the 4A figures.
+
+        The overrides here are the *comparison* controls (age and group
+        colours), not the Network Viewer ones — a violin plot reads no node
+        size or edge threshold, so those are neither accepted nor offered.
+        """
+        path, _ = cached_comparison_figure(
+            self.ctx, self.cache, family, level, split, metric, lag=lag, fmt=fmt,
+            dpi=DEFAULT_THUMBNAIL_DPI if thumbnail else None,
+            overrides=overrides or None,
+        )
+        return path
 
     def figure(self, recording: str, lag: int, name: str, *,
                fmt: str, overrides: dict, thumbnail: bool) -> Path:
@@ -174,6 +253,10 @@ class _Handler(BaseHTTPRequestHandler):
                 self._figure(query)
             elif parsed.path == "/api/activity":
                 self._activity(query)
+            elif parsed.path == "/api/comparison":
+                self._comparison(query)
+            elif parsed.path == "/api/lagseries":
+                self._lag_series(query)
             elif parsed.path == "/api/family":
                 self._json(self.service.family(
                     _one(query, "key"), fmt=_fmt(query)))
@@ -210,6 +293,27 @@ class _Handler(BaseHTTPRequestHandler):
         download = query.get("download", ["0"])[0] == "1"
         self._file(path, download_as=path.name if download else None)
 
+    def _comparison(self, query) -> None:
+        fmt = _fmt(query)
+        path = self.service.comparison(
+            _one(query, "family"), _one(query, "level"), _one(query, "split"),
+            _one(query, "metric"), lag=_optional_int(query, "lag"), fmt=fmt,
+            thumbnail=query.get("thumb", ["0"])[0] == "1",
+            overrides=parse_comparison_overrides(query),
+        )
+        download = query.get("download", ["0"])[0] == "1"
+        self._file(path, download_as=path.name if download else None)
+
+    def _lag_series(self, query) -> None:
+        fmt = _fmt(query)
+        path = self.service.lag_series_figure(
+            _one(query, "series"), _one(query, "key"), fmt=fmt,
+            thumbnail=query.get("thumb", ["0"])[0] == "1",
+            overrides=parse_comparison_overrides(query),
+        )
+        download = query.get("download", ["0"])[0] == "1"
+        self._file(path, download_as=path.name if download else None)
+
     # ── plumbing ─────────────────────────────────────────────────────────────
 
     def _send(self, status: int, content_type: str, body: bytes,
@@ -237,6 +341,21 @@ def _one(query: dict, key: str) -> str:
     if not value:
         raise ValueError(f"missing required parameter '{key}'")
     return value
+
+
+def _optional_int(query: dict, key: str) -> int | None:
+    """An optional whole-number parameter, absent or blank meaning "not given".
+
+    ``int()``'s own message ("invalid literal for int() with base 10") reaches
+    the page as the error text, so it is replaced with one naming the parameter.
+    """
+    value = query.get(key, [None])[0]
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"'{key}' must be a whole number, got {value!r}") from None
 
 
 def _fmt(query: dict) -> str:


### PR DESCRIPTION
Two related pieces of work on express mode's output: finding the `.meanap` file a run produces, and making the figures inside it navigable.

## 1. The bundle was easy to conclude didn't exist

An express run's entire output is one file, and it lands **beside** the output folder rather than inside it — `OutputData07Aug2026.meanap` next to `OutputData07Aug2026/`. The runner logged the path, but before the timing lines, so it scrolled away. An express run now ends with a framed block naming the file and the command that opens it.

**View report** was worse than unhelpful there. It builds a static page from the figures on disk, and express mode deliberately leaves almost none — 6 of 483 on the example dataset — so the page looked like a failed run. It now picks by what the run actually produced: the viewer for an express run, `report.html` for a full one.

A bundle is a file people email each other, so opening one no longer requires having run anything: **Open bundle…** in the toolbar, or drag the `.meanap` onto the window. `ViewerSessions` owns the servers that starts — one per bundle, reused on reopen, all shut down on close.

## 2. The batch comparisons were one gallery of 274 figures

On a three-lag run the 4B set was served as a single scroll of small multiples, 36 s to draw, with the only organisation in the caption text. Each of those figures is one metric at one lag, so each has an address — family, level, split, lag, metric. The gallery existed because nothing could ask for a single one.

- `netmet_comparison_frames` / `ephys_comparison_frames` extracted from the two plotting entry points, which now call them.
- `render_comparison_figure` draws one figure, into the same path under the same name the folder-at-a-time renderer uses.
- `/api/comparison` serves it, cached per address; `comparison_axes` enumerates what a run can offer.
- The page becomes three tabs: **Recordings** (unchanged), **Comparisons** (lag / level / split / metric), **Across lags** (graph metrics against lag, cartography roles per lag — absent on a one-lag run, where a curve through one point says nothing).

0.2 s for the figure you asked for, against 36 s for the wall, with PNG/SVG/PDF export on each.

## 3. Age and group colours are configurable

Different kinds of variable, so different kinds of palette: ages ordered → sequential colormap (`viridis` default, plus `plasma`, `cividis`, …); groups unordered → categorical list (`meanap` default, `okabe-ito`, `tab10`, `grey`). Custom colours override a preset and cycle if short. Available as `Params` fields for a full run and as a panel in the viewer.

`okabe-ito` is offered deliberately — a genotype comparison printed in a paper will be read by someone who cannot separate the default red and green.

## The invariant held throughout

`ColorScheme()` with no arguments reproduces the historical palettes exactly, and an unstyled request returns the figure the pipeline itself wrote — byte-for-byte. Every parity claim in these suites rests on that, so it is asserted rather than assumed: 80 network addresses, 46 activity ones, and 30 across-lag figures compared against a full run's own output.

## Fixes found on the way

- The group-ordering step raised `KeyError` on a batch whose recordings all have a single node — the empty node frame has no `Grp` column.
- The page kept one `VIEW.name` meaning "network figure" on one tab and "metric" on another. All tabs populate at startup, so the comparison fill overwrote the recordings selection and the first render 400'd.
- `plot_graph_metrics_by_lag` / `plot_node_cartography_by_lag` hardcoded `.png`, silently dropping those figures from SVG family renders.
- Read-only `QTextEdit` still accepts drags, so a bundle dropped on the status log — the largest target on the Pipeline tab — did nothing.

## Testing

| suite | before | after |
|---|---|---|
| `test_bundle_render.py` | 103 | **151** |
| `test_viewer_server.py` | 32 | **106** |
| `test_gui_tooltips.py` | 34 | **41** |
| `test_gui_bundle_viewer.py` | — | **31** (new) |

Plus a Playwright walkthrough of all three tabs against a real bundle, and a clean Sphinx build. Docs updated in `express-mode.md`, `gui-guide.md`, `output-report.md`.

## Not included

- The PyQt GUI has no controls for the new colour fields; they round-trip through saved parameter JSON and apply to full runs, but there is no widget for them yet.
- `7_DensityLandscape` still cannot be rebuilt from a bundle — it is written by `step4.py`, not by the comparison plotter, so no renderer reaches it.
- The on-disk `4B_GroupComparisons` tree is unchanged, as scoped: this is viewer-only, and existing paths, `report.html` and the MATLAB-parity comparison are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)