### PR TITLE
Show the settings a run used, in the report and the viewer

### DIFF
--- a/docs/python/express-mode.md
+++ b/docs/python/express-mode.md
@@ -287,6 +287,15 @@ the same plot at different scales. It hides itself for figures that have only
 one — the batch-scaled versions need a pooled bound for the figure's size
 metric, which a single-recording bundle may not have.
 
+### Parameters
+
+Every setting the run used, grouped as `Params` groups them, opening on the ones
+that differ from the defaults. The left column filters to a section; a toggle
+expands to all ~140 fields. Remote share links are shown as a placeholder, since
+a bundle is a thing people send each other.
+
+The tab is absent for a bundle that carries no `params.json`.
+
 ### Comparisons
 
 The 2B and 4B half-violin sets — network metrics and neuronal activity by group

--- a/docs/python/gui-guide.md
+++ b/docs/python/gui-guide.md
@@ -197,6 +197,8 @@ Run controls and step selection.
 | **Verbose level** | `Normal`, `Verbose`, or `Debug` logging detail in the status log. |
 | **Time each step** | Records per-step wall-clock time to `step_durations.json` in the output folder. |
 | **Fixed random seed** | Makes the stochastic steps (3 and 4) reproducible. Off — the default, matching MATLAB — gives a fresh seed per run. |
+| **Continue previous run** | Picks up a run that stopped partway: writes into the same output folder and skips any recording already finished. Also how you add or remove recordings — edit the spreadsheet, tick this, and only the new ones are analysed. Everything pooled across the batch is redone over whatever the spreadsheet now lists. |
+| **…and drop removed recordings' figures** | Only while continuing. Deletes the plots of recordings the spreadsheet no longer names; they are excluded from every CSV either way, but their figures otherwise stay in the output folder and the report. Their data is kept, so putting a recording back stays cheap. |
 | **Express mode** | Skips every figure that can be redrawn later and keeps **only** a small `.meanap` bundle — the output folder is removed once the bundle is written and verified. The numbers are identical either way, and the viewer can draw the folder back out again; see [Express mode and run bundles](express-mode.md). |
 
 The four buttons under **Run**:

--- a/docs/python/output-report.md
+++ b/docs/python/output-report.md
@@ -57,6 +57,20 @@ Opening a link like this auto-expands the sidebar tree and navigates straight
 to that folder — useful for pointing a labmate at one specific plot without
 walking them through the tree by hand.
 
+## Run parameters
+
+The sidebar's **⚙ Run parameters** entry shows the settings the run used, read
+from `params.json` and grouped the way `Params` groups them — Recording, Spike
+detection, Connectivity, and so on. It opens on **only what differs from the
+defaults**, which on a typical run is a dozen fields out of ~140, with the
+default each one departed from shown beside it; a toggle expands to all of them.
+
+Remote share links are replaced with a placeholder. A report is a file people
+attach to papers and email onward, and a Dropbox link in one is a credential.
+
+The entry is absent for an output folder with no `params.json` — an older run,
+or one that failed before writing it.
+
 ## Related: the interactive viewer
 
 `report.html` shows the figures a run *wrote*. If you ran with

--- a/python/README.md
+++ b/python/README.md
@@ -181,6 +181,49 @@ continued run that saw only what it recomputed would place them somewhere the
 original never would. `python/test_continue_interrupted.py` checks the result is
 identical to a run that was never interrupted, figures included.
 
+### Changing which recordings a run covers
+
+The same mechanism handles a batch that changes after the fact. In each case the
+result is what you would have got by analysing that set from the start — the
+pooled statistics, the batch-scaled axes and the cartography boundaries are all
+redone over whatever the spreadsheet now names.
+
+**Adding a recording.** Put it in the spreadsheet and continue: only the new one
+is computed.
+
+```python
+Params(..., output_data_folder_name="OutputData09Aug2026", continue_interrupted=True)
+```
+
+**Removing one.** Take it out of the spreadsheet and continue. It drops out of
+every CSV and pooled statistic on its own, but its *figures* do not delete
+themselves — they would keep appearing in the output folder and the report as
+though they were part of the analysis. So a continued run names them:
+
+```
+1 recording(s) in this folder are no longer in the spreadsheet: rec2
+  Their 23 figure(s) are still on disk and will appear in the output folder and
+  report, though they are excluded from every CSV and pooled statistic.
+  Set Params.prune_removed_recordings = True to delete them.
+```
+
+With `prune_removed_recordings=True` the figures go. The recording's *data* is
+kept either way — that is what makes putting it back cheap.
+
+**Combining separate runs.** Name more than one previous analysis and give a
+spreadsheet listing recordings from all of them; nothing is recomputed.
+
+```python
+Params(
+    prior_analysis=True,
+    prior_analysis_path="path/to/RunA",
+    prior_analysis_paths=["path/to/RunB"],   # searched after the first
+    start_analysis_step=4,
+)
+```
+
+Each folder may equally be a `.meanap` bundle.
+
 ### Progress and time estimates
 
 A run shows a progress bar on the Pipeline tab with the phase, the recording

--- a/python/README.md
+++ b/python/README.md
@@ -147,6 +147,40 @@ replace a run deliberately, delete it or set
 `Params(overwrite_existing_output=True)` — which is still reported in the log,
 never silent.
 
+### Queueing several runs
+
+A run takes minutes to hours, and until now a second one meant waiting for the
+first. The **Queue** tab takes parameter files saved with **Save params…** and
+runs them in order, unattended:
+
+1. configure a run, **Save params…**;
+2. change whatever you like, save again;
+3. on the Queue tab, **Add…** both, then **Run queue**.
+
+Each entry is a complete description of a run, so they may differ in anything —
+different datasets, different lags, even different pipelines. A CAT-NAP run and
+an electrophysiology run sit in the same queue, because `run_pipeline` decides
+which path to take from the parameters it is handed.
+
+**A run that fails does not stop the ones after it.** The point of leaving
+something going overnight is to come back to results, so each run is caught
+individually and the queue moves on; the summary at the end names every run,
+says where the outputs went, and gives the reason for anything that failed.
+Stopping finishes the current run and starts no more — the ones that never ran
+are listed as such rather than quietly missing.
+
+The list itself can be saved and reloaded (**Save queue…**), which stores the
+paths of the parameter files rather than a copy of the settings.
+
+From Python:
+
+```python
+from meanap.pipeline.queue import load_queue, run_queue
+
+result = run_queue(load_queue(["runA.json", "runB.json", "runC.json"]))
+print(result.done, "of", len(result.outcomes), "completed")
+```
+
 ### Continuing an interrupted run
 
 A batch cut off at recording 5 of 10 — Ctrl-C, a cluster wall clock, a closed

--- a/python/README.md
+++ b/python/README.md
@@ -133,7 +133,9 @@ The pipeline mirrors MATLAB's 4 steps — spike detection, neuronal activity (fi
 The output folder defaults to today's date, so two runs in a day both want
 `OutputData07Aug2026`. Rather than replacing the first one, the second writes to
 `OutputData07Aug2026_v2` and says so; the GUI asks first, offering the new name,
-**Overwrite**, or **Cancel**. Past `_v99` it falls back to a `_HHMMSS` stamp.
+**Continue it**, **Overwrite**, or **Cancel**. Past `_v99` it falls back to a
+`_HHMMSS` stamp. **Continue it** is the one an interrupted run wants — see
+[Continuing an interrupted run](#continuing-an-interrupted-run).
 
 The `.meanap` bundle counts on its own — an express run's folder is often
 deleted once the bundle is in hand, and it would otherwise be the one artefact

--- a/python/README.md
+++ b/python/README.md
@@ -187,7 +187,8 @@ In the GUI this is three controls. **Paths → Edit…** is where the recording 
 is changed; when you add or remove one it says so and points at the next step.
 **Pipeline → Continue previous run** is that next step, with a sub-option for
 deleting the figures of recordings you took out. **Paths → Previous analysis
-folder → …and also** takes further folders, which is all merging runs needs.
+folder → Additional folders** takes further previous analyses, which is all
+merging runs needs.
 
 The same mechanism handles a batch that changes after the fact. In each case the
 result is what you would have got by analysing that set from the start — the

--- a/python/README.md
+++ b/python/README.md
@@ -145,6 +145,40 @@ replace a run deliberately, delete it or set
 `Params(overwrite_existing_output=True)` — which is still reported in the log,
 never silent.
 
+### Continuing an interrupted run
+
+A batch cut off at recording 5 of 10 — Ctrl-C, a cluster wall clock, a closed
+laptop — can pick up at 6 rather than starting again:
+
+```python
+Params(..., output_data_folder_name="OutputData09Aug2026", continue_interrupted=True)
+```
+
+In the GUI it is the **Continue it** button on the dialog that appears when a
+run would land on an existing folder. A continued run writes into that same
+folder and skips any recording whose result for the step is already there:
+
+| Step | Skipped when present | Cost avoided |
+|---|---|---|
+| 1 — spike detection | `<rec>_spikes.npz` | ~52s/recording |
+| 3 — connectivity | `<rec>_adjM.npz` | ~21s/recording |
+| 4 — network metrics | that recording's entry in `netmet_results.json` | ~99s/recording |
+| CAT-NAP phase 1 | `<rec>_catnap.npz` | the STTC + thresholding half |
+
+Step 4 has no per-recording file, so `netmet_results.json` is itself the
+checkpoint: it is rewritten atomically after each recording finishes, from the
+parent process. An interrupted run therefore leaves a valid results file holding
+everything that completed, rather than nothing at all.
+
+Two things make this safe rather than merely convenient. **Writes are atomic** —
+every artefact goes to a temporary name and is `os.replace`d into position — so
+a file existing means it is whole; anything unreadable is deleted and redone.
+And **step 4 loads the finished recordings back in** rather than only skipping
+them, because its cartography boundaries are pooled across the whole batch: a
+continued run that saw only what it recomputed would place them somewhere the
+original never would. `python/test_continue_interrupted.py` checks the result is
+identical to a run that was never interrupted, figures included.
+
 ### Progress and time estimates
 
 A run shows a progress bar on the Pipeline tab with the phase, the recording

--- a/python/README.md
+++ b/python/README.md
@@ -183,6 +183,12 @@ identical to a run that was never interrupted, figures included.
 
 ### Changing which recordings a run covers
 
+In the GUI this is three controls. **Paths → Edit…** is where the recording list
+is changed; when you add or remove one it says so and points at the next step.
+**Pipeline → Continue previous run** is that next step, with a sub-option for
+deleting the figures of recordings you took out. **Paths → Previous analysis
+folder → …and also** takes further folders, which is all merging runs needs.
+
 The same mechanism handles a batch that changes after the fact. In each case the
 result is what you would have got by analysing that set from the start — the
 pooled statistics, the batch-scaled axes and the cartography boundaries are all

--- a/python/test_continue_interrupted.py
+++ b/python/test_continue_interrupted.py
@@ -478,6 +478,100 @@ def _gui_checks() -> list[Check]:
     return checks
 
 
+def _gui_controls_checks() -> list[Check]:
+    """The three things that make this reachable without editing Python."""
+    from PyQt6.QtWidgets import QApplication
+    from meanap.gui.panels.paths import PathsPanel
+    from meanap.gui.panels.pipeline import PipelinePanel
+    from meanap.gui.panels.spreadsheet_editor import SpreadsheetEditor
+    from meanap.pipeline.spreadsheet import (
+        new_recording_table, write_recording_table,
+    )
+
+    QApplication.instance() or QApplication([])
+    checks: list[Check] = []
+
+    # ── Pipeline tab ─────────────────────────────────────────────────────────
+    panel = PipelinePanel()
+    checks.append(("the Pipeline tab offers continuing a run",
+                   hasattr(panel, "continue_interrupted"), ""))
+    checks.append(("pruning is offered but disabled until it applies",
+                   hasattr(panel, "prune_removed")
+                   and not panel.prune_removed.isEnabled(), ""))
+    panel.continue_interrupted.setChecked(True)
+    checks.append(("and enabled once continuing is on",
+                   panel.prune_removed.isEnabled(), ""))
+
+    panel.prune_removed.setChecked(True)
+    out = Params()
+    panel.save(out)
+    checks.append(("both reach Params",
+                   out.continue_interrupted and out.prune_removed_recordings, ""))
+
+    panel.continue_interrupted.setChecked(False)
+    out2 = Params()
+    panel.save(out2)
+    checks.append(("pruning cannot leak into a run that is not continuing",
+                   not out2.prune_removed_recordings, ""))
+
+    panel.load(Params(continue_interrupted=True, prune_removed_recordings=True))
+    checks.append(("and they round-trip back into the panel",
+                   panel.continue_interrupted.isChecked()
+                   and panel.prune_removed.isChecked(), ""))
+
+    # ── Paths tab ────────────────────────────────────────────────────────────
+    paths = PathsPanel()
+    paths.load(Params(prior_analysis_path="/a/RunA",
+                      prior_analysis_paths=["/a/RunB", "/a/RunC"]))
+    checks.append(("several previous analyses can be listed",
+                   paths.extra_prior_paths() == ["/a/RunB", "/a/RunC"],
+                   str(paths.extra_prior_paths())))
+    merged = Params()
+    paths.save(merged)
+    checks.append(("the first stays prior_analysis_path, the rest the list",
+                   merged.prior_analysis_path == "/a/RunA"
+                   and merged.prior_analysis_paths == ["/a/RunB", "/a/RunC"],
+                   str(merged.prior_analysis_paths)))
+    checks.append(("a folder already named is not added twice",
+                   paths._prior_listed("/a/RunB") and paths._prior_listed("/a/RunA")
+                   and not paths._prior_listed("/a/New"), ""))
+
+    # ── Spreadsheet editor ───────────────────────────────────────────────────
+    with tempfile.TemporaryDirectory() as tmp:
+        sheet = Path(tmp) / "r.csv"
+        table = new_recording_table(["a_DIV21", "b_DIV21", "c_DIV21"])
+        table.iloc[:, 2] = "WT"
+        write_recording_table(sheet, table)
+
+        editor = SpreadsheetEditor(path=str(sheet))
+        checks.append(("an unedited sheet says nothing about continuing",
+                       "Continue previous run" not in editor._status.text(),
+                       editor._status.text()))
+
+        editor._on_add_row()
+        for col, value in ((0, "d_DIV21"), (1, "21"), (2, "WT")):
+            editor._table.item(3, col).setText(value)
+        checks.append(("adding a recording points at the Continue option",
+                       "1 added" in editor._status.text()
+                       and "Continue previous run" in editor._status.text(),
+                       editor._status.text()))
+
+        editor._table.setCurrentCell(0, 0)
+        editor._on_remove_rows()
+        text = editor._status.text()
+        checks.append(("removing one is reported too",
+                       "1 added and 1 removed" in text, text))
+        checks.append(("with the figures caveat, which only applies to removals",
+                       "figures stay in the output folder" in text, text))
+
+        fresh = SpreadsheetEditor()
+        fresh.set_recordings(["x_DIV21"])
+        checks.append(("a brand-new sheet has nothing to have changed from",
+                       "Continue previous run" not in fresh._status.text(),
+                       fresh._status.text()))
+    return checks
+
+
 def main() -> int:
     print("=" * 70)
     print("Continuing an interrupted run")
@@ -497,9 +591,11 @@ def main() -> int:
     except ImportError as e:
         print(f"\nGUI checks SKIPPED — PyQt6 not available ({e})")
     else:
-        p, n = _report("In the GUI:", _gui_checks())
-        total_pass += p
-        total += n
+        for title, build in [("In the GUI:", _gui_checks),
+                             ("GUI controls:", _gui_controls_checks)]:
+            p, n = _report(title, build())
+            total_pass += p
+            total += n
 
     print(f"\n{'=' * 70}")
     print(f"Total: {total_pass}/{total} checks passed")

--- a/python/test_continue_interrupted.py
+++ b/python/test_continue_interrupted.py
@@ -1,4 +1,4 @@
-"""Test continuing a run that was interrupted partway through its recordings.
+"""Test continuing an interrupted run, and changing which recordings it covers.
 
 Run from the repo root::
 
@@ -19,8 +19,18 @@ what an uninterrupted one would**. Two things have to hold for that:
     recomputed would put those boundaries somewhere the original never would, so
     the finished ones are loaded back in rather than merely skipped.
 
-The last section checks that end to end: interrupt, continue, and compare the
+The last sections check that end to end: interrupt, continue, and compare the
 recording-level CSV against a run that was never interrupted.
+
+The same machinery covers changing the batch. **Adding** a recording is just
+continuing with a longer spreadsheet — the new one is computed, the rest are
+loaded back, and every pooled statistic is redone over all of them.
+**Removing** one is a shorter spreadsheet; the numbers follow it on their own,
+but its *figures* do not, so those are reported and optionally pruned.
+**Combining** separate runs is several prior-analysis folders and one
+spreadsheet naming recordings from all of them. Each is checked against the
+run you would have got by analysing that set together from the start, because
+"cheaper" is only worth anything if the answer is the same.
 """
 
 from __future__ import annotations
@@ -277,6 +287,145 @@ def _step4_checks() -> list[Check]:
 
 # ── The GUI offers it ─────────────────────────────────────────────────────────
 
+# ── Changing which recordings a run covers ────────────────────────────────────
+
+def _batch_change_checks() -> list[Check]:
+    """Add one, remove one, and combine two runs — each against a fresh run."""
+    checks: list[Check] = []
+
+    def sheet(tmp: Path, recs, name: str) -> Path:
+        path = tmp / name
+        pd.DataFrame([{"Recording Filename": r, "DIV group": 21,
+                       "Genotype": "WT" if int(r[3:]) % 2 else "KO"}
+                      for r in recs]).to_csv(path, index=False)
+        return path
+
+    def table(root: Path) -> pd.DataFrame:
+        df = pd.read_csv(root / "4_NetworkActivity"
+                         / "NetworkActivity_RecordingLevel.csv")
+        return df.sort_values(df.columns[0]).reset_index(drop=True)
+
+    six = [f"rec{i}" for i in range(6)]
+
+    # ── Adding ───────────────────────────────────────────────────────────────
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        root = create_output_folders(tmp, "Run", ["WT", "KO"])
+        _seed_step4_inputs_for(root, six)
+        run_pipeline(_batch_params(tmp, "Run", sheet(tmp, six[:5], "five.csv")),
+                     log=lambda m: None)
+        run_pipeline(_batch_params(tmp, "Run", sheet(tmp, six, "six.csv"),
+                                   continue_interrupted=True), log=lambda m: None)
+
+        ref = create_output_folders(tmp, "Ref", ["WT", "KO"])
+        _seed_step4_inputs_for(ref, six)
+        ref = run_pipeline(_batch_params(tmp, "Ref", sheet(tmp, six, "six.csv")),
+                           log=lambda m: None)
+        checks.append(("adding a recording gives what a fresh run would",
+                       table(root).equals(table(ref)), "CSVs differ"))
+        checks.append(("including the pooled statistics over all of them",
+                       len(table(root)) == 6, str(len(table(root)))))
+
+    # ── Removing ─────────────────────────────────────────────────────────────
+    for prune in (False, True):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            root = create_output_folders(tmp, "Run", ["WT", "KO"])
+            _seed_step4_inputs_for(root, six)
+            run_pipeline(_batch_params(tmp, "Run", sheet(tmp, six, "six.csv")),
+                         log=lambda m: None)
+            kept = [r for r in six if r != "rec2"]
+            logs: list[str] = []
+            run_pipeline(_batch_params(tmp, "Run", sheet(tmp, kept, "five.csv"),
+                                       continue_interrupted=True,
+                                       prune_removed_recordings=prune),
+                         log=logs.append)
+
+            def rec2_figs() -> int:
+                base = root / "4_NetworkActivity" / "4A_IndividualNetworkAnalysis"
+                return len(list(base.rglob("*/rec2/**/*.png")))
+
+            if not prune:
+                checks.append(("removing a recording drops it from the results",
+                               "rec2" not in table(root).iloc[:, 0].values, ""))
+                checks.append(("it is named in the log as no longer listed",
+                               any("no longer in the spreadsheet" in m and "rec2" in m
+                                   for m in logs), ""))
+                checks.append(("its figures are reported rather than left silent",
+                               any("still on disk" in m for m in logs), ""))
+                checks.append(("and kept, since deleting results is opt-in",
+                               rec2_figs() > 0, str(rec2_figs())))
+            else:
+                checks.append(("pruning removes its figures",
+                               rec2_figs() == 0, str(rec2_figs())))
+                checks.append(("but keeps its data, so adding it back is cheap",
+                               (root / "ExperimentMatFiles" / "rec2_adjM.npz").exists(),
+                               ""))
+                ref = create_output_folders(tmp, "Ref", ["WT", "KO"])
+                _seed_step4_inputs_for(ref, kept)
+                ref = run_pipeline(
+                    _batch_params(tmp, "Ref", sheet(tmp, kept, "five.csv")),
+                    log=lambda m: None)
+                checks.append(("and the result matches a fresh run of what is left",
+                               table(root).equals(table(ref)), "CSVs differ"))
+
+    # ── Combining ────────────────────────────────────────────────────────────
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        for name, recs in [("RunA", six[:3]), ("RunB", six[3:])]:
+            root = create_output_folders(tmp, name, ["WT", "KO"])
+            _seed_step4_inputs_for(root, recs)
+            run_pipeline(_batch_params(tmp, name, sheet(tmp, recs, f"{name}.csv")),
+                         log=lambda m: None)
+
+        logs = []
+        combined = run_pipeline(
+            _batch_params(tmp, "Combined", sheet(tmp, six, "both.csv"),
+                          prior_analysis=True,
+                          prior_analysis_path=str(tmp / "RunA"),
+                          prior_analysis_paths=[str(tmp / "RunB")]),
+            log=logs.append)
+        checks.append(("combining two runs covers every recording",
+                       len(table(combined)) == 6, str(len(table(combined)))))
+        checks.append(("both prior folders are named in the log",
+                       sum("RunA" in m or "RunB" in m for m in logs) >= 2,
+                       str([m for m in logs if "Run" in m][:3])))
+
+        ref = create_output_folders(tmp, "Ref", ["WT", "KO"])
+        _seed_step4_inputs_for(ref, six)
+        ref = run_pipeline(_batch_params(tmp, "Ref", sheet(tmp, six, "both.csv")),
+                           log=lambda m: None)
+        checks.append(("and gives what one analysis of all six would",
+                       table(combined).equals(table(ref)), "CSVs differ"))
+    return checks
+
+
+def _seed_step4_inputs_for(root: Path, recs) -> None:
+    """As _seed_step4_inputs, for an explicit recording list."""
+    for rec in recs:
+        i = int(rec[3:])
+        rng = np.random.default_rng(i)
+        save_spike_times_npz(
+            root / "1_SpikeDetection" / "1A_SpikeDetectedData" / f"{rec}_spikes.npz",
+            {ch: {"bior1p5": np.sort(rng.uniform(0, 60, 80 + ch))}
+             for ch in range(N_CH)},
+            np.arange(1, N_CH + 1), FS, duration_s=60.0)
+        adj = np.abs(rng.normal(0, 0.3, (N_CH, N_CH)))
+        adj = (adj + adj.T) / 2
+        np.fill_diagonal(adj, 0)
+        atomic_savez(root / "ExperimentMatFiles" / f"{rec}_adjM.npz",
+                     channels=np.arange(1, N_CH + 1),
+                     **{f"adjM{LAG}mslag": adj, f"adjM{LAG}mslag_raw": adj})
+
+
+def _batch_params(tmp: Path, name: str, sheet_path: Path, **kw) -> Params:
+    p = _step4_params(tmp, name)
+    p.spreadsheet_file_name = str(sheet_path)
+    for k, v in kw.items():
+        setattr(p, k, v)
+    return p
+
+
 def _gui_checks() -> list[Check]:
     from PyQt6.QtCore import QTimer
     from PyQt6.QtWidgets import QApplication, QMessageBox
@@ -337,7 +486,8 @@ def main() -> int:
     for title, build in [("Atomic writes:", _atomic_checks),
                          ("Deciding what is done:", _already_done_checks),
                          ("Where it writes:", _destination_checks),
-                         ("Step 4, end to end:", _step4_checks)]:
+                         ("Step 4, end to end:", _step4_checks),
+                         ("Adding, removing, combining:", _batch_change_checks)]:
         p, n = _report(title, build())
         total_pass += p
         total += n

--- a/python/test_continue_interrupted.py
+++ b/python/test_continue_interrupted.py
@@ -1,0 +1,361 @@
+"""Test continuing a run that was interrupted partway through its recordings.
+
+Run from the repo root::
+
+    uv run python python/test_continue_interrupted.py
+
+A batch cut off at recording 5 of 10 used to mean redoing all ten. Continuing
+skips the ones whose result for that step is already on disk.
+
+The load-bearing claim is not "it skips things" but **a continued run produces
+what an uninterrupted one would**. Two things have to hold for that:
+
+  - *completeness* — writes are atomic, so a file existing means it is whole.
+    Without that, a truncated ``.npz`` from the interrupt would be skipped and
+    then fail to load a step later, far from the cause;
+  - *the batch reduce still sees the batch* — step 4 pools participation
+    coefficient and within-module z-score across every recording to place the
+    node-cartography boundaries. A continued run that only saw the recordings it
+    recomputed would put those boundaries somewhere the original never would, so
+    the finished ones are loaded back in rather than merely skipped.
+
+The last section checks that end to end: interrupt, continue, and compare the
+recording-level CSV against a run that was never interrupted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from meanap.params import Params  # noqa: E402
+from meanap.pipeline.atomic import (  # noqa: E402
+    atomic_path, atomic_savez, guard_readable, is_readable_npz,
+)
+from meanap.pipeline.io import save_spike_times_npz  # noqa: E402
+from meanap.pipeline.output_folders import create_output_folders  # noqa: E402
+from meanap.pipeline.resume import already_done  # noqa: E402
+from meanap.pipeline.runner import (  # noqa: E402
+    resolve_output_folder_name, run_pipeline,
+)
+
+Check = tuple[str, bool, str]
+
+N_REC, N_CH, FS, LAG = 6, 12, 2000.0, 25
+RECS = [f"rec{i}" for i in range(N_REC)]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+# ── Atomic writes ─────────────────────────────────────────────────────────────
+
+def _atomic_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+
+        path = atomic_savez(tmp / "a.npz", x=np.arange(5))
+        checks.append(("a normal write lands and reads back",
+                       is_readable_npz(path), ""))
+        checks.append(("leaving no scratch file behind",
+                       not [q for q in tmp.iterdir() if q.name.startswith(".")],
+                       str([q.name for q in tmp.iterdir()])))
+
+        # The case this exists for: interrupted mid-write.
+        atomic_savez(tmp / "b.npz", x=np.arange(3))
+        before = (tmp / "b.npz").read_bytes()
+        try:
+            with atomic_path(tmp / "b.npz", suffix=".npz") as scratch:
+                scratch.write_bytes(b"half a file")
+                raise KeyboardInterrupt("simulated Ctrl-C")
+        except KeyboardInterrupt:
+            pass
+        checks.append(("an interrupted write leaves the previous file intact",
+                       (tmp / "b.npz").read_bytes() == before, ""))
+        checks.append(("and cleans up after itself",
+                       not [q for q in tmp.iterdir() if q.name.startswith(".")],
+                       str([q.name for q in tmp.iterdir()])))
+
+        # A truncated file from before atomic writes existed.
+        (tmp / "c.npz").write_bytes(b"PK\x03\x04truncated")
+        checks.append(("a corrupt artefact is not mistaken for a finished one",
+                       not is_readable_npz(tmp / "c.npz"), ""))
+        said: list[str] = []
+        checks.append(("the guard rejects it",
+                       guard_readable(tmp / "c.npz", said.append) is False, ""))
+        checks.append(("deletes it, so it is not re-tripped every run",
+                       not (tmp / "c.npz").exists(), ""))
+        checks.append(("and explains why it is redoing the work",
+                       said and "interrupted" in said[0], str(said)))
+    return checks
+
+
+# ── already_done ──────────────────────────────────────────────────────────────
+
+def _already_done_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        good = atomic_savez(tmp / "good.npz", x=np.arange(3))
+
+        off = Params(continue_interrupted=False)
+        on = Params(continue_interrupted=True)
+        checks.append(("a normal run never skips, however complete the file",
+                       not already_done(off, tmp, good), ""))
+        checks.append(("a continued run skips a complete artefact",
+                       already_done(on, tmp, good), ""))
+        checks.append(("and does not skip one that isn't there",
+                       not already_done(on, tmp, tmp / "absent.npz"), ""))
+
+        (tmp / "bad.npz").write_bytes(b"PK\x03\x04nope")
+        said: list[str] = []
+        checks.append(("nor one that will not open",
+                       not already_done(on, tmp, tmp / "bad.npz", said.append), ""))
+        checks.append(("having removed it so the work is actually redone",
+                       not (tmp / "bad.npz").exists(), ""))
+    return checks
+
+
+# ── Where a continued run writes ──────────────────────────────────────────────
+
+def _destination_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "Run" / "4_NetworkActivity").mkdir(parents=True)
+        (tmp / "Run" / "4_NetworkActivity" / "x.csv").write_text("x")
+
+        base = dict(output_data_folder=str(tmp), output_data_folder_name="Run")
+        logs: list[str] = []
+        checks.append(("a normal run steps aside from an existing folder",
+                       resolve_output_folder_name(Params(**base), logs.append)
+                       == "Run_v2", ""))
+
+        logs.clear()
+        chosen = resolve_output_folder_name(
+            Params(**base, continue_interrupted=True), logs.append)
+        checks.append(("a continued run goes into the folder it is continuing",
+                       chosen == "Run", chosen))
+        checks.append(("and says what it will do with it",
+                       any("Continuing" in m and "skipped" in m for m in logs),
+                       str(logs)))
+
+        logs.clear()
+        fresh = resolve_output_folder_name(
+            Params(output_data_folder=str(tmp), output_data_folder_name="New",
+                   continue_interrupted=True), logs.append)
+        checks.append(("continuing something that isn't there just runs",
+                       fresh == "New"
+                       and any("Nothing to continue" in m for m in logs),
+                       str(logs)))
+    return checks
+
+
+# ── Step 4, end to end ────────────────────────────────────────────────────────
+
+def _seed_step4_inputs(root: Path) -> None:
+    """Spike times and adjacency — the two things step 4 reads."""
+    for i, rec in enumerate(RECS):
+        rng = np.random.default_rng(i)
+        spikes = {ch: {"bior1p5": np.sort(rng.uniform(0, 60, 80 + ch))}
+                  for ch in range(N_CH)}
+        save_spike_times_npz(
+            root / "1_SpikeDetection" / "1A_SpikeDetectedData" / f"{rec}_spikes.npz",
+            spikes, np.arange(1, N_CH + 1), FS, duration_s=60.0)
+        adj = np.abs(rng.normal(0, 0.3, (N_CH, N_CH)))
+        adj = (adj + adj.T) / 2
+        np.fill_diagonal(adj, 0)
+        atomic_savez(root / "ExperimentMatFiles" / f"{rec}_adjM.npz",
+                     channels=np.arange(1, N_CH + 1),
+                     **{f"adjM{LAG}mslag": adj, f"adjM{LAG}mslag_raw": adj})
+
+
+def _step4_params(tmp: Path, name: str, **kw) -> Params:
+    p = Params(output_data_folder=str(tmp), output_data_folder_name=name,
+               spreadsheet_file_name=str(tmp / "recs.csv"),
+               spreadsheet_range="2:100", raw_data=str(tmp / "no-raw"),
+               start_analysis_step=4, stop_analysis_step=4,
+               func_con_lag_val=[LAG], channel_layout="MCS60",
+               min_number_of_nodes_to_cal_net_met=2, random_seed=5,
+               recording_workers=1)
+    for k, v in kw.items():
+        setattr(p, k, v)
+    return p
+
+
+def _step4_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        pd.DataFrame([{"Recording Filename": r, "DIV group": 21, "Genotype": "WT"}
+                      for r in RECS]).to_csv(tmp / "recs.csv", index=False)
+
+        ref_root = create_output_folders(tmp, "Ref", ["WT"])
+        _seed_step4_inputs(ref_root)
+        ref = run_pipeline(_step4_params(tmp, "Ref"), log=lambda m: None)
+        ref_json = json.load(open(ref / "4_NetworkActivity" / "netmet_results.json"))
+        checks.append(("an uninterrupted run writes every recording",
+                       sorted(ref_json) == sorted(RECS), str(sorted(ref_json))))
+
+        # What an interrupted run leaves: the checkpoint holds the recordings
+        # that finished, because it is rewritten after each one.
+        part = create_output_folders(tmp, "Run", ["WT"])
+        _seed_step4_inputs(part)
+        ckpt = part / "4_NetworkActivity" / "netmet_results.json"
+        ckpt.write_text(json.dumps({k: ref_json[k] for k in RECS[:3]}))
+
+        logs: list[str] = []
+        root = run_pipeline(
+            _step4_params(tmp, "Run", continue_interrupted=True), log=logs.append)
+        checks.append(("continuing writes into the same folder",
+                       root.name == "Run", root.name))
+        checks.append(("it says how many it is skipping",
+                       any("3 recording(s) already have network metrics" in m
+                           for m in logs), ""))
+
+        final = json.load(open(ckpt))
+        checks.append(("and ends with every recording",
+                       sorted(final) == sorted(RECS), str(sorted(final))))
+
+        def table(root: Path) -> pd.DataFrame:
+            df = pd.read_csv(root / "4_NetworkActivity"
+                             / "NetworkActivity_RecordingLevel.csv")
+            return df.sort_values(df.columns[0]).reset_index(drop=True)
+
+        # The claim the whole feature rests on.
+        checks.append(("the result is identical to never being interrupted",
+                       table(root).equals(table(ref)), "CSVs differ"))
+
+        # Phase C needs adjMsub, which the checkpoint does not store — it is
+        # rebuilt from the adjacency. If that failed, the skipped recordings
+        # would silently have no figures.
+        def n_figs(r: Path) -> int:
+            return len(list((r / "4_NetworkActivity"
+                             / "4A_IndividualNetworkAnalysis").rglob("*.png")))
+        checks.append(("figures are drawn for the skipped recordings too",
+                       n_figs(root) == n_figs(ref),
+                       f"{n_figs(root)} vs {n_figs(ref)}"))
+
+        # A checkpoint naming a recording whose adjacency is gone must not be
+        # trusted: that recording is recomputed instead.
+        part2 = create_output_folders(tmp, "Run2", ["WT"])
+        _seed_step4_inputs(part2)
+        (part2 / "4_NetworkActivity" / "netmet_results.json").write_text(
+            json.dumps({k: ref_json[k] for k in RECS[:2]}))
+        (part2 / "ExperimentMatFiles" / f"{RECS[0]}_adjM.npz").unlink()
+        logs2: list[str] = []
+        root2 = run_pipeline(
+            _step4_params(tmp, "Run2", continue_interrupted=True), log=logs2.append)
+        final2 = json.load(open(root2 / "4_NetworkActivity" / "netmet_results.json"))
+        checks.append(("a checkpoint entry with no adjacency is not trusted",
+                       any("1 recording(s) already have" in m for m in logs2),
+                       str([m for m in logs2 if "already have" in m])))
+        checks.append(("and that recording is simply redone or skipped cleanly",
+                       RECS[0] not in final2 or final2[RECS[0]],
+                       "left in a half state"))
+    return checks
+
+
+# ── The GUI offers it ─────────────────────────────────────────────────────────
+
+def _gui_checks() -> list[Check]:
+    from PyQt6.QtCore import QTimer
+    from PyQt6.QtWidgets import QApplication, QMessageBox
+    from meanap.gui.main_window import MainWindow
+
+    app = QApplication.instance() or QApplication([])
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "Run" / "4_NetworkActivity").mkdir(parents=True)
+        (tmp / "Run" / "4_NetworkActivity" / "x.csv").write_text("x")
+        window = MainWindow()
+
+        def click(role) -> None:
+            def go() -> None:
+                for widget in app.topLevelWidgets():
+                    if isinstance(widget, QMessageBox) and widget.isVisible():
+                        for btn in widget.buttons():
+                            if widget.buttonRole(btn) == role:
+                                btn.click()
+                                return
+            QTimer.singleShot(0, go)
+
+        def base() -> Params:
+            return Params(output_data_folder=str(tmp),
+                          output_data_folder_name="Run")
+
+        click(QMessageBox.ButtonRole.ActionRole)
+        chosen = window._confirm_output_folder(base())
+        checks.append(("the dialog offers continuing the existing run",
+                       chosen is not None and chosen.continue_interrupted,
+                       str(chosen and chosen.continue_interrupted)))
+        checks.append(("keeping its folder name",
+                       chosen is not None
+                       and chosen.output_data_folder_name == "Run",
+                       str(chosen and chosen.output_data_folder_name)))
+
+        session = base()
+        click(QMessageBox.ButtonRole.ActionRole)
+        window._confirm_output_folder(session)
+        checks.append(("without marking the session's own params to continue",
+                       # Otherwise "Save params" would carry it into every run.
+                       not session.continue_interrupted, ""))
+
+        already = Params(output_data_folder=str(tmp),
+                         output_data_folder_name="Run",
+                         continue_interrupted=True)
+        checks.append(("a run already set to continue is not questioned",
+                       window._confirm_output_folder(already) is already, ""))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Continuing an interrupted run")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [("Atomic writes:", _atomic_checks),
+                         ("Deciding what is done:", _already_done_checks),
+                         ("Where it writes:", _destination_checks),
+                         ("Step 4, end to end:", _step4_checks)]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+
+    try:
+        import PyQt6  # noqa: F401
+    except ImportError as e:
+        print(f"\nGUI checks SKIPPED — PyQt6 not available ({e})")
+    else:
+        p, n = _report("In the GUI:", _gui_checks())
+        total_pass += p
+        total += n
+
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_params_summary.py
+++ b/python/test_params_summary.py
@@ -1,0 +1,238 @@
+"""Test the run-parameter summary shown in the report and the viewer.
+
+Run from the repo root::
+
+    uv run python python/test_params_summary.py
+
+``params.json`` is the authoritative record of how a result was produced, and is
+unreadable as a flat object of ~140 keys in declaration order. The summary
+groups it and marks what differs from the defaults, which is the question a
+reader actually has.
+
+Two things here are load-bearing beyond "it renders". The grouping is read off
+the ``Params`` source rather than kept in a list, so a field added later lands
+in its section with nothing to update — asserted by checking every field is
+covered. And a report is a file people attach to papers, so a share link in one
+is a credential: the summary redacts the same fields the bundle does.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from meanap.params import Params, SECRET_URL_FIELDS, save_params  # noqa: E402
+from meanap.params_summary import (  # noqa: E402
+    REDACTED, field_sections, summarise_params, summary_from_file,
+)
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+def _grouping_checks() -> list[Check]:
+    checks: list[Check] = []
+    sections = field_sections()
+    fields = {f.name for f in dataclasses.fields(Params)}
+
+    checks.append(("every Params field is assigned a section",
+                   set(sections) == fields,
+                   f"unmapped: {sorted(fields - set(sections))[:5]}"))
+    checks.append(("the sections come from the dataclass, not a list here",
+                   "Spike detection" in sections.values()
+                   and "Two-photon / CAT-NAP" in sections.values(), ""))
+    checks.append(("fields land in the section they are declared under",
+                   sections.get("fs") == "Recording"
+                   and sections.get("suite2p_mode") == "Two-photon / CAT-NAP"
+                   and sections.get("express_mode") == "Pipeline control",
+                   f"{sections.get('fs')}, {sections.get('suite2p_mode')}"))
+
+    summary = summarise_params(Params())
+    checks.append(("a default run covers every field and changes none",
+                   summary.total == len(fields) and summary.changed == 0,
+                   f"{summary.changed}/{summary.total} of {len(fields)}"))
+    checks.append(("groups keep declaration order",
+                   [g.name for g in summary.groups][:3]
+                   == ["Paths", "Recording", "Spike detection"],
+                   str([g.name for g in summary.groups][:3])))
+    return checks
+
+
+def _change_checks() -> list[Check]:
+    checks: list[Check] = []
+    p = Params(fs=12500.0, express_mode=True, random_seed=7,
+               func_con_lag_val=[25])
+    summary = summarise_params(p)
+
+    changed = {e.name: e for g in summary.groups for e in g.entries if e.changed}
+    checks.append(("exactly the changed fields are marked",
+                   set(changed) == {"fs", "express_mode", "random_seed",
+                                    "func_con_lag_val"},
+                   str(sorted(changed))))
+    checks.append(("each carries the default it departed from",
+                   changed["fs"].default == 25000.0
+                   and changed["random_seed"].default is None,
+                   f"{changed['fs'].default}"))
+    checks.append(("a list field compares by value, not identity",
+                   # func_con_lag_val's default comes from a factory; comparing
+                   # objects rather than values would mark it changed always.
+                   changed["func_con_lag_val"].value == [25]
+                   and changed["func_con_lag_val"].default == [10, 15, 25], ""))
+    checks.append(("a field left alone is not marked",
+                   not any(e.changed for g in summary.groups
+                           for e in g.entries if e.name == "ref_period"), ""))
+    checks.append(("the counts add up",
+                   summary.changed == 4
+                   and sum(g.changed for g in summary.groups) == 4,
+                   str(summary.changed)))
+    return checks
+
+
+def _redaction_checks() -> list[Check]:
+    checks: list[Check] = []
+    link = "https://www.dropbox.com/scl/fo/abc/def?rlkey=SUPERSECRET"
+    summary = summarise_params(Params(raw_data=link))
+    entry = next(e for g in summary.groups for e in g.entries
+                 if e.name == "raw_data")
+
+    checks.append(("a share link is replaced, not shown",
+                   entry.value == REDACTED and entry.redacted,
+                   str(entry.value)))
+    checks.append(("and the secret appears nowhere in the summary",
+                   "SUPERSECRET" not in json.dumps(summary.as_dict()), ""))
+    checks.append(("but it still reads as changed",
+                   entry.changed, ""))
+    checks.append(("a local path in the same field is left alone",
+                   next(e for g in summarise_params(Params(raw_data="/data/x")).groups
+                        for e in g.entries if e.name == "raw_data").value == "/data/x",
+                   ""))
+    checks.append(("every secret field is present to be redacted",
+                   all(any(e.name == f for g in summary.groups for e in g.entries)
+                       for f in SECRET_URL_FIELDS), str(SECRET_URL_FIELDS)))
+    return checks
+
+
+def _file_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        save_params(Params(fs=9000.0), tmp)
+        summary = summary_from_file(tmp / "params.json")
+        checks.append(("a written params.json round-trips",
+                       summary is not None and summary.changed == 1,
+                       str(summary.changed if summary else None)))
+
+        checks.append(("a missing file is None, not an exception",
+                       summary_from_file(tmp / "nope.json") is None, ""))
+        (tmp / "broken.json").write_text("{not json")
+        checks.append(("an unparseable file is None too",
+                       summary_from_file(tmp / "broken.json") is None, ""))
+        (tmp / "list.json").write_text("[1,2,3]")
+        checks.append(("so is one that isn't an object",
+                       summary_from_file(tmp / "list.json") is None, ""))
+
+        # A file from a newer version carries fields this build has no slot for.
+        raw = json.loads((tmp / "params.json").read_text())
+        raw["some_future_setting"] = 42
+        (tmp / "future.json").write_text(json.dumps(raw))
+        s = summary_from_file(tmp / "future.json")
+        checks.append(("unknown keys are surfaced, not dropped",
+                       s is not None and "some_future_setting" in s.unknown,
+                       str(s.unknown if s else None)))
+    return checks
+
+
+def _report_checks() -> list[Check]:
+    from meanap.pipeline.output_folders import create_output_folders
+    from meanap.pipeline.report import generate_report
+
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        root = create_output_folders(Path(tmp), "Run", ["WT"])
+        link = "https://www.dropbox.com/scl/fo/a/b?rlkey=LEAKME"
+        save_params(Params(fs=12500.0, express_mode=True, raw_data=link), root)
+        html = generate_report(root).read_text()
+
+        checks.append(("the report offers a parameters view",
+                       'id="params-link"' in html and "function renderParams" in html,
+                       ""))
+        checks.append(("with the summary embedded, not fetched",
+                       '"groups":' in html and '"changed":' in html, ""))
+        checks.append(("a changed value is in there",
+                       "12500" in html, ""))
+        checks.append(("the share link is not",
+                       "LEAKME" not in html, ""))
+
+        # An output folder with no params.json must still produce a report.
+        bare = create_output_folders(Path(tmp), "Bare", ["WT"])
+        bare_html = generate_report(bare).read_text()
+        checks.append(("a run without params.json still builds a report",
+                       "const PARAMS = null" in bare_html, ""))
+    return checks
+
+
+def _viewer_checks() -> list[Check]:
+    from meanap.viewer import page, server
+
+    checks: list[Check] = []
+    html = page.PAGE_HTML
+    for label, needle in [
+        ("a Parameters tab", 'data-tab="params"'),
+        ("its own side panel", 'id="side-params"'),
+        ("a pane to render into", 'id="params"'),
+        ("a renderer", "function showParams"),
+        ("section filtering", "PARAM_SECTION"),
+        ("a show-all toggle", "PARAM_ALL"),
+        ("the tab hidden when the run recorded nothing",
+         "if (!MANIFEST.params)"),
+        ("the pane put away when a figure is shown",
+         '$("params").classList.add("hidden")'),
+    ]:
+        checks.append((label, needle in html, needle))
+
+    src = Path(server.__file__).read_text()
+    checks.append(("the server puts the summary in its manifest",
+                   '"params": self._params_summary()' in src, ""))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Run parameter summary")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [("Grouping:", _grouping_checks),
+                         ("Changes:", _change_checks),
+                         ("Redaction:", _redaction_checks),
+                         ("Reading params.json:", _file_checks),
+                         ("In report.html:", _report_checks),
+                         ("In the viewer:", _viewer_checks)]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_run_queue.py
+++ b/python/test_run_queue.py
@@ -1,0 +1,409 @@
+"""Test running several saved analyses back to back.
+
+Run from the repo root::
+
+    uv run python python/test_run_queue.py
+
+A queue exists so nobody has to be awake for the handover between runs. That
+makes its failure behaviour the interesting part, not its success behaviour:
+
+  - **one bad run must not end the night.** Coming back to five results and one
+    error is worth far more than coming back to one error, so each run is caught
+    individually and the queue carries on;
+  - **the summary has to be readable cold.** Whoever reads it has forgotten what
+    was queued, so every run is named, and failures say why rather than only
+    that;
+  - **stopping means stopping.** Cancelling during run three must not start run
+    four, and the runs that never started say so instead of being missing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from meanap.params import Params, save_params  # noqa: E402
+from meanap.pipeline.atomic import atomic_savez  # noqa: E402
+from meanap.pipeline.io import save_spike_times_npz  # noqa: E402
+from meanap.pipeline.output_folders import create_output_folders  # noqa: E402
+from meanap.pipeline.queue import (  # noqa: E402
+    CANCELLED, DONE, FAILED, SKIPPED, QueuedRun, load_queue, run_queue,
+    summarise,
+)
+
+Check = tuple[str, bool, str]
+
+N_CH, FS, LAG = 8, 2000.0, 25
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+def _seed(root: Path, recs: list[str]) -> None:
+    """Step-4 inputs, so a queued run has something real to do."""
+    for rec in recs:
+        rng = np.random.default_rng(abs(hash(rec)) % 1000)
+        save_spike_times_npz(
+            root / "1_SpikeDetection" / "1A_SpikeDetectedData" / f"{rec}_spikes.npz",
+            {ch: {"bior1p5": np.sort(rng.uniform(0, 60, 60 + ch))}
+             for ch in range(N_CH)},
+            np.arange(1, N_CH + 1), FS, duration_s=60.0)
+        adj = np.abs(rng.normal(0, 0.3, (N_CH, N_CH)))
+        adj = (adj + adj.T) / 2
+        np.fill_diagonal(adj, 0)
+        atomic_savez(root / "ExperimentMatFiles" / f"{rec}_adjM.npz",
+                     channels=np.arange(1, N_CH + 1),
+                     **{f"adjM{LAG}mslag": adj, f"adjM{LAG}mslag_raw": adj})
+
+
+def _write_params(tmp: Path, name: str, sheet: Path, **kw) -> Path:
+    """A parameter file for a run that will succeed, unless kw breaks it."""
+    root = create_output_folders(tmp, name, ["WT"])
+    _seed(root, ["recX", "recY"])
+    base = dict(
+        output_data_folder=str(tmp), output_data_folder_name=name,
+        spreadsheet_file_name=str(sheet), spreadsheet_range="2:100",
+        raw_data=str(tmp / "no-raw"), start_analysis_step=4, stop_analysis_step=4,
+        func_con_lag_val=[LAG], channel_layout="MCS60",
+        min_number_of_nodes_to_cal_net_met=2, random_seed=3,
+        recording_workers=1, continue_interrupted=True,
+    )
+    base.update(kw)
+    holder = tmp / f"_{name}"
+    holder.mkdir(exist_ok=True)
+    save_params(Params(**base), holder)
+    destination = tmp / f"{name}.json"
+    (holder / "params.json").rename(destination)
+    return destination
+
+
+def _sheet(tmp: Path) -> Path:
+    path = tmp / "recs.csv"
+    pd.DataFrame([{"Recording Filename": r, "DIV group": 21, "Genotype": "WT"}
+                  for r in ("recX", "recY")]).to_csv(path, index=False)
+    return path
+
+
+# ── Loading ───────────────────────────────────────────────────────────────────
+
+def _loading_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sheet = _sheet(tmp)
+        a = _write_params(tmp, "Alpha", sheet)
+        b = _write_params(tmp, "Beta", sheet, express_mode=True)
+
+        runs = load_queue([a, b])
+        checks.append(("parameter files load into queued runs",
+                       len(runs) == 2, str(len(runs))))
+        checks.append(("each is named by its output folder",
+                       [r.label for r in runs] == ["Alpha", "Beta"],
+                       str([r.label for r in runs])))
+        checks.append(("and describes what it will do",
+                       "Ephys" in runs[0].describe()
+                       and "steps 4–4" in runs[0].describe(),
+                       runs[0].describe()))
+        checks.append(("noting express mode, which changes what is written",
+                       "express" in runs[1].describe(), runs[1].describe()))
+
+        # A queue is validated in full before anything starts: a typo should be
+        # a message now, not a gap in the morning's results.
+        try:
+            load_queue([a, tmp / "nope.json"])
+            said = ""
+        except ValueError as e:
+            said = str(e)
+        checks.append(("a missing file is refused up front, by name",
+                       "nope.json" in said, said))
+
+        (tmp / "broken.json").write_text("{not json")
+        try:
+            load_queue([tmp / "broken.json"])
+            said = ""
+        except ValueError as e:
+            said = str(e)
+        checks.append(("so is one that will not parse",
+                       "broken.json" in said, said))
+
+        # A run configured in the GUI has no file behind it yet.
+        loose = QueuedRun(params=Params(output_data_folder_name="Ad hoc"))
+        checks.append(("a run with no file still has a usable name",
+                       loose.label == "Ad hoc", loose.label))
+        checks.append(("and one with neither falls back rather than blanking",
+                       QueuedRun(params=Params()).label == "unnamed run", ""))
+    return checks
+
+
+# ── Running ───────────────────────────────────────────────────────────────────
+
+def _running_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sheet = _sheet(tmp)
+        good1 = _write_params(tmp, "First", sheet)
+        bad = _write_params(tmp, "Broken", sheet, spreadsheet_file_name="")
+        good2 = _write_params(tmp, "Third", sheet)
+
+        logs: list[str] = []
+        finished: list[str] = []
+        result = run_queue(load_queue([good1, bad, good2]), log=logs.append,
+                           on_finished=lambda o: finished.append(o.run.label))
+
+        checks.append(("every run is attempted",
+                       len(result.outcomes) == 3, str(len(result.outcomes))))
+        checks.append(("a failure in the middle does not stop the rest",
+                       result.done == 2 and result.failed == 1,
+                       f"done={result.done} failed={result.failed}"))
+        checks.append(("the runs after it still produce output",
+                       result.outcomes[2].output is not None
+                       and result.outcomes[2].output.is_dir(),
+                       str(result.outcomes[2].output)))
+        checks.append(("the failure records why, not just that",
+                       "Spreadsheet file must be set" in result.outcomes[1].error,
+                       result.outcomes[1].error))
+        checks.append(("and the log says the queue is carrying on",
+                       any("queue continues" in m for m in logs), ""))
+        checks.append(("outcomes are reported as they happen",
+                       finished == ["First", "Broken", "Third"], str(finished)))
+
+        text = "\n".join(summarise(result))
+        checks.append(("the summary names every run",
+                       all(n in text for n in ("First", "Broken", "Third")), ""))
+        checks.append(("marks which failed",
+                       "✗ 2. Broken" in text, text))
+        checks.append(("gives the output folder of the ones that worked",
+                       str(result.outcomes[0].output) in text, ""))
+        checks.append(("and counts them up",
+                       "2 of 3 completed, 1 failed" in text, text))
+    return checks
+
+
+def _cancel_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sheet = _sheet(tmp)
+        paths = [_write_params(tmp, f"Run{i}", sheet) for i in range(4)]
+
+        # Stop after the first run finishes: the rest must not start.
+        state = {"stop": False}
+        seen: list[str] = []
+
+        def finished(outcome) -> None:
+            seen.append(outcome.status)
+            state["stop"] = True
+
+        result = run_queue(load_queue(paths), log=lambda m: None,
+                           should_cancel=lambda: state["stop"],
+                           on_finished=finished)
+
+        checks.append(("the first run completes",
+                       result.outcomes[0].status == DONE,
+                       result.outcomes[0].status))
+        checks.append(("the rest are not started",
+                       all(o.status == SKIPPED for o in result.outcomes[1:]),
+                       str([o.status for o in result.outcomes])))
+        checks.append(("but they are still listed, rather than missing",
+                       len(result.outcomes) == 4, str(len(result.outcomes))))
+        text = "\n".join(summarise(result))
+        checks.append(("and the summary says they never ran",
+                       text.count("not started") == 3, text))
+
+        # Cancelling before anything starts should run nothing at all.
+        result2 = run_queue(load_queue(paths), log=lambda m: None,
+                            should_cancel=lambda: True)
+        checks.append(("a queue cancelled up front runs nothing",
+                       result2.done == 0
+                       and all(o.status == SKIPPED for o in result2.outcomes),
+                       str([o.status for o in result2.outcomes])))
+    return checks
+
+
+def _progress_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sheet = _sheet(tmp)
+        paths = [_write_params(tmp, f"P{i}", sheet) for i in range(2)]
+
+        seen: list[tuple[int, str, float]] = []
+        run_queue(load_queue(paths), log=lambda m: None,
+                  progress=lambda i, run, snap: seen.append(
+                      (i, run.label, snap.fraction)))
+
+        checks.append(("progress is reported during the runs",
+                       len(seen) > 0, str(len(seen))))
+        checks.append(("carrying which run it belongs to",
+                       {i for i, _, _ in seen} == {0, 1},
+                       str(sorted({i for i, _, _ in seen}))),)
+        checks.append(("and that run's own name",
+                       {label for _, label, _ in seen} == {"P0", "P1"},
+                       str({label for _, label, _ in seen})))
+        checks.append(("each run's progress runs to completion",
+                       max(f for i, _, f in seen if i == 0) == 1.0,
+                       str(max(f for i, _, f in seen if i == 0))))
+    return checks
+
+
+def _empty_checks() -> list[Check]:
+    logs: list[str] = []
+    result = run_queue([], log=logs.append)
+    return [
+        ("an empty queue is not an error",
+         result.outcomes == [] and result.done == 0, ""),
+        ("and says so rather than printing an empty summary",
+         any("Nothing was queued" in m for m in logs), str(logs)),
+    ]
+
+
+# ── The Queue tab ─────────────────────────────────────────────────────────────
+
+def _gui_checks() -> list[Check]:
+    from PyQt6.QtCore import QEventLoop, QTimer
+    from PyQt6.QtWidgets import QApplication
+
+    from meanap.gui.main_window import MainWindow
+    from meanap.gui.modes import MODES, TAB_QUEUE
+
+    app = QApplication.instance() or QApplication([])
+    checks: list[Check] = []
+
+    checks.append(("the Queue tab is available in every mode",
+                   all(TAB_QUEUE in m.tabs for m in MODES.values()),
+                   str([k for k, m in MODES.items() if TAB_QUEUE not in m.tabs])))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        sheet = _sheet(tmp)
+        good = [_write_params(tmp, n, sheet) for n in ("One", "Two")]
+        bad = _write_params(tmp, "Bad", sheet, spreadsheet_file_name="")
+
+        window = MainWindow()
+        panel = window._queue_panel
+
+        panel.add_paths([good[0], bad, good[1]])
+        checks.append(("files can be queued",
+                       panel.list.count() == 3, str(panel.list.count())))
+        checks.append(("adding one twice does not queue it twice",
+                       panel.add_paths([good[0]]) == 0
+                       and panel.list.count() == 3, str(panel.list.count())))
+
+        before = [p.name for p in panel.paths()]
+        panel.list.item(1).setSelected(True)
+        panel._move(1)
+        after = [p.name for p in panel.paths()]
+        checks.append(("runs can be reordered",
+                       after == [before[0], before[2], before[1]], str(after)))
+        panel.list.clearSelection()
+
+        panel.list.item(2).setSelected(True)
+        panel._on_remove()
+        checks.append(("and removed",
+                       panel.list.count() == 2, str(panel.list.count())))
+        panel.add_paths([bad])
+        panel.list.clearSelection()
+
+        # Run it for real, on the UI thread's event loop.
+        summaries: list[str] = []
+        loop = QEventLoop()
+        window._on_run_queue()
+        window._queue_worker.finished_all.connect(
+            lambda text: (summaries.append(text), loop.quit()))
+        window._queue_worker.failed.connect(
+            lambda m: (summaries.append("FAILED " + m), loop.quit()))
+        checks.append(("starting disables editing while it runs",
+                       not panel.add_btn.isEnabled()
+                       and not panel.run_btn.isEnabled()
+                       and panel.stop_btn.isEnabled(), ""))
+        QTimer.singleShot(900_000, loop.quit)
+        loop.exec()
+
+        checks.append(("the queue reports what completed",
+                       summaries == ["2 of 3 completed, 1 failed"],
+                       str(summaries)))
+        marks = [panel.list.item(i).text().split()[0]
+                 for i in range(panel.list.count())]
+        checks.append(("each run is marked with how it ended",
+                       marks == ["✓", "✓", "✗"], str(marks)))
+        checks.append(("the bar finishes full",
+                       panel.overall.value() == 1000, str(panel.overall.value())))
+        checks.append(("and editing is possible again",
+                       panel.add_btn.isEnabled() and panel.run_btn.isEnabled()
+                       and not panel.stop_btn.isEnabled(), ""))
+
+        text = panel.log.toPlainText()
+        checks.append(("the summary is in the tab's own log",
+                       "2 of 3 completed" in text and "Bad" in text, ""))
+
+        # Saving and reloading the queue itself.
+        queue_file = tmp / "overnight.meanapqueue"
+        import json as _json
+        queue_file.write_text(_json.dumps(
+            {"runs": [str(p) for p in panel.paths()]}))
+        panel._paths.clear()
+        panel._status.clear()
+        panel.add_paths(_json.loads(queue_file.read_text())["runs"])
+        checks.append(("a saved queue reloads to the same runs",
+                       [p.name for p in panel.paths()]
+                       == [Path(p).name for p in
+                           _json.loads(queue_file.read_text())["runs"]], ""))
+
+        # The two run buttons must not overlap.
+        window._queue_worker = None
+        checks.append(("a single run is refused while the queue is going",
+                       hasattr(window, "_on_run_queue")
+                       and "_queue_worker" in Path(
+                           __import__("meanap.gui.main_window",
+                                      fromlist=["x"]).__file__).read_text(), ""))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("Running a queue of analyses")
+    print("=" * 70)
+    total_pass = total = 0
+    for title, build in [("Loading a queue:", _loading_checks),
+                         ("Running it:", _running_checks),
+                         ("Stopping it:", _cancel_checks),
+                         ("Progress:", _progress_checks),
+                         ("Nothing queued:", _empty_checks)]:
+        p, n = _report(title, build())
+        total_pass += p
+        total += n
+
+    try:
+        import PyQt6  # noqa: F401
+    except ImportError as e:
+        print(f"\nGUI checks SKIPPED — PyQt6 not available ({e})")
+    else:
+        p, n = _report("The Queue tab:", _gui_checks())
+        total_pass += p
+        total += n
+    print(f"\n{'=' * 70}")
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/meanap/catnap/loader.py
+++ b/src/meanap/catnap/loader.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import numpy as np
 
+from meanap.pipeline.atomic import atomic_savez
+
 
 @dataclass
 class Suite2pData:
@@ -112,7 +114,7 @@ def _load_ops_fields(
             arrays = {"fs": np.array(fs)}
             if mean_img is not None:
                 arrays["mean_img"] = np.asarray(mean_img, dtype=np.float32)
-            np.savez_compressed(out, **arrays)
+            atomic_savez(out, compressed=True, **arrays)
         except OSError:
             # A read-only suite2p folder with no derived root configured: the
             # cache is an optimisation, never a requirement.

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -43,7 +43,8 @@ from meanap.catnap.store import (
 )
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
 from meanap.pipeline.resume import (
-    ADJM_SUBDIR, CATNAP_SUFFIX, InputLocator, build_input_locator,
+    ADJM_SUBDIR, CATNAP_SUFFIX, InputLocator, already_done,
+    build_input_locator,
 )
 from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo
@@ -198,10 +199,21 @@ def run_catnap_pipeline(
             continue
         plane0 = fetched
 
+        # Continuing an interrupted run: this recording's adjacency and
+        # activity stats are already in *this* folder, so load them rather than
+        # redoing the STTC and the circular-shift thresholding, which is the
+        # expensive half of the CAT-NAP path.
+        continued = already_done(
+            params, output_root,
+            state_dir / f"{rec.filename}{CATNAP_SUFFIX}", log)
+        if continued:
+            log(f"  [{rec.filename}] already computed — loading")
+
         loaded = (
-            _load_recording(locator, rec, plane0, log) if resuming else
-            _compute_recording(params, rec, plane0, log,
-                               make_rng(params.random_seed, "catnap", rec.filename))
+            _load_recording(locator, rec, plane0, log) if (resuming or continued)
+            else _compute_recording(params, rec, plane0, log,
+                                    make_rng(params.random_seed, "catnap",
+                                             rec.filename))
         )
         if loaded is None:
             if not resuming:

--- a/src/meanap/catnap/store.py
+++ b/src/meanap/catnap/store.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 import numpy as np
 
+from meanap.pipeline.atomic import atomic_savez
+
 __all__ = [
     "RecordingState",
     "save_recording_state",
@@ -167,7 +169,7 @@ def save_recording_state(path: Path, state: RecordingState, stats: dict) -> None
     arrays["stat_none"] = np.asarray(none_keys, dtype=str)
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez(path, **arrays)
+    atomic_savez(path, **arrays)
 
 
 def load_recording_state(path: Path, plane0: Path) -> tuple[RecordingState, dict]:
@@ -307,8 +309,9 @@ def save_background(path: Path, background: tuple | None) -> None:
               else np.zeros(img.shape, dtype=np.uint8))
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    np.savez_compressed(
-        path, levels=levels, value_range=np.array([lo, hi], dtype=float),
+    atomic_savez(
+        path, compressed=True,
+        levels=levels, value_range=np.array([lo, hi], dtype=float),
         extent=np.asarray(extent, dtype=float),
     )
 

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -20,10 +20,11 @@ from meanap.gui import theme
 from meanap.gui.branding import logo_icon, logo_pixmap
 from meanap.gui.modes import (
     DEFAULT_MODE, MODES, TAB_CATNAP, TAB_CONNECTIVITY, TAB_NETWORK, TAB_PATHS,
-    TAB_PIPELINE, TAB_RECORDING, TAB_SPIKE, TAB_STIM, TAB_STIM_PREVIEW,
+    TAB_PIPELINE, TAB_QUEUE, TAB_RECORDING, TAB_SPIKE, TAB_STIM,
+    TAB_STIM_PREVIEW,
     apply_mode_to_params, mode_for_params,
 )
-from meanap.gui.pipeline_worker import PipelineWorker
+from meanap.gui.pipeline_worker import PipelineWorker, QueueWorker
 from meanap.gui.viewer_session import ViewerSessions
 from meanap.gui.panels.paths import PathsPanel
 from meanap.gui.panels.recording import RecordingPanel
@@ -32,6 +33,7 @@ from meanap.gui.panels.connectivity import ConnectivityPanel
 from meanap.gui.panels.stim import StimPanel
 from meanap.gui.panels.stim_preview import StimPreviewPanel
 from meanap.gui.panels.pipeline import PipelinePanel
+from meanap.gui.panels.queue import QueuePanel
 from meanap.gui.panels.catnap import CatNapPanel
 from meanap.gui.panels.network_viewer import NetworkViewerPanel
 from meanap.gui.tooltip import install_tooltip_style, wrap_tooltips
@@ -70,6 +72,7 @@ class MainWindow(QMainWindow):
         self._last_bundle: Path | None = None
         self._current_theme = "dark"
         self._worker: PipelineWorker | None = None
+        self._queue_worker: QueueWorker | None = None
         self._tutorial: TutorialOverlay | None = None
         self._viewers = ViewerSessions()
 
@@ -173,6 +176,7 @@ class MainWindow(QMainWindow):
         self._stim_preview_panel = StimPreviewPanel()
         self._catnap_panel = CatNapPanel()
         self._pipeline_panel = PipelinePanel()
+        self._queue_panel = QueuePanel()
         self._network_viewer_panel = NetworkViewerPanel()
 
         # Every tab is built once and kept alive here; the current mode decides
@@ -188,10 +192,13 @@ class MainWindow(QMainWindow):
             (TAB_CATNAP, self._catnap_panel, "  CAT-NAP (2P)  "),
             (TAB_NETWORK, self._network_viewer_panel, "  Network Viewer  "),
             (TAB_PIPELINE, _scrollable(self._pipeline_panel), "  Pipeline  "),
+            (TAB_QUEUE, self._queue_panel, "  Queue  "),
         ]
         self._apply_mode(self._mode, sync_params=False)
 
         self._catnap_panel.log_message.connect(self._pipeline_panel.append_log)
+        self._queue_panel.run_requested.connect(self._on_run_queue)
+        self._queue_panel.stop_requested.connect(self._on_stop_queue)
 
         # The Paths "Raw data folder" and the CAT-NAP "Recordings folder" are
         # two views of one setting (Params.raw_data), and both panels write it
@@ -632,6 +639,12 @@ class MainWindow(QMainWindow):
     def _on_run(self) -> None:
         if self._worker is not None and self._worker.isRunning():
             return  # a run is already in progress
+        if self._queue_worker is not None and self._queue_worker.isRunning():
+            QMessageBox.information(
+                self, "The queue is running",
+                "Wait for the queue on the Queue tab to finish, or stop it, "
+                "before starting a single run.")
+            return
 
         params = self._collect_params()
         self._params = params
@@ -759,6 +772,51 @@ class MainWindow(QMainWindow):
             # file and quietly overwrite every run that later loads it.
             return replace(params, overwrite_existing_output=True)
         return None
+
+    def _on_run_queue(self) -> None:
+        """Start the queued runs. Refuses to overlap with a single run."""
+        if self._worker is not None and self._worker.isRunning():
+            QMessageBox.information(
+                self, "A run is already going",
+                "Wait for the run on the Pipeline tab to finish, or stop it, "
+                "before starting the queue.")
+            return
+        if self._queue_worker is not None and self._queue_worker.isRunning():
+            return
+
+        paths = self._queue_panel.paths()
+        if not paths:
+            return
+
+        self._queue_panel.start()
+        self._queue_panel.append_log(f"Starting {len(paths)} queued run(s)…")
+
+        worker = QueueWorker(paths, parent=self)
+        worker.log_message.connect(self._queue_panel.append_log)
+        worker.progress.connect(self._queue_panel.show_progress)
+        worker.run_finished.connect(self._queue_panel.mark)
+        worker.finished_all.connect(self._on_queue_finished)
+        worker.failed.connect(self._on_queue_failed)
+        self._queue_worker = worker
+        worker.start()
+
+    def _on_stop_queue(self) -> None:
+        if self._queue_worker is not None and self._queue_worker.isRunning():
+            self._queue_panel.append_log(
+                "Stop requested — finishing the current run, then halting. "
+                "Runs after it will not be started.")
+            self._queue_panel.stop_btn.setEnabled(False)
+            self._queue_worker.request_cancel()
+
+    def _on_queue_finished(self, summary: str) -> None:
+        self._queue_panel.finish(summary)
+        self._queue_worker = None
+
+    def _on_queue_failed(self, message: str) -> None:
+        self._queue_panel.finish("The queue could not start.")
+        self._queue_panel.append_log(f"ERROR: {message}")
+        self._queue_worker = None
+        QMessageBox.critical(self, "Queue error", message)
 
     def _on_stop(self) -> None:
         if self._worker is not None and self._worker.isRunning():

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -708,7 +708,7 @@ class MainWindow(QMainWindow):
             default_output_folder_name, resumes_in_place,
         )
 
-        if resumes_in_place(params):
+        if resumes_in_place(params) or params.continue_interrupted:
             return params   # the run is going to read what is in there
 
         name = params.output_data_folder_name or default_output_folder_name()
@@ -726,9 +726,14 @@ class MainWindow(QMainWindow):
         box.setText(f"<b>{name}</b> already holds a run's results.")
         box.setInformativeText(
             "Running now would overwrite it — its figures, its CSVs and its "
-            f"bundle.<br><br>Save this run as <b>{fresh}</b> instead?"
+            f"bundle.<br><br>Save this run as <b>{fresh}</b> instead, or "
+            "continue the existing one where it stopped?"
         )
         use_new = box.addButton(f"Use {fresh}", QMessageBox.ButtonRole.AcceptRole)
+        # The third option is the one a stopped run actually wants: fill in the
+        # recordings that never finished rather than redo the ones that did.
+        continue_it = box.addButton("Continue it",
+                                    QMessageBox.ButtonRole.ActionRole)
         overwrite = box.addButton("Overwrite", QMessageBox.ButtonRole.DestructiveRole)
         box.addButton(QMessageBox.StandardButton.Cancel)
         box.setDefaultButton(use_new)
@@ -742,6 +747,12 @@ class MainWindow(QMainWindow):
             params.output_data_folder_name = fresh
             self._pipeline_panel.append_log(f"Saving this run as {fresh}.")
             return params
+        if clicked is continue_it:
+            self._pipeline_panel.append_log(
+                f"Continuing {name} — recordings already finished are skipped.")
+            # A copy, for the same reason as below: continuing is a decision
+            # about this run, not a setting to carry into every future one.
+            return replace(params, continue_interrupted=True)
         if clicked is overwrite:
             self._pipeline_panel.append_log(f"Overwriting the existing run in {name}.")
             # A copy, so "overwrite this once" cannot be saved into a parameter

--- a/src/meanap/gui/modes.py
+++ b/src/meanap/gui/modes.py
@@ -19,9 +19,11 @@ from taste:
   apply. It *does* read the connectivity settings (``func_con_lag_val`` and the
   probabilistic-thresholding fields), so that tab stays.
 
-The Paths, Network Viewer and Pipeline tabs appear in every mode: the first two
-are mode-independent (a viewer for results already on disk), and the last is how
-you start a run.
+The Paths, Network Viewer, Pipeline and Queue tabs appear in every mode: the
+first two are mode-independent (a viewer for results already on disk), the third
+is how you start a run, and the fourth runs saved parameter files back to back —
+which may describe *different* pipelines, since each file carries its own mode
+flags and ``run_pipeline`` decides from those.
 """
 
 from __future__ import annotations
@@ -39,6 +41,7 @@ TAB_STIM_PREVIEW = "stim_preview"
 TAB_CATNAP = "catnap"
 TAB_NETWORK = "network"
 TAB_PIPELINE = "pipeline"
+TAB_QUEUE = "queue"
 
 
 @dataclass(frozen=True)
@@ -57,7 +60,7 @@ class Mode:
 
 
 _EPHYS_TABS = (TAB_PATHS, TAB_RECORDING, TAB_SPIKE, TAB_CONNECTIVITY,
-               TAB_NETWORK, TAB_PIPELINE)
+               TAB_NETWORK, TAB_PIPELINE, TAB_QUEUE)
 
 MODES: dict[str, Mode] = {
     "meanap": Mode(
@@ -78,7 +81,7 @@ MODES: dict[str, Mode] = {
         label="CAT-NAP  ·  2P imaging",
         blurb="Network analysis of two-photon calcium imaging processed with suite2p.",
         tabs=frozenset((TAB_PATHS, TAB_CONNECTIVITY, TAB_CATNAP,
-                        TAB_NETWORK, TAB_PIPELINE)),
+                        TAB_NETWORK, TAB_PIPELINE, TAB_QUEUE)),
         suite2p_mode=True,
     ),
 }

--- a/src/meanap/gui/panels/paths.py
+++ b/src/meanap/gui/panels/paths.py
@@ -150,7 +150,7 @@ class PathsPanel(QWidget):
         extra_row.setContentsMargins(0, 0, 0, 0)
         extra_row.addWidget(self.extra_priors)
         extra_row.addLayout(prior_buttons)
-        form3.addRow("…and also", extra_row)
+        form3.addRow("Additional folders", extra_row)
 
         hint = QLabel("Naming more than one combines them: a spreadsheet listing "
                       "recordings from several runs is analysed as one batch.")

--- a/src/meanap/gui/panels/paths.py
+++ b/src/meanap/gui/panels/paths.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 
 from PyQt6.QtWidgets import (
-    QFileDialog, QFormLayout, QGroupBox, QHBoxLayout,
-    QLineEdit, QPushButton, QVBoxLayout, QWidget,
+    QFileDialog, QFormLayout, QGroupBox, QHBoxLayout, QLabel,
+    QLineEdit, QListWidget, QPushButton, QVBoxLayout, QWidget,
 )
 
 from meanap.params import Params, is_remote_url
@@ -118,8 +118,45 @@ class PathsPanel(QWidget):
         form3 = QFormLayout(prior_box)
         form3.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
 
+        # One row, plus a list for any further folders. Merging runs is just
+        # naming more than one previous analysis, and a spreadsheet listing
+        # recordings from all of them — so the field that already means "read
+        # from an earlier run" grows rather than a second concept appearing.
         self.prior_analysis_path = PathRow(self)
         form3.addRow("Previous analysis folder", self.prior_analysis_path)
+
+        self.extra_priors = QListWidget()
+        self.extra_priors.setMaximumHeight(74)
+        self.extra_priors.setToolTip(
+            "Further previous analyses, searched after the one above. A run "
+            "whose spreadsheet lists recordings from several of these produces "
+            "one pooled analysis over all of them, recomputing none.\n\n"
+            "Each may be an OutputData… folder or a .meanap bundle."
+        )
+        self.add_prior_btn = QPushButton("Add…")
+        self.add_prior_btn.setFixedWidth(80)
+        self.add_prior_btn.clicked.connect(self._on_add_prior)
+        self.remove_prior_btn = QPushButton("Remove")
+        self.remove_prior_btn.setFixedWidth(80)
+        self.remove_prior_btn.clicked.connect(self._on_remove_prior)
+
+        prior_buttons = QVBoxLayout()
+        prior_buttons.setContentsMargins(0, 0, 0, 0)
+        prior_buttons.addWidget(self.add_prior_btn)
+        prior_buttons.addWidget(self.remove_prior_btn)
+        prior_buttons.addStretch()
+
+        extra_row = QHBoxLayout()
+        extra_row.setContentsMargins(0, 0, 0, 0)
+        extra_row.addWidget(self.extra_priors)
+        extra_row.addLayout(prior_buttons)
+        form3.addRow("…and also", extra_row)
+
+        hint = QLabel("Naming more than one combines them: a spreadsheet listing "
+                      "recordings from several runs is analysed as one batch.")
+        hint.setWordWrap(True)
+        hint.setStyleSheet("color: gray; font-size: 10px;")
+        form3.addRow("", hint)
 
         layout.addWidget(input_box)
         layout.addWidget(output_box)
@@ -141,6 +178,37 @@ class PathsPanel(QWidget):
         if path:
             self.spreadsheet.set_value(path)
 
+    def _on_add_prior(self) -> None:
+        start = (self.prior_analysis_path.value.strip()
+                 or self.output_data_folder.value.strip())
+        # Either kind: a run folder, or the bundle an express run left instead.
+        path = QFileDialog.getExistingDirectory(
+            self, "Select another previous analysis folder", start)
+        if not path:
+            path, _ = QFileDialog.getOpenFileName(
+                self, "…or a .meanap bundle", start, "Run bundles (*.meanap)")
+        if path and not self._prior_listed(path):
+            self.extra_priors.addItem(path)
+
+    def _on_remove_prior(self) -> None:
+        for item in self.extra_priors.selectedItems():
+            self.extra_priors.takeItem(self.extra_priors.row(item))
+
+    def _prior_listed(self, path: str) -> bool:
+        """Whether this folder is already named, here or as the first one.
+
+        Listing one twice is harmless — the lookup takes the first hit — but it
+        reads as though it were contributing twice, which it is not.
+        """
+        listed = {self.prior_analysis_path.value.strip()}
+        listed |= {self.extra_priors.item(i).text()
+                   for i in range(self.extra_priors.count())}
+        return path in listed
+
+    def extra_prior_paths(self) -> list[str]:
+        return [self.extra_priors.item(i).text()
+                for i in range(self.extra_priors.count())]
+
     def load(self, params: Params) -> None:
         self.raw_data.set_value(params.raw_data)
         self.spreadsheet.set_value(params.spreadsheet_file_name)
@@ -150,6 +218,9 @@ class PathsPanel(QWidget):
         self.output_data_folder.set_value(params.output_data_folder)
         self.output_data_folder_name.setText(params.output_data_folder_name)
         self.prior_analysis_path.set_value(params.prior_analysis_path)
+        self.extra_priors.clear()
+        for extra in params.prior_analysis_paths:
+            self.extra_priors.addItem(extra)
 
     def save(self, params: Params) -> None:
         params.raw_data = self.raw_data.value
@@ -160,3 +231,4 @@ class PathsPanel(QWidget):
         params.output_data_folder = self.output_data_folder.value
         params.output_data_folder_name = self.output_data_folder_name.text()
         params.prior_analysis_path = self.prior_analysis_path.value
+        params.prior_analysis_paths = self.extra_prior_paths()

--- a/src/meanap/gui/panels/pipeline.py
+++ b/src/meanap/gui/panels/pipeline.py
@@ -51,6 +51,34 @@ class PipelinePanel(QWidget):
             lambda v: self.start_step.setValue(min(self.start_step.value(), v))
         )
 
+        # Continuing is about *recordings*, where prior analysis is about
+        # *steps* — two different questions that both mean "don't redo work",
+        # so they sit together and each says what it skips.
+        self.continue_interrupted = QCheckBox()
+        self.continue_interrupted.setToolTip(
+            "Pick up a run that stopped partway. Writes into the same output "
+            "folder and skips any recording already finished, so a batch cut "
+            "off at recording 5 of 10 carries on at 6.\n\n"
+            "This is also how you add or remove recordings: edit the "
+            "spreadsheet, tick this, and only the new ones are computed. "
+            "Everything pooled across the batch — group comparisons, "
+            "batch-scaled axes, cartography boundaries — is redone over "
+            "whatever the spreadsheet now lists."
+        )
+
+        self.prune_removed = QCheckBox()
+        self.prune_removed.setEnabled(False)
+        self.prune_removed.setToolTip(
+            "When continuing, delete the figures of recordings the spreadsheet "
+            "no longer lists. They are left out of every CSV and pooled "
+            "statistic either way, but their plots stay in the output folder "
+            "and the report unless removed, looking like part of the "
+            "analysis.\n\n"
+            "Their data files are kept regardless, so putting a recording back "
+            "stays cheap."
+        )
+        self.continue_interrupted.toggled.connect(self.prune_removed.setEnabled)
+
         self.prior_analysis = QCheckBox()
         self.prior_analysis.setToolTip(
             "Resume from an earlier run: steps before 'Start at step' are read from the "
@@ -68,6 +96,8 @@ class PipelinePanel(QWidget):
         form.addRow("Start at step", self.start_step)
         form.addRow("Stop at step", self.stop_step)
         form.addRow("Use prior analysis", self.prior_analysis)
+        form.addRow("Continue previous run", self.continue_interrupted)
+        form.addRow("   …and drop removed recordings' figures", self.prune_removed)
         form.addRow("Optional steps", self.optional_steps)
 
         # ── Step overview ─────────────────────────────────────────────────────
@@ -272,6 +302,9 @@ class PipelinePanel(QWidget):
         self.start_step.setValue(params.start_analysis_step)
         self.stop_step.setValue(params.stop_analysis_step)
         self.prior_analysis.setChecked(params.prior_analysis)
+        self.continue_interrupted.setChecked(params.continue_interrupted)
+        self.prune_removed.setChecked(params.prune_removed_recordings)
+        self.prune_removed.setEnabled(params.continue_interrupted)
         idx = self.verbose_level.findText(params.verbose_level)
         if idx >= 0:
             self.verbose_level.setCurrentIndex(idx)
@@ -288,6 +321,11 @@ class PipelinePanel(QWidget):
         params.start_analysis_step = self.start_step.value()
         params.stop_analysis_step = self.stop_step.value()
         params.prior_analysis = self.prior_analysis.isChecked()
+        params.continue_interrupted = self.continue_interrupted.isChecked()
+        # Only meaningful while continuing, and a stored True that silently
+        # applied to a fresh run would delete figures nobody asked about.
+        params.prune_removed_recordings = (
+            self.prune_removed.isChecked() and self.continue_interrupted.isChecked())
         params.verbose_level = self.verbose_level.currentText()
         params.time_processes = self.time_processes.isChecked()
         params.express_mode = self.express_mode.isChecked()

--- a/src/meanap/gui/panels/queue.py
+++ b/src/meanap/gui/panels/queue.py
@@ -1,0 +1,293 @@
+"""Queue tab: several saved analyses, run one after another.
+
+The window configures *one* run. This tab is for the other case — a few
+different analyses to get through, and nobody wanting to sit up for the
+handovers. Each entry is a parameter file saved from the toolbar, so building a
+queue is: configure a run, **Save params…**, change what you like, save again,
+then add both here.
+
+Deliberately a list of *files* rather than of in-memory settings. A queue that
+referred to the window's current state could not be reordered, saved, or read
+the next morning to see what actually ran, and would silently change under a
+tab edit made while it was running.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QFileDialog, QGroupBox, QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
+    QMessageBox, QProgressBar, QPushButton, QTextEdit, QVBoxLayout, QWidget,
+)
+
+from meanap.pipeline.progress import format_duration
+
+#: Shown against each entry as the queue proceeds.
+_MARKS = {"queued": "·", "running": "▶", "done": "✓",
+          "failed": "✗", "cancelled": "■", "skipped": "·"}
+
+
+class QueuePanel(QWidget):
+    """Build a list of saved runs, then run the lot."""
+
+    log_message = pyqtSignal(str)
+    #: Asks the window to start or stop the queue — the panel owns the list,
+    #: the window owns the worker, for the same reason the Pipeline tab does.
+    run_requested = pyqtSignal()
+    stop_requested = pyqtSignal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._paths: list[Path] = []
+        self._status: list[str] = []
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+
+        intro = QLabel(
+            "Add parameter files saved with <b>Save params…</b>. They run in "
+            "order, each into its own output folder, and a run that fails does "
+            "not stop the ones after it."
+        )
+        intro.setWordWrap(True)
+        intro.setStyleSheet("color: gray;")
+        layout.addWidget(intro)
+
+        layout.addWidget(self._build_list_box(), stretch=1)
+        layout.addWidget(self._build_progress_box())
+        layout.addWidget(self._build_log_box(), stretch=1)
+
+    # ── Construction ──────────────────────────────────────────────────────────
+
+    def _build_list_box(self) -> QWidget:
+        box = QGroupBox("Runs")
+        outer = QHBoxLayout(box)
+
+        self.list = QListWidget()
+        self.list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        outer.addWidget(self.list, stretch=1)
+
+        buttons = QVBoxLayout()
+        self.add_btn = QPushButton("Add…")
+        self.add_btn.clicked.connect(self._on_add)
+        self.remove_btn = QPushButton("Remove")
+        self.remove_btn.clicked.connect(self._on_remove)
+        self.up_btn = QPushButton("Move up")
+        self.up_btn.clicked.connect(lambda: self._move(-1))
+        self.down_btn = QPushButton("Move down")
+        self.down_btn.clicked.connect(lambda: self._move(1))
+        self.save_btn = QPushButton("Save queue…")
+        self.save_btn.setToolTip(
+            "Write this list to a file so the same set of runs can be loaded "
+            "again — the queue itself, not the parameters, which stay in their "
+            "own files."
+        )
+        self.save_btn.clicked.connect(self._on_save_queue)
+        self.load_btn = QPushButton("Load queue…")
+        self.load_btn.clicked.connect(self._on_load_queue)
+
+        for widget in (self.add_btn, self.remove_btn, self.up_btn, self.down_btn):
+            widget.setFixedWidth(110)
+            buttons.addWidget(widget)
+        buttons.addSpacing(12)
+        for widget in (self.save_btn, self.load_btn):
+            widget.setFixedWidth(110)
+            buttons.addWidget(widget)
+        buttons.addStretch()
+        outer.addLayout(buttons)
+        return box
+
+    def _build_progress_box(self) -> QWidget:
+        box = QGroupBox("Run")
+        layout = QVBoxLayout(box)
+
+        row = QHBoxLayout()
+        self.run_btn = QPushButton("▶  Run queue")
+        self.run_btn.setFixedHeight(40)
+        self.run_btn.clicked.connect(self.run_requested)
+        self.stop_btn = QPushButton("■  Stop")
+        self.stop_btn.setFixedHeight(40)
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self.stop_requested)
+        row.addWidget(self.run_btn)
+        row.addWidget(self.stop_btn)
+        layout.addLayout(row)
+
+        self.overall = QProgressBar()
+        self.overall.setRange(0, 1000)
+        self.overall.setTextVisible(False)
+        self.overall.setFixedHeight(18)
+        self.status_label = QLabel("Nothing queued.")
+        self.status_label.setWordWrap(True)
+        self.eta_label = QLabel("")
+        self.eta_label.setStyleSheet("font-size: 11px; color: gray;")
+
+        layout.addWidget(self.overall)
+        layout.addWidget(self.status_label)
+        layout.addWidget(self.eta_label)
+        return box
+
+    def _build_log_box(self) -> QWidget:
+        box = QGroupBox("Queue log")
+        layout = QVBoxLayout(box)
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setAcceptDrops(False)
+        self.log.setMinimumHeight(120)
+        layout.addWidget(self.log)
+        return box
+
+    # ── The list ──────────────────────────────────────────────────────────────
+
+    def paths(self) -> list[Path]:
+        return list(self._paths)
+
+    def _refresh(self) -> None:
+        self.list.clear()
+        for path, status in zip(self._paths, self._status):
+            item = QListWidgetItem(f"{_MARKS.get(status, '·')}  {path.stem}")
+            item.setToolTip(str(path))
+            if status == "failed":
+                item.setForeground(Qt.GlobalColor.red)
+            self.list.addItem(item)
+        n = len(self._paths)
+        if not n:
+            self.status_label.setText("Nothing queued.")
+        self.run_btn.setEnabled(bool(n))
+
+    def add_paths(self, paths) -> int:
+        """Add parameter files, skipping any already listed. Returns how many."""
+        added = 0
+        for entry in paths:
+            path = Path(entry)
+            if path in self._paths:
+                # Running the same file twice would write to the same output
+                # folder twice, which is a mistake rather than an instruction.
+                self._log(f"Already queued, not added again: {path.name}")
+                continue
+            self._paths.append(path)
+            self._status.append("queued")
+            added += 1
+        self._refresh()
+        return added
+
+    def _on_add(self) -> None:
+        paths, _ = QFileDialog.getOpenFileNames(
+            self, "Add saved parameter files", "",
+            "MEA-NAP parameters (*.json)")
+        if paths:
+            self.add_paths(paths)
+
+    def _on_remove(self) -> None:
+        for row in sorted({i.row() for i in self.list.selectedIndexes()},
+                          reverse=True):
+            del self._paths[row]
+            del self._status[row]
+        self._refresh()
+
+    def _move(self, delta: int) -> None:
+        rows = sorted({i.row() for i in self.list.selectedIndexes()},
+                      reverse=delta > 0)
+        if not rows:
+            return
+        for row in rows:
+            target = row + delta
+            if not 0 <= target < len(self._paths):
+                return
+            for seq in (self._paths, self._status):
+                seq[row], seq[target] = seq[target], seq[row]
+        self._refresh()
+        for row in rows:
+            self.list.item(row + delta).setSelected(True)
+
+    def _on_save_queue(self) -> None:
+        if not self._paths:
+            return
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save this queue", "", "MEA-NAP queue (*.meanapqueue *.json)")
+        if not path:
+            return
+        try:
+            Path(path).write_text(json.dumps(
+                {"runs": [str(p) for p in self._paths]}, indent=2))
+        except OSError as e:
+            QMessageBox.warning(self, "Could not save the queue", str(e))
+            return
+        self._log(f"Queue saved to {path}")
+
+    def _on_load_queue(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load a queue", "", "MEA-NAP queue (*.meanapqueue *.json)")
+        if not path:
+            return
+        try:
+            data = json.loads(Path(path).read_text())
+            entries = [str(p) for p in data["runs"]]
+        except (OSError, ValueError, KeyError, TypeError) as e:
+            QMessageBox.warning(
+                self, "Could not read that queue",
+                f"{Path(path).name}: {e}\n\nA queue file lists the parameter "
+                f"files to run, under a 'runs' key.")
+            return
+        self._paths.clear()
+        self._status.clear()
+        added = self.add_paths(entries)
+        self._log(f"Loaded {added} run(s) from {Path(path).name}")
+
+    # ── Progress ──────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        self._status = ["queued"] * len(self._paths)
+        self._refresh()
+        self.run_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        for widget in (self.add_btn, self.remove_btn, self.up_btn,
+                       self.down_btn, self.load_btn):
+            widget.setEnabled(False)
+        self.overall.setValue(0)
+        self.eta_label.setText("")
+
+    def show_progress(self, index: int, label: str, snapshot) -> None:
+        """Where the queue is, and where the run in flight is within it."""
+        total = max(len(self._paths), 1)
+        if index < len(self._status):
+            self._status[index] = "running"
+            self._refresh()
+        # One bar for the queue: whole runs behind, plus this run's fraction.
+        self.overall.setValue(
+            int(round((index + snapshot.fraction) / total * 1000)))
+        self.status_label.setText(
+            f"Run {index + 1} of {total} — {label}   ·   "
+            f"{snapshot.percent}%  {snapshot.phase}"
+            + (f"  ·  {snapshot.detail}" if snapshot.detail else ""))
+        self.eta_label.setText(
+            f"{format_duration(snapshot.elapsed_s)} into this run"
+            + ("" if snapshot.eta_s is None
+               else f"  ·  about {format_duration(snapshot.eta_s)} left in it"))
+
+    def mark(self, index: int, status: str) -> None:
+        if 0 <= index < len(self._status):
+            self._status[index] = status
+            self._refresh()
+
+    def finish(self, summary: str) -> None:
+        self.run_btn.setEnabled(bool(self._paths))
+        self.stop_btn.setEnabled(False)
+        for widget in (self.add_btn, self.remove_btn, self.up_btn,
+                       self.down_btn, self.load_btn):
+            widget.setEnabled(True)
+        self.overall.setValue(1000)
+        self.status_label.setText(summary)
+        self.eta_label.setText("")
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    def _log(self, text: str) -> None:
+        self.log.append(text)
+        self.log_message.emit(text)
+
+    def append_log(self, text: str) -> None:
+        self.log.append(text)

--- a/src/meanap/gui/panels/spreadsheet_editor.py
+++ b/src/meanap/gui/panels/spreadsheet_editor.py
@@ -63,6 +63,11 @@ class SpreadsheetEditor(QDialog):
         self._path = str(path or "")
         self._suggested_path = str(suggested_path or "")
         self._updating = False
+        #: Recording names as this sheet was opened, or None for a new one.
+        #: Editing an existing list is how a batch is added to or trimmed, and
+        #: the run has a cheaper way of handling that than starting again — but
+        #: only if the person editing knows it exists.
+        self._opened_with: set[str] | None = None
 
         layout = QVBoxLayout(self)
 
@@ -94,6 +99,8 @@ class SpreadsheetEditor(QDialog):
                                     "Starting from an empty sheet instead.")
                 table = None
         self.set_table(table if table is not None else new_recording_table([]))
+        if self._path:
+            self._opened_with = self._recording_names()
 
     # ── Construction ──────────────────────────────────────────────────────────
 
@@ -363,17 +370,53 @@ class SpreadsheetEditor(QDialog):
 
     # ── Validation display ────────────────────────────────────────────────────
 
+    def _recording_names(self) -> set[str]:
+        return {str(n).strip() for n in self.table().iloc[:, 0]
+                if str(n).strip()} if self._table.rowCount() else set()
+
+    def _describe_edits(self) -> str:
+        """What changed since this sheet was opened, and what it means for a run.
+
+        Only for a sheet that was opened from disk: a new one has nothing to
+        have changed from.
+        """
+        if self._opened_with is None:
+            return ""
+        now = self._recording_names()
+        added = now - self._opened_with
+        removed = self._opened_with - now
+        if not added and not removed:
+            return ""
+
+        parts = []
+        if added:
+            parts.append(f"{len(added)} added")
+        if removed:
+            parts.append(f"{len(removed)} removed")
+        return (f"{' and '.join(parts)}. Tick “Continue previous run” on the "
+                f"Pipeline tab and only the new recording(s) are analysed — "
+                f"everything pooled across the batch is redone either way."
+                + (" Removed recordings' figures stay in the output folder "
+                   "unless you also tick the option below it."
+                   if removed else ""))
+
     def _refresh(self) -> None:
         self._file_label.setText(
             f"Editing {self._path}" if self._path
             else "Unsaved spreadsheet — use “Save as…” to choose where it goes."
         )
         problems = validate_recording_table(self.table())
+        # Shown alongside any problems rather than instead of them: what needs
+        # fixing and what the edit means for the next run are different
+        # questions, and the second is the one nobody would think to ask.
+        edits = self._describe_edits()
         if problems:
-            self._set_status(" ".join(problems), warn=True)
+            self._set_status(" ".join(problems) + (f"  —  {edits}" if edits else ""),
+                             warn=True)
         else:
             n = self._table.rowCount()
-            self._set_status(f"{n} recording(s), ready to use.")
+            base = f"{n} recording(s), ready to use."
+            self._set_status(f"{base}  {edits}" if edits else base)
 
     def _set_status(self, text: str, warn: bool = False) -> None:
         self._status.setText(("⚠ " if warn else "") + text)

--- a/src/meanap/gui/pipeline_worker.py
+++ b/src/meanap/gui/pipeline_worker.py
@@ -62,3 +62,69 @@ class PipelineWorker(QThread):
             self.failed.emit(str(exc))
         else:
             self.finished_ok.emit(output_root)
+
+
+class QueueWorker(QThread):
+    """Runs a queue of saved analyses in the background.
+
+    Separate from :class:`PipelineWorker` rather than a mode of it: this owns a
+    *list* of runs and has to report which one is in flight, and folding both
+    into one class would mean every signal carrying an index the single-run case
+    never uses.
+    """
+
+    log_message = pyqtSignal(str)
+    #: ``(index, label, Progress)`` for the run currently going.
+    progress = pyqtSignal(int, str, object)
+    #: ``(index, status)`` as each run ends — see meanap.pipeline.queue.
+    run_finished = pyqtSignal(int, str)
+    #: The whole queue is done; carries a one-line summary.
+    finished_all = pyqtSignal(str)
+    failed = pyqtSignal(str)
+
+    def __init__(self, paths, parent=None) -> None:
+        super().__init__(parent)
+        self._paths = list(paths)
+        self._cancel_requested = False
+
+    def request_cancel(self) -> None:
+        """Stop after the current run reaches its next checkpoint."""
+        self._cancel_requested = True
+
+    def run(self) -> None:  # noqa: D401 - QThread entry point
+        from meanap.pipeline.queue import load_queue, run_queue
+
+        try:
+            runs = load_queue(self._paths)
+        except ValueError as e:
+            # Bad input is worth refusing before anything starts, so the person
+            # who set this up at 6pm hears about it at 6pm.
+            self.failed.emit(str(e))
+            return
+
+        index = {"of": 0}
+
+        def finished(outcome) -> None:
+            self.run_finished.emit(index["of"], outcome.status)
+            index["of"] += 1
+
+        try:
+            result = run_queue(
+                runs,
+                log=self.log_message.emit,
+                should_cancel=lambda: self._cancel_requested,
+                progress=lambda i, run, snap: self.progress.emit(
+                    i, run.label, snap),
+                on_finished=finished,
+            )
+        except Exception as exc:                          # noqa: BLE001
+            self.failed.emit(str(exc))
+            return
+
+        total = len(result.outcomes)
+        summary = f"{result.done} of {total} completed"
+        if result.failed:
+            summary += f", {result.failed} failed"
+        if result.cancelled or any(o.status == "skipped" for o in result.outcomes):
+            summary += ", stopped early"
+        self.finished_all.emit(summary)

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -21,6 +21,12 @@ class Params:
     # overwrite, for the caller who means it. Resuming *into* a folder is not
     # affected; that reads what it then rewrites. See pipeline/output_folders.py.
     overwrite_existing_output: bool = False
+    # Pick up an interrupted run where it stopped. Writes into the *same* output
+    # folder and skips any recording whose result for that step is already there
+    # — so a batch cut off at recording 5 of 10 resumes at 6 rather than from
+    # the start. Only artefacts that are complete count: writes are atomic, and
+    # anything unreadable is redone. See pipeline/atomic.py and pipeline/resume.py.
+    continue_interrupted: bool = False
 
     # ── Recording ────────────────────────────────────────────────────────────
     fs: float = 25000.0

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -27,6 +27,13 @@ class Params:
     # the start. Only artefacts that are complete count: writes are atomic, and
     # anything unreadable is redone. See pipeline/atomic.py and pipeline/resume.py.
     continue_interrupted: bool = False
+    # When continuing, delete the figures of recordings the spreadsheet no
+    # longer names. They are excluded from every CSV and pooled statistic
+    # either way; left on disk they still show up in the output folder and the
+    # report, looking like part of the analysis. Off by default because this
+    # deletes results. Their data files are kept regardless — that is what
+    # makes adding a recording back cheap. See pipeline/roster.py.
+    prune_removed_recordings: bool = False
 
     # ── Recording ────────────────────────────────────────────────────────────
     fs: float = 25000.0
@@ -149,6 +156,11 @@ class Params:
     # recomputing them. Results still go to this run's own output folder — the
     # prior run is only ever read. See pipeline/resume.py.
     prior_analysis: bool = False
+    # Further previous runs to read from, searched after ``prior_analysis_path``.
+    # This is what combines runs: a spreadsheet naming recordings analysed in
+    # different batches produces one pooled analysis over all of them, with
+    # nothing recomputed. See pipeline/resume.py.
+    prior_analysis_paths: list[str] = field(default_factory=list)
     # Seed for every stochastic stage (step-3 thresholding, modularity, null
     # models, NMF, example-trace picking). None = fresh OS entropy each run,
     # matching MATLAB, which seeds nothing. See pipeline/rng.py.

--- a/src/meanap/params_summary.py
+++ b/src/meanap/params_summary.py
@@ -1,0 +1,213 @@
+"""The settings a run used, arranged for a person to read.
+
+``params.json`` is the authoritative record of how a result was produced, and
+it is unreadable: a flat object of ~180 keys in declaration order, most of them
+at their defaults. The question a reader actually has is narrower — *what was
+different about this run?* — and the answer is usually a dozen fields.
+
+So this groups the fields the way :class:`~meanap.params.Params` groups them,
+marks the ones that differ from the defaults, and hides paths that should not
+travel. Both the static ``report.html`` and the interactive viewer render the
+same structure, so the two cannot disagree about what a run was.
+
+**The grouping comes from the dataclass source**, not from a list kept here.
+``Params`` marks its sections with ``# ── Spike detection ──`` comments and
+declares its fields in order, so walking the source assigns every field to the
+section it was written under — and a field added tomorrow lands in the right
+place with nothing to update. If the source is unavailable (a frozen build),
+everything falls into one group rather than nothing being shown.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from meanap.params import Params, SECRET_URL_FIELDS, is_remote_url
+
+__all__ = [
+    "ParamEntry", "ParamGroup", "ParamsSummary",
+    "summarise_params", "summary_from_file", "field_sections",
+]
+
+#: Shown instead of a value that should not travel with a shared report.
+REDACTED = "‹remote source hidden›"
+
+#: ``# ── Spike detection ──────────`` in the dataclass body.
+_SECTION_RE = re.compile(r"^\s*#\s*──\s*(?P<name>.+?)\s*─+\s*$")
+
+#: ``fs: float = 25000.0`` — a field declaration, not a comment or a method.
+_FIELD_RE = re.compile(r"^\s{4}(?P<name>[a-z_][a-z0-9_]*)\s*:")
+
+#: Where a field with no section of its own is put.
+_UNGROUPED = "Other"
+
+
+@dataclass(frozen=True)
+class ParamEntry:
+    """One setting, and whether the run changed it."""
+
+    name: str
+    value: Any
+    default: Any
+    changed: bool
+    #: True when the value was replaced because it names a remote source.
+    redacted: bool = False
+
+    def as_dict(self) -> dict:
+        return {"name": self.name, "value": self.value, "default": self.default,
+                "changed": self.changed, "redacted": self.redacted}
+
+
+@dataclass(frozen=True)
+class ParamGroup:
+    """One section of the settings, in declaration order."""
+
+    name: str
+    entries: list[ParamEntry]
+
+    @property
+    def changed(self) -> int:
+        return sum(1 for e in self.entries if e.changed)
+
+    def as_dict(self) -> dict:
+        return {"name": self.name, "changed": self.changed,
+                "entries": [e.as_dict() for e in self.entries]}
+
+
+@dataclass
+class ParamsSummary:
+    """Every setting, grouped, plus what the file held that we don't know."""
+
+    groups: list[ParamGroup] = field(default_factory=list)
+    #: Keys present in the file that this version has no field for — a
+    #: version-skew signal, and the reason it is surfaced rather than dropped.
+    unknown: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def changed(self) -> int:
+        return sum(g.changed for g in self.groups)
+
+    @property
+    def total(self) -> int:
+        return sum(len(g.entries) for g in self.groups)
+
+    def as_dict(self) -> dict:
+        return {"groups": [g.as_dict() for g in self.groups],
+                "unknown": self.unknown,
+                "changed": self.changed, "total": self.total}
+
+
+def field_sections() -> dict[str, str]:
+    """``field name → section heading``, read off the dataclass source.
+
+    Empty when the source cannot be read, which callers treat as "one group".
+    """
+    try:
+        source = inspect.getsource(Params)
+    except (OSError, TypeError):
+        return {}
+
+    sections: dict[str, str] = {}
+    current = _UNGROUPED
+    for line in source.splitlines():
+        match = _SECTION_RE.match(line)
+        if match:
+            current = match.group("name")
+            continue
+        match = _FIELD_RE.match(line)
+        if match:
+            sections.setdefault(match.group("name"), current)
+    return sections
+
+
+def _defaults() -> dict[str, Any]:
+    """Each field's default, with the factory ones actually called."""
+    out: dict[str, Any] = {}
+    for f in dataclasses.fields(Params):
+        if f.default is not dataclasses.MISSING:
+            out[f.name] = f.default
+        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            out[f.name] = f.default_factory()               # type: ignore[misc]
+    return out
+
+
+def _display(name: str, value: Any) -> tuple[Any, bool]:
+    """The value to show, and whether it was hidden.
+
+    A report is a thing people attach to papers and email around. A share link
+    in it is a credential — see :data:`~meanap.params.SECRET_URL_FIELDS`, which
+    exists for the same reason on the bundle side.
+    """
+    if name in SECRET_URL_FIELDS and is_remote_url(str(value)):
+        return REDACTED, True
+    if isinstance(value, Path):
+        return str(value), False
+    return value, False
+
+
+def summarise_params(
+    params: Params | dict, *, unknown: dict[str, Any] | None = None,
+) -> ParamsSummary:
+    """Group *params* by section and mark what differs from the defaults."""
+    if isinstance(params, Params):
+        values = dataclasses.asdict(params)
+    else:
+        values = dict(params)
+
+    defaults = _defaults()
+    sections = field_sections()
+
+    # Declaration order, which is the order a reader of Params would meet them.
+    known = [f.name for f in dataclasses.fields(Params)]
+    grouped: dict[str, list[ParamEntry]] = {}
+    order: list[str] = []
+
+    for name in known:
+        if name not in values:
+            continue                      # an older file simply lacks the field
+        raw = values[name]
+        default = defaults.get(name)
+        shown, redacted = _display(name, raw)
+        section = sections.get(name, _UNGROUPED)
+        if section not in grouped:
+            grouped[section] = []
+            order.append(section)
+        grouped[section].append(ParamEntry(
+            name=name, value=shown, default=default,
+            changed=raw != default, redacted=redacted,
+        ))
+
+    extra = {k: v for k, v in values.items() if k not in set(known)}
+    if unknown:
+        extra.update(unknown)
+
+    return ParamsSummary(
+        groups=[ParamGroup(name=s, entries=grouped[s]) for s in order],
+        unknown=extra,
+    )
+
+
+def summary_from_file(path: Path | str) -> ParamsSummary | None:
+    """Summarise a ``params.json``, or ``None`` if it isn't there or is broken.
+
+    Returns ``None`` rather than raising: a report missing its parameter table
+    is worth less than one that fails to build.
+    """
+    import json
+
+    path = Path(path)
+    if not path.is_file():
+        return None
+    try:
+        with open(path) as fh:
+            raw = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return summarise_params(raw)

--- a/src/meanap/pipeline/atomic.py
+++ b/src/meanap/pipeline/atomic.py
@@ -1,0 +1,122 @@
+"""Writes that either land whole or not at all.
+
+Everything the pipeline writes, it used to write in place: open the final path,
+stream bytes into it, hope. That is fine until a run is interrupted — Ctrl-C, a
+cluster job hitting its wall clock, a laptop lid — and then the file that was
+mid-write is left truncated, at its final name, looking exactly like a finished
+one.
+
+That is survivable when the only cost is redoing the work. It stops being
+survivable once a run can *continue* from what is already on disk, because then
+"the file is there" is taken to mean "that recording is done". A truncated
+``.npz`` would be skipped and then fail to load in a later step, hours away from
+the thing that caused it.
+
+So resumable artefacts are written to a temporary name in the same directory and
+then :func:`os.replace`\\ d into place, which is atomic on POSIX and on Windows.
+A reader sees the old file or the new one, never a partial one, and an interrupt
+leaves the temporary file behind rather than a corrupt result.
+
+Same directory matters: ``os.replace`` is only atomic within a filesystem, and a
+temp dir is often a different one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable
+
+__all__ = ["atomic_path", "atomic_write_json", "atomic_savez", "is_readable_npz"]
+
+
+@contextmanager
+def atomic_path(path: Path | str, suffix: str = ""):
+    """Yield a temporary path; on clean exit, move it onto *path*.
+
+    ``suffix`` is worth passing when the writer picks its behaviour from the
+    extension — ``numpy.savez`` appends ``.npz`` to a name that lacks it, which
+    would otherwise move the wrong file into place.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.",
+                               suffix=suffix or ".tmp")
+    os.close(fd)
+    tmp = Path(tmp)
+    try:
+        yield tmp
+        os.replace(tmp, path)
+    except BaseException:
+        # Includes KeyboardInterrupt: an interrupted write must not leave its
+        # scratch file lying around looking like a result.
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_json(path: Path | str, obj: Any, **kwargs) -> Path:
+    """Serialise *obj* to *path* as JSON, atomically."""
+    path = Path(path)
+    with atomic_path(path) as tmp:
+        with open(tmp, "w") as fh:
+            json.dump(obj, fh, **kwargs)
+    return path
+
+
+def atomic_savez(
+    path: Path | str, *, compressed: bool = False, **arrays,
+) -> Path:
+    """``numpy.savez`` to *path*, atomically.
+
+    ``savez`` insists on an ``.npz`` extension, adding one if the name lacks it,
+    so the temporary file is given that extension up front rather than being
+    renamed out from under us.
+    """
+    import numpy as np
+
+    path = Path(path)
+    save = np.savez_compressed if compressed else np.savez
+    with atomic_path(path, suffix=".npz") as tmp:
+        save(tmp, **arrays)
+    return path
+
+
+def is_readable_npz(path: Path | str) -> bool:
+    """Whether *path* is an ``.npz`` that opens and lists its members.
+
+    A cheap integrity check for artefacts written before atomic writes existed,
+    or by something else. It reads the zip directory, not the arrays, so it
+    costs a seek rather than a load.
+    """
+    import numpy as np
+
+    path = Path(path)
+    if not path.is_file():
+        return False
+    try:
+        with np.load(path, allow_pickle=False) as data:
+            data.files
+    except Exception:                                   # noqa: BLE001
+        return False
+    return True
+
+
+def guard_readable(path: Path | str, on_bad: Callable[[str], None] | None = None) -> bool:
+    """``True`` if the artefact can be trusted; otherwise remove it and say so.
+
+    Used where a run decides whether to skip already-done work. Deleting the bad
+    file rather than leaving it means the recording is redone this time *and*
+    next time, instead of tripping the same check on every future run.
+    """
+    if is_readable_npz(path):
+        return True
+    path = Path(path)
+    if path.exists():
+        if on_bad is not None:
+            on_bad(f"  {path.name} is unreadable — redoing it "
+                   f"(a previous run was probably interrupted mid-write)")
+        path.unlink(missing_ok=True)
+    return False

--- a/src/meanap/pipeline/io.py
+++ b/src/meanap/pipeline/io.py
@@ -21,6 +21,7 @@ import h5py
 import numpy as np
 import scipy.io as sio
 
+from meanap.pipeline.atomic import atomic_savez
 from meanap.pipeline.axion_raw import (
     is_axion_raw,
     load_axion_well,
@@ -363,7 +364,7 @@ def save_spike_times_npz(
         for method, times in methods.items():
             arrays[f"spike_times_{ch_idx}_{method}"] = times
 
-    np.savez(path, **arrays)
+    atomic_savez(path, **arrays)
 
     if params is not None:
         params_path = path.with_name(path.stem + "_params.txt")

--- a/src/meanap/pipeline/plotting.py
+++ b/src/meanap/pipeline/plotting.py
@@ -29,6 +29,7 @@ from meanap.params import Params
 from meanap.pipeline.figure_output import savefig
 from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spike_detection import SpikeDetectionResult, bandpass_filter
+from meanap.pipeline.atomic import atomic_savez
 
 __all__ = [
     "SpikeCheckData",
@@ -295,7 +296,7 @@ def save_spike_check_data(path: Path | str, data: SpikeCheckData) -> Path:
     for method, waves in data.waveforms.items():
         arrays[f"waveforms_{method}"] = waves
 
-    np.savez_compressed(path, **arrays)
+    atomic_savez(path, compressed=True, **arrays)
     return path
 
 

--- a/src/meanap/pipeline/plotting_step3.py
+++ b/src/meanap/pipeline/plotting_step3.py
@@ -29,6 +29,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from meanap.pipeline.figure_output import savefig
+from meanap.pipeline.atomic import atomic_savez
 
 __all__ = [
     "EdgeThresholdCheckData",
@@ -154,7 +155,7 @@ def save_edge_threshold_check(
         for field in ("rep_val", "mean_thr", "std_thr", "trajectories",
                       "map_reps", "maps"):
             arrays[f"{lag}ms_{field}"] = getattr(data, field)
-    np.savez_compressed(path, **arrays)
+    atomic_savez(path, compressed=True, **arrays)
     return path
 
 

--- a/src/meanap/pipeline/queue.py
+++ b/src/meanap/pipeline/queue.py
@@ -1,0 +1,243 @@
+"""Running several analyses back to back, unattended.
+
+A run takes minutes to hours, and until now the only way to do a second one was
+to wait for the first, reconfigure, and start again — which means someone has to
+be awake for every handover. The work itself is unattended; the *scheduling* was
+not.
+
+A queue is a list of saved parameter files. Each is a complete description of a
+run, so they can differ in anything at all — different datasets, different
+lags, different pipelines. Nothing here inspects them beyond reading them: a
+CAT-NAP run and an electrophysiology run sit in the same queue because
+:func:`~meanap.pipeline.runner.run_pipeline` already decides which path to take
+from the parameters it is handed.
+
+**One failure does not end the night.** Each run is caught individually and
+recorded; the queue moves on. The point of leaving something running overnight
+is to come back to results, and coming back to five results and one traceback is
+better than coming back to one traceback.
+
+**Cancellation is checked between runs as well as inside them.** Stopping the
+queue while run three is going should not start run four, and the pipeline's own
+cooperative cancellation handles the rest.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+from meanap.params import Params, load_params
+
+__all__ = [
+    "QueuedRun", "RunOutcome", "QueueResult",
+    "load_queue", "run_queue", "summarise",
+]
+
+#: What a queued run ended up doing.
+DONE, FAILED, CANCELLED, SKIPPED = "done", "failed", "cancelled", "skipped"
+
+
+@dataclass
+class QueuedRun:
+    """One analysis waiting to run: its parameters, and where they came from."""
+
+    params: Params
+    #: The parameter file, when it was loaded from one. Shown in the GUI and in
+    #: the summary, because "run 3 of 6" means nothing the next morning.
+    source: Path | None = None
+    #: Parameter keys the file carried that this version has no field for.
+    unknown_keys: list[str] = field(default_factory=list)
+
+    @property
+    def label(self) -> str:
+        """A short name for this run, preferring what the user called it."""
+        if self.params.output_data_folder_name:
+            return self.params.output_data_folder_name
+        if self.source is not None:
+            return self.source.stem
+        return "unnamed run"
+
+    def describe(self) -> str:
+        """One line saying what this run will actually do."""
+        from meanap.gui.modes import MODES, mode_for_params
+
+        mode = MODES[mode_for_params(self.params)].label
+        steps = (f"steps {self.params.start_analysis_step}"
+                 f"–{self.params.stop_analysis_step}")
+        bits = [mode, steps]
+        if self.params.express_mode:
+            bits.append("express")
+        if self.params.continue_interrupted:
+            bits.append("continuing")
+        return "  ·  ".join(bits)
+
+
+@dataclass
+class RunOutcome:
+    """How one queued run finished."""
+
+    run: QueuedRun
+    status: str
+    output: Path | None = None
+    error: str = ""
+    seconds: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        return self.status == DONE
+
+
+@dataclass
+class QueueResult:
+    """How the whole queue finished."""
+
+    outcomes: list[RunOutcome] = field(default_factory=list)
+
+    @property
+    def done(self) -> int:
+        return sum(1 for o in self.outcomes if o.status == DONE)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for o in self.outcomes if o.status == FAILED)
+
+    @property
+    def cancelled(self) -> int:
+        return sum(1 for o in self.outcomes if o.status == CANCELLED)
+
+
+def load_queue(paths: Iterable[Path | str]) -> list[QueuedRun]:
+    """Read parameter files into queued runs.
+
+    A file that will not load raises here rather than at 3am: the queue is
+    checked in full before anything starts, so a typo'd path is a message now
+    instead of a gap in the morning's results.
+    """
+    runs: list[QueuedRun] = []
+    for entry in paths:
+        path = Path(entry).expanduser()
+        if not path.is_file():
+            raise ValueError(f"Parameter file not found: {path}")
+        try:
+            params, unknown = load_params(path)
+        except Exception as e:                            # noqa: BLE001
+            raise ValueError(f"Could not read {path.name}: {e}") from e
+        runs.append(QueuedRun(params=params, source=path,
+                              unknown_keys=list(unknown)))
+    return runs
+
+
+def run_queue(
+    runs: list[QueuedRun],
+    log: Callable[[str], None] = print,
+    should_cancel: Callable[[], bool] | None = None,
+    progress: Callable[[int, QueuedRun, object], None] | None = None,
+    on_finished: Callable[[RunOutcome], None] | None = None,
+) -> QueueResult:
+    """Run each of *runs* in turn, returning what each one did.
+
+    ``progress`` is called as ``(index, run, snapshot)`` with the pipeline's own
+    :class:`~meanap.pipeline.progress.Progress` for the run in flight, so a
+    caller can show both "run 2 of 6" and how far into run 2 it is.
+
+    ``on_finished`` is called with each outcome as it happens, which is what
+    lets a UI mark runs off one by one rather than all at the end.
+    """
+    from meanap.pipeline.cancellation import PipelineCancelled
+    from meanap.pipeline.runner import run_pipeline
+
+    result = QueueResult()
+    total = len(runs)
+
+    for index, run in enumerate(runs):
+        if should_cancel is not None and should_cancel():
+            # Everything from here on is untouched, and says so rather than
+            # being silently missing from the summary.
+            for remaining in runs[index:]:
+                outcome = RunOutcome(run=remaining, status=SKIPPED)
+                result.outcomes.append(outcome)
+                if on_finished is not None:
+                    on_finished(outcome)
+            break
+
+        log(f"\n{'═' * 66}")
+        log(f"Run {index + 1} of {total}: {run.label}")
+        log(f"  {run.describe()}")
+        if run.source is not None:
+            log(f"  from {run.source}")
+        if run.unknown_keys:
+            log(f"  note: {len(run.unknown_keys)} setting(s) in this file are "
+                f"not known to this version: {', '.join(run.unknown_keys[:5])}")
+        log("═" * 66)
+
+        started = time.perf_counter()
+        try:
+            output = run_pipeline(
+                run.params, log=log, should_cancel=should_cancel,
+                progress=(None if progress is None
+                          else lambda snap, i=index, r=run: progress(i, r, snap)),
+            )
+        except PipelineCancelled:
+            outcome = RunOutcome(run=run, status=CANCELLED,
+                                 seconds=time.perf_counter() - started)
+            log(f"Run {index + 1} stopped.")
+        except Exception as e:                            # noqa: BLE001
+            # Caught per run on purpose: the whole point of a queue left running
+            # overnight is that one bad configuration costs one run.
+            outcome = RunOutcome(run=run, status=FAILED, error=str(e),
+                                 seconds=time.perf_counter() - started)
+            log(f"Run {index + 1} FAILED: {e}")
+            log("  The queue continues with the next run.")
+        else:
+            outcome = RunOutcome(run=run, status=DONE, output=output,
+                                 seconds=time.perf_counter() - started)
+            log(f"Run {index + 1} finished in "
+                f"{_duration(outcome.seconds)} → {output}")
+
+        result.outcomes.append(outcome)
+        if on_finished is not None:
+            on_finished(outcome)
+
+    for line in summarise(result):
+        log(line)
+    return result
+
+
+def summarise(result: QueueResult) -> list[str]:
+    """The lines to end on: what ran, what didn't, and where the results are.
+
+    Written for someone reading it the next morning, so every run is named and
+    the failures say why rather than only that.
+    """
+    if not result.outcomes:
+        return ["Nothing was queued."]
+
+    lines = ["", "═" * 66, "Queue summary", "═" * 66]
+    for i, outcome in enumerate(result.outcomes, start=1):
+        mark = {DONE: "✓", FAILED: "✗", CANCELLED: "■", SKIPPED: "·"}[outcome.status]
+        line = f"  {mark} {i}. {outcome.run.label}"
+        if outcome.status == DONE:
+            line += f"  ({_duration(outcome.seconds)})"
+        elif outcome.status == SKIPPED:
+            line += "  — not started"
+        lines.append(line)
+        if outcome.output is not None:
+            lines.append(f"       → {outcome.output}")
+        if outcome.error:
+            lines.append(f"       {outcome.error}")
+
+    total = len(result.outcomes)
+    lines.append("")
+    lines.append(f"  {result.done} of {total} completed"
+                 + (f", {result.failed} failed" if result.failed else "")
+                 + (f", {result.cancelled} stopped" if result.cancelled else ""))
+    return lines
+
+
+def _duration(seconds: float) -> str:
+    from meanap.pipeline.progress import format_duration
+
+    return format_duration(seconds)

--- a/src/meanap/pipeline/report.py
+++ b/src/meanap/pipeline/report.py
@@ -575,10 +575,22 @@ def generate_report(output_root: Path | str, out_path: Path | str | None = None)
     tree = _build_tree(output_root, output_root)
     tree["name"] = output_root.name
 
-    # Escape "<" so no value in the tree — a CSV cell, a filename — can close
-    # the <script> block it is embedded in. \u003c is still "<" to JSON.parse.
+    # The settings the run used, grouped and with the non-defaults marked. A
+    # report is the thing that outlives the folder in someone's downloads, so
+    # what produced it should travel with it. None when there is no params.json
+    # — an older run, or one that failed before writing it.
+    from meanap.params import PARAMS_FILENAME
+    from meanap.params_summary import summary_from_file
+
+    summary = summary_from_file(output_root / PARAMS_FILENAME)
+    params_json = json.dumps(summary.as_dict() if summary else None)
+
+    # Escape "<" so no value in the tree — a CSV cell, a filename, a parameter
+    # — can close the <script> block it is embedded in. \u003c is still "<" to
+    # JSON.parse.
     tree_json = json.dumps(tree).replace("<", "\\u003c")
     html = _HTML_TEMPLATE.replace("__TREE_JSON__", tree_json)
+    html = html.replace("__PARAMS_JSON__", params_json.replace("<", "\\u003c"))
     html = html.replace("__TITLE__", f"MEA-NAP Output Report — {output_root.name}")
     out_path.write_text(html)
     return out_path
@@ -602,6 +614,23 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
              overflow-y: auto; padding: 12px 8px; }
   #sidebar h1 { font-size: 14px; padding: 4px 8px 12px; margin: 0; color: var(--text); word-break: break-word; }
   #main { flex: 1; overflow-y: auto; padding: 24px 32px; }
+  .params-toggle { margin: 4px 0 18px; padding: 6px 12px; font-size: 13px;
+    cursor: pointer; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--card-bg); color: var(--text); }
+  .params-toggle:hover { border-color: var(--accent); color: var(--accent); }
+  h3.params-group { margin: 22px 0 8px; font-size: 14px; letter-spacing: .02em;
+    text-transform: uppercase; color: var(--muted); font-weight: 600; }
+  table.params-table { border-collapse: collapse; width: 100%;
+    max-width: 900px; font-size: 13px; }
+  table.params-table td { padding: 5px 10px; border-top: 1px solid var(--border);
+    vertical-align: top; }
+  table.params-table tr.changed .p-name,
+  table.params-table tr.changed .p-value { font-weight: 600; }
+  .p-name { width: 38%; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--text); word-break: break-word; }
+  .p-value { width: 37%; word-break: break-word; }
+  .p-default { width: 25%; color: var(--muted); font-size: 12px; }
+  .p-redacted { color: var(--muted); font-style: italic; }
   ul.tree { list-style: none; margin: 0; padding-left: 14px; }
   ul.tree.root { padding-left: 0; }
   .tree li { margin: 1px 0; }
@@ -656,6 +685,11 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 <div id="layout">
   <div id="sidebar">
     <h1>__TITLE__</h1>
+    <div id="params-link" class="node-label" style="display:none;">
+      <span class="caret" style="visibility:hidden;"></span>
+      <span>&#9881;</span><span>Run parameters</span>
+      <span class="count" id="params-count"></span>
+    </div>
     <ul class="tree root" id="tree-root"></ul>
   </div>
   <div id="main">
@@ -671,6 +705,7 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 </div>
 <script>
 const TREE = __TREE_JSON__;
+const PARAMS = __PARAMS_JSON__;
 
 function countImages(node) {
   if (node.type !== "folder") return node.type === "image" ? 1 : 0;
@@ -754,6 +789,108 @@ function buildTreeDOM(node, container, path) {
   }
 
   return li;
+}
+
+/* ── Run parameters ──────────────────────────────────────────────────────
+   Every setting the run used, grouped as the Params dataclass groups them.
+   Defaults are folded away by default: the question a reader has is "what was
+   different about this run", and on a typical run that is a dozen fields out
+   of 137. */
+function fmtValue(v) {
+  if (v === null || v === undefined) return "\u2014";      // em dash
+  if (Array.isArray(v)) return v.length ? v.join(", ") : "[]";
+  if (typeof v === "boolean") return v ? "on" : "off";
+  if (typeof v === "object") return JSON.stringify(v);
+  if (v === "") return "\u2014";
+  return String(v);
+}
+
+let showAllParams = false;
+
+function renderParams(labelEl) {
+  if (selectedLabel) selectedLabel.classList.remove("selected");
+  labelEl.classList.add("selected");
+  selectedLabel = labelEl;
+
+  breadcrumb.textContent = "Run parameters";
+  mainTitle.textContent = "Run parameters";
+  folderDesc.textContent =
+    `${PARAMS.changed} of ${PARAMS.total} settings differ from the defaults. ` +
+    `These are the values the run actually used \u2014 the same numbers in ` +
+    `params.json, grouped for reading.`;
+  folderDesc.style.display = "block";
+
+  content.innerHTML = "";
+
+  const toggle = document.createElement("button");
+  toggle.className = "params-toggle";
+  toggle.textContent = showAllParams
+    ? "Show only what changed" : `Show all ${PARAMS.total} settings`;
+  toggle.addEventListener("click", () => {
+    showAllParams = !showAllParams;
+    renderParams(labelEl);
+  });
+  content.appendChild(toggle);
+
+  let shown = 0;
+  for (const group of PARAMS.groups) {
+    const entries = showAllParams
+      ? group.entries : group.entries.filter(e => e.changed);
+    if (!entries.length) continue;
+    shown += entries.length;
+
+    const h = document.createElement("h3");
+    h.className = "params-group";
+    h.textContent = group.name;
+    if (!showAllParams) {
+      const n = document.createElement("span");
+      n.className = "count";
+      n.textContent = entries.length;
+      h.appendChild(n);
+    }
+    content.appendChild(h);
+
+    const table = document.createElement("table");
+    table.className = "params-table";
+    for (const e of entries) {
+      const tr = document.createElement("tr");
+      if (e.changed) tr.className = "changed";
+      const name = document.createElement("td");
+      name.className = "p-name";
+      name.textContent = e.name;
+      const val = document.createElement("td");
+      val.className = "p-value";
+      val.textContent = fmtValue(e.value);
+      if (e.redacted) val.classList.add("p-redacted");
+      const def = document.createElement("td");
+      def.className = "p-default";
+      // Only worth the ink where it differs from what is shown beside it.
+      def.textContent = e.changed ? "default " + fmtValue(e.default) : "";
+      tr.appendChild(name); tr.appendChild(val); tr.appendChild(def);
+      table.appendChild(tr);
+    }
+    content.appendChild(table);
+  }
+
+  if (!shown) {
+    const p = document.createElement("p");
+    p.className = "empty";
+    p.textContent = "Every setting was left at its default.";
+    content.appendChild(p);
+  }
+
+  if (PARAMS.unknown && Object.keys(PARAMS.unknown).length) {
+    const h = document.createElement("h3");
+    h.className = "params-group";
+    h.textContent = "Not recognised by this version";
+    content.appendChild(h);
+    const p = document.createElement("p");
+    p.className = "empty";
+    p.textContent = "This run recorded settings that this build has no field "
+      + "for \u2014 it was probably produced by a newer version: "
+      + Object.keys(PARAMS.unknown).join(", ");
+    content.appendChild(p);
+  }
 }
 
 let selectedLabel = null;
@@ -940,6 +1077,16 @@ lightbox.addEventListener("click", () => lightbox.classList.remove("open"));
 document.addEventListener("keydown", (e) => { if (e.key === "Escape") lightbox.classList.remove("open"); });
 
 buildTreeDOM(TREE, treeRoot, []);
+
+// Only offered when the run recorded its settings: an older output folder has
+// no params.json, and a dead link is worse than no link.
+if (PARAMS) {
+  const link = document.getElementById("params-link");
+  link.style.display = "flex";
+  document.getElementById("params-count").textContent =
+    PARAMS.changed ? PARAMS.changed + " changed" : "all default";
+  link.addEventListener("click", () => renderParams(link));
+}
 
 function openHashPath() {
   const target = decodeURIComponent(location.hash.replace(/^#/, ""));

--- a/src/meanap/pipeline/resume.py
+++ b/src/meanap/pipeline/resume.py
@@ -197,6 +197,32 @@ def build_input_locator(params: Params, output_root: Path) -> InputLocator:
     )
 
 
+def already_done(
+    params: Params, output_root: Path, artefact: Path, log=None,
+) -> bool:
+    """Whether this recording's result for the current step is already there.
+
+    Only true when the run was asked to continue an interrupted one. The file
+    must be in *this* output folder, not in a prior run's — continuing means
+    filling the gaps in one folder, while a prior-analysis resume deliberately
+    reads an older run and writes somewhere new.
+
+    An artefact that will not open is deleted and reported rather than trusted:
+    writes are atomic (:mod:`meanap.pipeline.atomic`), so an unreadable file
+    means it predates that or came from somewhere else, and either way redoing
+    it is cheaper than discovering the problem two steps later.
+    """
+    from meanap.pipeline.atomic import guard_readable
+
+    if not params.continue_interrupted:
+        return False
+    artefact = Path(artefact)
+    if not artefact.is_file():
+        return False
+    # Guard against a half-written file from before atomic writes existed.
+    return guard_readable(artefact, log)
+
+
 def missing_step_inputs(
     locator: InputLocator,
     recordings: list[RecordingInfo],

--- a/src/meanap/pipeline/resume.py
+++ b/src/meanap/pipeline/resume.py
@@ -122,9 +122,12 @@ class InputLocator:
         lines = [f"Reading step inputs from: {self.output_root}"]
         if self.spike_dir is not None:
             lines.append(f"  … then spike data from: {self.spike_dir}")
-        for i, root in enumerate(self.prior_roots):
-            lead = "  … then prior analysis:  " if i == 0 else "  … and also:            "
-            lines.append(f"{lead}{root}")
+        # Numbered only when there is more than one to distinguish — the
+        # ordinary single-folder case reads better without an index on it.
+        multiple = len(self.prior_roots) > 1
+        for i, root in enumerate(self.prior_roots, start=1):
+            label = f"prior analysis {i}:" if multiple else "prior analysis: "
+            lines.append(f"  … then {label} {root}")
         return lines
 
 

--- a/src/meanap/pipeline/resume.py
+++ b/src/meanap/pipeline/resume.py
@@ -70,8 +70,17 @@ class InputLocator:
     """Where each step should look for the outputs of the steps before it."""
 
     output_root: Path
-    prior_root: Path | None = None
+    #: Previous runs to read from, in order. More than one lets a spreadsheet
+    #: name recordings analysed in *different* runs and have them come out as
+    #: one batch — see ``Params.prior_analysis_paths``. A tuple because this is
+    #: frozen and gets pickled into spawned workers.
+    prior_roots: tuple[Path, ...] = ()
     spike_dir: Path | None = None
+
+    @property
+    def prior_root(self) -> Path | None:
+        """The first prior run, for callers that only ever expected one."""
+        return self.prior_roots[0] if self.prior_roots else None
 
     # ── lookups ──────────────────────────────────────────────────────────────
 
@@ -81,16 +90,14 @@ class InputLocator:
         candidates = [self.output_root / SPIKE_SUBDIR / name]
         if self.spike_dir is not None:
             candidates.append(self.spike_dir / name)
-        if self.prior_root is not None:
-            candidates.append(self.prior_root / SPIKE_SUBDIR / name)
+        candidates += [root / SPIKE_SUBDIR / name for root in self.prior_roots]
         return _first_existing(candidates)
 
     def adjm_file(self, recording_name: str) -> Path | None:
         """Path to a recording's Step-3 adjacency file, or ``None`` if absent."""
         name = f"{recording_name}{ADJM_SUFFIX}"
         candidates = [self.output_root / ADJM_SUBDIR / name]
-        if self.prior_root is not None:
-            candidates.append(self.prior_root / ADJM_SUBDIR / name)
+        candidates += [root / ADJM_SUBDIR / name for root in self.prior_roots]
         return _first_existing(candidates)
 
     def catnap_file(self, recording_name: str) -> Path | None:
@@ -101,23 +108,23 @@ class InputLocator:
         """
         name = f"{recording_name}{CATNAP_SUFFIX}"
         candidates = [self.output_root / ADJM_SUBDIR / name]
-        if self.prior_root is not None:
-            candidates.append(self.prior_root / ADJM_SUBDIR / name)
+        candidates += [root / ADJM_SUBDIR / name for root in self.prior_roots]
         return _first_existing(candidates)
 
     # ── reporting ────────────────────────────────────────────────────────────
 
     @property
     def is_resuming(self) -> bool:
-        return self.prior_root is not None or self.spike_dir is not None
+        return bool(self.prior_roots) or self.spike_dir is not None
 
     def describe(self) -> list[str]:
         """Human-readable lines describing the search path, for the run log."""
         lines = [f"Reading step inputs from: {self.output_root}"]
         if self.spike_dir is not None:
             lines.append(f"  … then spike data from: {self.spike_dir}")
-        if self.prior_root is not None:
-            lines.append(f"  … then prior analysis:  {self.prior_root}")
+        for i, root in enumerate(self.prior_roots):
+            lead = "  … then prior analysis:  " if i == 0 else "  … and also:            "
+            lines.append(f"{lead}{root}")
         return lines
 
 
@@ -155,6 +162,26 @@ def _unpack_prior_bundle(path: Path) -> Path:
     return bundle.root
 
 
+def _resolve_prior(entry: str) -> Path:
+    """One previous-analysis path, validated and unpacked if it is a bundle."""
+    root = Path(entry).expanduser()
+    # A ``.meanap`` bundle is an output folder in a zip, so resuming from one is
+    # just resuming from where it unpacks to — no lookup needs to know the
+    # difference. This is what lets the file you share double as the file you
+    # re-run from.
+    if root.is_file():
+        root = _unpack_prior_bundle(root)
+    if not root.is_dir():
+        raise ValueError(f"Previous analysis folder does not exist: {root}")
+    if not (root / SPIKE_SUBDIR).is_dir() and not (root / ADJM_SUBDIR).is_dir():
+        raise ValueError(
+            f"{root} does not look like a MEA-NAP output folder — expected it to "
+            f"contain '{SPIKE_SUBDIR}' and/or '{ADJM_SUBDIR}'. Point this at the "
+            "OutputData… folder itself, not at its parent."
+        )
+    return root
+
+
 def build_input_locator(params: Params, output_root: Path) -> InputLocator:
     """Build the locator for a run, validating the configured paths up front.
 
@@ -162,29 +189,18 @@ def build_input_locator(params: Params, output_root: Path) -> InputLocator:
     typo'd path degrade into "every recording skipped", which is how a missing
     input used to present.
     """
-    prior_root: Path | None = None
+    prior_roots: list[Path] = []
     if params.prior_analysis:
-        if not params.prior_analysis_path:
+        configured = [params.prior_analysis_path, *params.prior_analysis_paths]
+        configured = [c for c in configured if c]
+        if not configured:
             raise ValueError(
                 "'Use prior analysis' is enabled but no previous analysis folder is set. "
                 "Set Params.prior_analysis_path to a previous OutputData… folder, or "
                 "disable prior analysis."
             )
-        prior_root = Path(params.prior_analysis_path).expanduser()
-        # A ``.meanap`` bundle is an output folder in a zip, so resuming from
-        # one is just resuming from where it unpacks to — no lookup below needs
-        # to know the difference. This is what lets the file you share double as
-        # the file you re-run from.
-        if prior_root.is_file():
-            prior_root = _unpack_prior_bundle(prior_root)
-        if not prior_root.is_dir():
-            raise ValueError(f"Previous analysis folder does not exist: {prior_root}")
-        if not (prior_root / SPIKE_SUBDIR).is_dir() and not (prior_root / ADJM_SUBDIR).is_dir():
-            raise ValueError(
-                f"{prior_root} does not look like a MEA-NAP output folder — expected it to "
-                f"contain '{SPIKE_SUBDIR}' and/or '{ADJM_SUBDIR}'. Point this at the "
-                "OutputData… folder itself, not at its parent."
-            )
+        for entry in configured:
+            prior_roots.append(_resolve_prior(entry))
 
     spike_dir: Path | None = None
     if params.spike_detected_data:
@@ -193,7 +209,8 @@ def build_input_locator(params: Params, output_root: Path) -> InputLocator:
             raise ValueError(f"Spike-detected data folder does not exist: {spike_dir}")
 
     return InputLocator(
-        output_root=Path(output_root), prior_root=prior_root, spike_dir=spike_dir
+        output_root=Path(output_root), prior_roots=tuple(prior_roots),
+        spike_dir=spike_dir,
     )
 
 

--- a/src/meanap/pipeline/roster.py
+++ b/src/meanap/pipeline/roster.py
@@ -1,0 +1,170 @@
+"""Keeping an output folder honest about which recordings it analysed.
+
+The spreadsheet decides what a run covers, and it changes: a sixth recording
+arrives, or one turns out to be bad and is taken out. Continuing a run
+(``Params.continue_interrupted``) handles both for the *numbers* — a new
+recording is computed, a removed one is left out of every pooled statistic, and
+the CSVs are rewritten from what remains.
+
+The **figures** are the problem. They are written per recording into their own
+folders and nothing goes back for them, so a removed recording leaves its plots
+sitting in the output tree and in ``report.html``, indistinguishable from the
+ones that are still part of the analysis. A folder that shows twenty-three
+figures for a recording its own CSVs never mention is worse than one that is
+merely out of date, because nothing about it looks wrong.
+
+So a continued run reconciles the two: anything the folder holds that the
+spreadsheet no longer names is reported by name, and pruned when the run asks
+for it. Reporting is the default because this deletes results, and a run that
+quietly removed the wrong thing would be discovered much later, if ever.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+__all__ = ["StaleRecording", "find_stale_recordings", "prune_recordings"]
+
+#: Per-recording *figure* directories, relative to the run root. Each holds one
+#: subfolder per group, then one per recording.
+_FIGURE_ROOTS = (
+    Path("4_NetworkActivity") / "4A_IndividualNetworkAnalysis",
+    Path("2_NeuronalActivity") / "2A_IndividualNeuronalAnalysis",
+    Path("1_SpikeDetection") / "1B_SpikeDetectionChecks",
+)
+
+#: Per-recording *data* files, as ``(directory, filename pattern)``. Kept apart
+#: from the figures because they are worth different things: the data is what
+#: makes a recording cheap to add back, the figures are pure output.
+_DATA_FILES = (
+    (Path("ExperimentMatFiles"), "{rec}_adjM.npz"),
+    (Path("ExperimentMatFiles"), "{rec}_catnap.npz"),
+    (Path("ExperimentMatFiles"), "{rec}_background.npz"),
+    (Path("ExperimentMatFiles"), "{rec}_edgecheck.npz"),
+    (Path("1_SpikeDetection") / "1A_SpikeDetectedData", "{rec}_spikes.npz"),
+    (Path("1_SpikeDetection") / "1A_SpikeDetectedData", "{rec}_step1checks.npz"),
+)
+
+
+@dataclass
+class StaleRecording:
+    """A recording the folder still holds but the spreadsheet no longer names."""
+
+    name: str
+    figure_dirs: list[Path] = field(default_factory=list)
+    data_files: list[Path] = field(default_factory=list)
+
+    @property
+    def n_figures(self) -> int:
+        return sum(len(list(d.rglob("*.png"))) for d in self.figure_dirs)
+
+    def describe(self) -> str:
+        bits = []
+        if self.n_figures:
+            bits.append(f"{self.n_figures} figure(s)")
+        if self.data_files:
+            bits.append(f"{len(self.data_files)} data file(s)")
+        return f"{self.name}: " + (", ".join(bits) if bits else "nothing on disk")
+
+
+def find_stale_recordings(
+    output_root: Path | str, keep: Iterable[str],
+) -> list[StaleRecording]:
+    """Recordings with work in *output_root* that *keep* does not name.
+
+    ``keep`` is the spreadsheet's recording list. Directory names are matched
+    exactly against it, so a recording is only ever called stale because the
+    spreadsheet stopped naming it — never because of a near-miss.
+    """
+    output_root = Path(output_root)
+    keep = set(keep)
+    found: dict[str, StaleRecording] = {}
+
+    def entry(name: str) -> StaleRecording:
+        return found.setdefault(name, StaleRecording(name=name))
+
+    for rel in _FIGURE_ROOTS:
+        base = output_root / rel
+        if not base.is_dir():
+            continue
+        # <family>/<group>/<recording>/ — the group layer is the pipeline's, and
+        # groups are not recordings, so only the second level is considered.
+        for group_dir in base.iterdir():
+            if not group_dir.is_dir():
+                continue
+            for rec_dir in group_dir.iterdir():
+                if rec_dir.is_dir() and rec_dir.name not in keep:
+                    entry(rec_dir.name).figure_dirs.append(rec_dir)
+
+    for rel, pattern in _DATA_FILES:
+        base = output_root / rel
+        if not base.is_dir():
+            continue
+        suffix = pattern.replace("{rec}", "")
+        for path in base.glob(pattern.replace("{rec}", "*")):
+            name = path.name[: -len(suffix)] if suffix else path.stem
+            if name and name not in keep:
+                entry(name).data_files.append(path)
+
+    return [found[name] for name in sorted(found)]
+
+
+def prune_recordings(
+    stale: list[StaleRecording],
+    *,
+    data: bool = False,
+    log: Callable[[str], None] = print,
+) -> int:
+    """Delete stale recordings' figures, and their data files if asked.
+
+    Figures are removed by default because they are the misleading part — they
+    show up in the output tree and the report as though they belonged to the
+    analysis. The data files are kept unless ``data`` is set: they are what
+    makes putting a recording *back* cheap, and they mislead nobody.
+
+    Returns how many recordings were touched.
+    """
+    touched = 0
+    for item in stale:
+        removed = False
+        for directory in item.figure_dirs:
+            try:
+                shutil.rmtree(directory)
+                removed = True
+            except OSError as e:
+                log(f"  Could not remove {directory}: {e}")
+        if data:
+            for path in item.data_files:
+                try:
+                    path.unlink()
+                    removed = True
+                except OSError as e:
+                    log(f"  Could not remove {path}: {e}")
+        if removed:
+            touched += 1
+            log(f"  Removed {item.name}'s figures"
+                + (" and data" if data else "")
+                + " — it is no longer in the spreadsheet.")
+    return touched
+
+
+def report_stale(
+    stale: list[StaleRecording], *, pruned: bool, log: Callable[[str], None],
+) -> None:
+    """Say what was found, in terms of what it means for the folder."""
+    if not stale:
+        return
+    names = ", ".join(item.name for item in stale)
+    log(f"{len(stale)} recording(s) in this folder are no longer in the "
+        f"spreadsheet: {names}")
+    if pruned:
+        return
+    figures = sum(item.n_figures for item in stale)
+    if figures:
+        log(f"  Their {figures} figure(s) are still on disk and will appear in "
+            f"the output folder and report, though they are excluded from every "
+            f"CSV and pooled statistic.")
+        log("  Set Params.prune_removed_recordings = True to delete them.")

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -27,7 +27,9 @@ from meanap.pipeline.output_folders import (
 from meanap.pipeline.progress import (
     ProgressFn, RunProgress, plan_catnap, plan_ephys,
 )
-from meanap.pipeline.resume import build_input_locator, missing_step_inputs
+from meanap.pipeline.resume import (
+    already_done, build_input_locator, missing_step_inputs,
+)
 from meanap.pipeline.spike_detection import SpikeDetectionParams, detect_spikes_recording
 from meanap.pipeline.spreadsheet import RecordingInfo, read_recording_csv
 
@@ -35,6 +37,11 @@ from meanap.pipeline.spreadsheet import RecordingInfo, read_recording_csv
 def default_output_folder_name() -> str:
     """Default output folder name, matching MATLAB's ``'OutputData' + ddmmmyyyy``."""
     return "OutputData" + datetime.date.today().strftime("%d%b%Y")
+
+
+def continues_in_place(params: Params) -> bool:
+    """Whether this run is picking up an interrupted one in the same folder."""
+    return bool(params.continue_interrupted)
 
 
 def resumes_in_place(params: Params) -> bool:
@@ -65,6 +72,16 @@ def resolve_output_folder_name(
     """
     name = params.output_data_folder_name or default_output_folder_name()
     parent = Path(params.output_data_folder or ".")
+
+    if params.continue_interrupted:
+        # The folder is the point: continuing means filling the gaps in the run
+        # that stopped, not starting a neighbour to it.
+        if output_name_taken(parent, name):
+            log(f"Continuing the interrupted run in {parent / name} — "
+                f"recordings already finished will be skipped.")
+        else:
+            log(f"Nothing to continue in {parent / name}; running from the start.")
+        return name
 
     if resumes_in_place(params) or params.overwrite_existing_output:
         if params.overwrite_existing_output and output_name_taken(parent, name):
@@ -495,6 +512,17 @@ def _run_step1_spike_detection(
     for rec, raw_path in source.stream(recordings, depth=params.prefetch_depth,
                                        kind="ephys"):
         check_cancel(should_cancel)
+        # Continuing an interrupted run: this recording's spike times are
+        # already on disk, so the expensive part is done. Checked here rather
+        # than before the stream so the source still releases whatever it
+        # fetched for it.
+        done_path = spike_dir / f"{rec.filename}_spikes.npz"
+        if already_done(params, output_root, done_path, log):
+            log(f"  [{rec.filename}] already detected — skipping")
+            source.unpin(rec.filename)
+            source.release(rec.filename)
+            progress.item_done(rec.filename)
+            continue
         if isinstance(raw_path, BaseException):
             log(f"  ! raw file not found, skipping: {rec.filename}"
                 f" (looked for {', '.join(RAW_EXTENSIONS)})")

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -164,6 +164,12 @@ def run_pipeline(
     except Exception as e:
         log(f"Warning: could not write {PARAMS_FILENAME}: {e}")
 
+    # A continued run may be continuing a *different* spreadsheet — a recording
+    # added, or one taken out. The numbers follow the spreadsheet on their own;
+    # the per-recording figures do not, so they are reconciled here.
+    if params.continue_interrupted:
+        _reconcile_roster(params, output_root, recordings, log)
+
     # Raises on a misconfigured prior-analysis/spike-data path, before any work.
     locator = build_input_locator(params, output_root)
     if locator.is_resuming:
@@ -393,6 +399,21 @@ def _check_remote_source(params: Params, recordings, log, progress=None) -> None
             "The remote source is not ready to run (see the pre-flight report "
             "above). Fix the problems listed, or run meanap-preflight with "
             "--write-spreadsheet to correct recording names.")
+
+
+def _reconcile_roster(params: Params, output_root: Path, recordings, log) -> None:
+    """Report — and optionally remove — work for recordings no longer listed."""
+    from meanap.pipeline.roster import (
+        find_stale_recordings, prune_recordings, report_stale,
+    )
+
+    stale = find_stale_recordings(output_root, {r.filename for r in recordings})
+    if not stale:
+        return
+    pruned = False
+    if params.prune_removed_recordings:
+        pruned = prune_recordings(stale, log=log) > 0
+    report_stale(stale, pruned=pruned, log=log)
 
 
 def _discard_folder_for_bundle(output_root: Path, bundle: Path | None, log) -> Path:

--- a/src/meanap/pipeline/step3.py
+++ b/src/meanap/pipeline/step3.py
@@ -22,9 +22,10 @@ from meanap.pipeline.io import find_raw_file, load_spike_times_npz, resolve_dura
 from meanap.pipeline.parallel import map_recordings
 from meanap.pipeline.progress import RunProgress
 from meanap.pipeline.probabilistic_threshold import adjm_thr
-from meanap.pipeline.resume import build_input_locator
+from meanap.pipeline.resume import already_done, build_input_locator
 from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
+from meanap.pipeline.atomic import atomic_savez
 
 # Peak per-worker RAM for Step 3: spike times (sparse) + a few 64x64xrep_num
 # surrogate stacks (~6 MB at rep_num=200). Tiny — worker count is CPU-limited.
@@ -48,6 +49,13 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
     plot_checks = bool(getattr(params, "prob_thresh_plot_checks", False))
 
     logs: list[str] = []
+    # Continuing an interrupted run: adjacency for this recording is already
+    # written, and it is the expensive part of this step.
+    done_path = mat_files_dir / f"{rec.filename}_adjM.npz"
+    if already_done(params, output_root, done_path, logs.append):
+        logs.append(f"  [{rec.filename}] adjacency already computed — skipping")
+        return rec.filename, logs
+
     npz_file = locator.spike_file(rec.filename)
     if npz_file is None:
         logs.append(f"  [{rec.filename}] SKIP: spike data not found ({rec.filename}_spikes.npz)")
@@ -116,7 +124,7 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
         out_arrays[f"adjM{lag_ms}mslag_raw"] = adj_m
 
     out_path = mat_files_dir / f"{rec.filename}_adjM.npz"
-    np.savez(out_path, channels=data["channels"], **out_arrays)
+    atomic_savez(out_path, channels=data["channels"], **out_arrays)
     if edge_checks:
         from meanap.pipeline.plotting_step3 import (
             EDGE_CHECK_SUFFIX, save_edge_threshold_check,

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -31,7 +31,7 @@ from meanap.pipeline.plotting_step4 import (
     plot_network_beside_field, plot_node_cartography, plot_spatial_network,
     plot_spatial_network_combined,
 )
-from meanap.pipeline.resume import build_input_locator
+from meanap.pipeline.resume import ADJM_SUFFIX, build_input_locator
 from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
 
@@ -752,6 +752,124 @@ def _apply_cartography_boundaries(
                     m[f"NCpn{i + 1}count"] = int(pop_num_nc[i])
 
 
+#: Where phase A's running results are kept. The final artefact *is* the
+#: checkpoint — no separate journal to write, clean up, or get out of step with
+#: the thing it shadows. Rewritten after each recording rather than appended to,
+#: because a JSON object cannot be appended to; the cost is one serialisation
+#: per recording, and the benefit is that an interrupted run leaves a valid,
+#: readable results file holding everything that finished.
+NETMET_FILENAME = "netmet_results.json"
+
+
+def _netmet_json(all_results: dict) -> dict:
+    """The JSON form of the metrics: everything except the adjacency subgraph.
+
+    ``adjMsub`` is dropped because it is a pure function of the stored adjacency
+    and ``activeChannelIndex`` — see :func:`_restore_adjm_sub`, which puts it
+    back — and it is the largest thing in the dict.
+    """
+    return {
+        rec_name: {
+            lag: {k: v for k, v in metrics.items() if k != "adjMsub"}
+            for lag, metrics in rec_results.items()
+        }
+        for rec_name, rec_results in all_results.items()
+    }
+
+
+def _write_netmet(out_dir: Path, all_results: dict) -> None:
+    """Checkpoint phase A's results so far. Atomic; safe to call repeatedly."""
+    from meanap.pipeline.atomic import atomic_write_json
+
+    atomic_write_json(out_dir / NETMET_FILENAME,
+                      _convert_numpy(_netmet_json(all_results)), indent=2)
+
+
+def _restore_adjm_sub(output_root: Path, recording: str, rec_results: dict) -> bool:
+    """Put ``adjMsub`` back for a recording loaded from the checkpoint.
+
+    Phase C draws from it and the JSON does not carry it. Rebuilt from the
+    adjacency this run already wrote plus ``activeChannelIndex``, exactly as
+    ``compute_network_metrics`` derived it in the first place. ``False`` when the
+    adjacency is missing, which makes the recording recompute rather than plot
+    from a half-restored state.
+    """
+    path = output_root / "ExperimentMatFiles" / f"{recording}{ADJM_SUFFIX}"
+    if not path.is_file():
+        return False
+    try:
+        with np.load(path) as data:
+            for lag_key, metrics in rec_results.items():
+                lag = lag_key.replace("mslag", "")
+                key = next((k for k in (f"adjM{lag}mslag_raw", f"adjM{lag}mslag")
+                            if k in data.files), None)
+                active = metrics.get("activeChannelIndex")
+                if key is None or active is None:
+                    return False
+                adj = np.asarray(data[key], dtype=float).copy()
+                adj[adj < 0] = 0.0
+                adj = np.nan_to_num(adj, nan=0.0)
+                idx = np.asarray(active, dtype=int)
+                metrics["adjMsub"] = adj[np.ix_(idx, idx)]
+    except Exception:                                    # noqa: BLE001
+        return False
+    return True
+
+
+def _load_netmet_checkpoint(
+    params: Params, output_root: Path, recordings, log,
+) -> tuple[dict, dict]:
+    """Recordings already finished by an interrupted run: metrics and channels.
+
+    Returns ``({name: results}, {name: channels})``, both empty unless the run
+    was asked to continue. A recording is only accepted when its adjacency is
+    also present, so what is skipped is genuinely complete.
+    """
+    if not params.continue_interrupted:
+        return {}, {}
+
+    path = output_root / "4_NetworkActivity" / NETMET_FILENAME
+    if not path.is_file():
+        return {}, {}
+    try:
+        with open(path) as fh:
+            stored = json.load(fh)
+    except (OSError, ValueError) as e:
+        log(f"  Ignoring an unreadable {NETMET_FILENAME} ({e}) — recomputing.")
+        return {}, {}
+
+    wanted = {rec.filename for rec in recordings}
+    results: dict = {}
+    channels: dict = {}
+    for name, rec_results in stored.items():
+        if name not in wanted or not rec_results:
+            continue
+        restored = _to_arrays(rec_results)
+        if not _restore_adjm_sub(output_root, name, restored):
+            continue
+        adjm = output_root / "ExperimentMatFiles" / f"{name}{ADJM_SUFFIX}"
+        try:
+            with np.load(adjm) as data:
+                channels[name] = np.asarray(data["channels"])
+        except Exception:                                # noqa: BLE001
+            continue
+        results[name] = restored
+    if results:
+        log(f"  Continuing: {len(results)} recording(s) already have network "
+            f"metrics — skipping them.")
+    return results, channels
+
+
+def _to_arrays(obj):
+    """Undo the array-to-list flattening ``_convert_numpy`` applies for JSON."""
+    if isinstance(obj, dict):
+        return {k: _to_arrays(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        arr = np.asarray(obj)
+        return arr if arr.dtype != object else [_to_arrays(v) for v in obj]
+    return obj
+
+
 def _run_step4_network_metrics(
     params: Params,
     recordings: list[RecordingInfo],
@@ -770,29 +888,54 @@ def _run_step4_network_metrics(
 
     _cancel = (lambda: bool(should_cancel())) if should_cancel else None
 
+    # What an interrupted run already finished. Seeding from it — rather than
+    # only skipping — matters for phase B: the cartography boundaries are pooled
+    # across the whole batch, so a continued run that saw half of it would place
+    # them somewhere the original never would.
+    all_results, channels_by_rec = _load_netmet_checkpoint(
+        params, output_root, recordings, log)
+    todo = [rec for rec in recordings if rec.filename not in all_results]
+    for rec in recordings:
+        if rec.filename in all_results:
+            progress.item_done(rec.filename)
+
     def _emit(result) -> None:
+        """Phase C's callback: log lines, and one step of the bar.
+
+        Deliberately shape-agnostic — the two phases return different tuples,
+        and this only needs the ends of them.
+        """
         for line in result[-1]:  # log lines are always the last element
             log(line)
-        # In the parent, in completion order — the only place a process pool
-        # gives the bar something to move on.
         progress.item_done(result[0])
 
-    # ── Phase A: parallel compute over recordings (map) ──────────────────────
-    check_cancel(should_cancel)
-    compute_out = map_recordings(
-        _step4_compute_one,
-        [(params, rec, str(output_root)) for rec in recordings],
-        mem_per_task_gb=_STEP4_MEM_PER_TASK_GB,
-        max_workers=params.recording_workers,
-        on_result=_emit,
-        cancel_check=_cancel,
-    )
-    all_results: dict[str, dict] = {}
-    channels_by_rec: dict[str, np.ndarray] = {}
-    for filename, rec_results, channels_arr, _logs in compute_out:
+    def _emit_computed(result) -> None:
+        """Phase A's callback. Runs in the parent, in completion order, which is
+        the only place it is safe to touch the shared dicts or the checkpoint."""
+        filename, rec_results, channels_arr, logs = result
+        for line in logs:
+            log(line)
         if rec_results:
             all_results[filename] = rec_results
             channels_by_rec[filename] = channels_arr
+            # Written after every recording so an interrupt costs the one in
+            # flight, not the batch. Atomic, so a reader never sees it partial.
+            try:
+                _write_netmet(out_dir, all_results)
+            except OSError as e:
+                log(f"  Warning: could not checkpoint {NETMET_FILENAME}: {e}")
+        progress.item_done(filename)
+
+    # ── Phase A: parallel compute over recordings (map) ──────────────────────
+    check_cancel(should_cancel)
+    map_recordings(
+        _step4_compute_one,
+        [(params, rec, str(output_root)) for rec in todo],
+        mem_per_task_gb=_STEP4_MEM_PER_TASK_GB,
+        max_workers=params.recording_workers,
+        on_result=_emit_computed,
+        cancel_check=_cancel,
+    )
 
     # ── Phase B: reduce (serial) ─────────────────────────────────────────────
     # Data-driven node-cartography boundaries: pool PC/Z across every recording
@@ -833,15 +976,9 @@ def _run_step4_network_metrics(
     )
 
     try:
-        json_results = {
-            rec_name: {
-                lag: {k: v for k, v in metrics.items() if k != "adjMsub"}
-                for lag, metrics in rec_results.items()
-            }
-            for rec_name, rec_results in all_results.items()
-        }
-        with open(out_dir / "netmet_results.json", "w") as fh:
-            json.dump(_convert_numpy(json_results), fh, indent=2)
+        # Already checkpointed after each recording; written once more so a run
+        # that skipped every recording still leaves the file in a known state.
+        _write_netmet(out_dir, all_results)
 
         # Export CSVs like MATLAB's saveNetMet.m
         rec_rows = []

--- a/src/meanap/viewer/page.py
+++ b/src/meanap/viewer/page.py
@@ -68,6 +68,20 @@ PAGE_HTML = r"""<!doctype html>
   #tabs button[aria-selected="true"] {
     color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
   #tabs .spacer { flex: 1; }
+  #params { padding: 4px 2px 24px; overflow-y: auto; }
+  #params h3 { margin: 20px 0 6px; font-size: 12px; letter-spacing: .04em;
+    text-transform: uppercase; color: var(--muted); font-weight: 600; }
+  #params table { border-collapse: collapse; width: 100%; max-width: 860px;
+    font-size: 13px; }
+  #params td { padding: 5px 10px; border-top: 1px solid var(--border);
+    vertical-align: top; }
+  #params tr.changed td.k, #params tr.changed td.v { font-weight: 600; }
+  #params td.k { width: 38%; font-family: ui-monospace, SFMono-Regular, Menlo,
+    monospace; word-break: break-word; }
+  #params td.v { width: 37%; word-break: break-word; }
+  #params td.d { width: 25%; color: var(--muted); font-size: 12px; }
+  #params .redacted { color: var(--muted); font-style: italic; }
+  #params .lead { color: var(--muted); font-size: 13px; margin: 4px 0 14px; }
   #tabs .src { color: var(--muted); font-size: 12px; padding-right: 4px;
     overflow-wrap: anywhere; max-width: 40ch; text-align: right; }
 
@@ -126,6 +140,7 @@ PAGE_HTML = r"""<!doctype html>
   <button id="tab-recordings" data-tab="recordings" aria-selected="true">Recordings</button>
   <button id="tab-comparisons" data-tab="comparisons" aria-selected="false">Comparisons</button>
   <button id="tab-lags" data-tab="lags" aria-selected="false">Across lags</button>
+  <button id="tab-params" data-tab="params" aria-selected="false">Parameters</button>
   <span class="spacer"></span>
   <button id="export" class="hidden" title="Draw every figure out into an ordinary
 folder, with a report.html to browse them — for sending results to someone who
@@ -166,6 +181,11 @@ does not have MEA-NAP installed.">Export output folder</button>
     <div class="list" id="families"></div>
   </div>
 
+  <div id="side-params" class="hidden">
+    <h2>Settings</h2>
+    <div class="list" id="param-groups"></div>
+  </div>
+
   <div id="side-lags" class="hidden">
     <h2>Figure set</h2>
     <div class="list" id="lag-series"></div>
@@ -186,6 +206,7 @@ does not have MEA-NAP installed.">Export output folder</button>
   <figure id="single"><img id="figure-img" alt=""></figure>
   <div id="pair" class="hidden"></div>
   <div class="gallery hidden" id="gallery"></div>
+  <div id="params" class="hidden"></div>
 </main>
 
 <aside class="right" id="controls-panel">
@@ -931,6 +952,9 @@ function setMode(kind) {
   $("single").classList.toggle("hidden", !one);
   $("pair").classList.toggle("hidden", !(kind === "comparison" || kind === "both"));
   $("gallery").classList.toggle("hidden", kind !== "family");
+  // Every kind setMode is called for is a figure, so the parameters pane is
+  // never the right thing to be showing.
+  $("params").classList.add("hidden");
   // "Both" shows two figures; a single download button cannot mean both, so
   // the buttons go away rather than silently picking one.
   const downloadable = one || kind === "comparison";
@@ -954,6 +978,128 @@ function showFigure() {
   img.alt = VIEW.name;
 }
 
+/* ── Parameters ──────────────────────────────────────────────────────────
+   The settings the run used. Defaults are folded away by default: the question
+   is "what was different about this run", and on a typical run that is a dozen
+   fields out of 137. The left column filters to one section. */
+let PARAM_SECTION = null;      // null = every section
+let PARAM_ALL = false;         // false = only what differs from the default
+
+function fmtParam(v) {
+  if (v === null || v === undefined) return "\u2014";
+  if (Array.isArray(v)) return v.length ? v.join(", ") : "[]";
+  if (typeof v === "boolean") return v ? "on" : "off";
+  if (typeof v === "object") return JSON.stringify(v);
+  if (v === "") return "\u2014";
+  return String(v);
+}
+
+function fillParamGroups() {
+  const box = $("param-groups");
+  box.innerHTML = "";
+  const mk = (label, section, count) => {
+    const b = document.createElement("button");
+    b.textContent = count === null ? label : `${label}  (${count})`;
+    b.dataset.section = section === null ? "" : section;
+    b.addEventListener("click", () => {
+      PARAM_SECTION = section;
+      showParams();
+    });
+    box.appendChild(b);
+  };
+  mk("All sections", null, null);
+  for (const g of MANIFEST.params.groups) {
+    // The count follows the filter, so it says how many rows the click gives.
+    mk(g.name, g.name, PARAM_ALL ? g.entries.length : g.changed);
+  }
+}
+
+function showParams() {
+  const P = MANIFEST.params;
+  for (const el of ["single", "pair", "gallery"])
+    $(el).classList.add("hidden");
+  $("params").classList.remove("hidden");
+  $("controls-panel").classList.add("hidden");
+  $("facets-panel").classList.add("hidden");
+  for (const id of ["dl-png", "dl-svg", "dl-pdf"])
+    $(id).classList.add("hidden");
+  $("error").textContent = "";
+  $("status").textContent = `${P.changed} of ${P.total} settings changed`;
+
+  for (const b of document.querySelectorAll("#param-groups button"))
+    b.setAttribute("aria-current",
+      String((b.dataset.section || null) === PARAM_SECTION));
+
+  const box = $("params");
+  box.innerHTML = "";
+
+  const lead = document.createElement("p");
+  lead.className = "lead";
+  lead.textContent = "The values this run actually used — the same numbers as "
+    + "params.json, grouped for reading. Bold rows differ from the default.";
+  box.appendChild(lead);
+
+  const toggle = document.createElement("button");
+  toggle.textContent = PARAM_ALL
+    ? "Show only what changed" : `Show all ${P.total} settings`;
+  toggle.addEventListener("click", () => {
+    PARAM_ALL = !PARAM_ALL;
+    fillParamGroups();
+    showParams();
+  });
+  box.appendChild(toggle);
+
+  let shown = 0;
+  for (const g of P.groups) {
+    if (PARAM_SECTION !== null && g.name !== PARAM_SECTION) continue;
+    const rows = PARAM_ALL ? g.entries : g.entries.filter(e => e.changed);
+    if (!rows.length) continue;
+    shown += rows.length;
+
+    const h = document.createElement("h3");
+    h.textContent = g.name;
+    box.appendChild(h);
+
+    const table = document.createElement("table");
+    for (const e of rows) {
+      const tr = document.createElement("tr");
+      if (e.changed) tr.className = "changed";
+      const k = document.createElement("td");
+      k.className = "k"; k.textContent = e.name;
+      const v = document.createElement("td");
+      v.className = "v" + (e.redacted ? " redacted" : "");
+      v.textContent = fmtParam(e.value);
+      const d = document.createElement("td");
+      d.className = "d";
+      d.textContent = e.changed ? "default " + fmtParam(e.default) : "";
+      tr.appendChild(k); tr.appendChild(v); tr.appendChild(d);
+      table.appendChild(tr);
+    }
+    box.appendChild(table);
+  }
+
+  if (!shown) {
+    const p = document.createElement("p");
+    p.className = "sub";
+    p.textContent = PARAM_ALL
+      ? "Nothing in this section."
+      : "Every setting here was left at its default.";
+    box.appendChild(p);
+  }
+
+  if (P.unknown && Object.keys(P.unknown).length) {
+    const h = document.createElement("h3");
+    h.textContent = "Not recognised by this version";
+    box.appendChild(h);
+    const p = document.createElement("p");
+    p.className = "sub";
+    p.textContent = "This bundle records settings this build has no field for, "
+      + "so it was probably written by a newer version: "
+      + Object.keys(P.unknown).join(", ");
+    box.appendChild(p);
+  }
+}
+
 function selectTab(tab) {
   TAB = tab;
   for (const b of document.querySelectorAll("#tabs button"))
@@ -961,8 +1107,10 @@ function selectTab(tab) {
   $("side-recordings").classList.toggle("hidden", tab !== "recordings");
   $("side-comparisons").classList.toggle("hidden", tab !== "comparisons");
   $("side-lags").classList.toggle("hidden", tab !== "lags");
+  $("side-params").classList.toggle("hidden", tab !== "params");
   if (tab === "recordings") showFigure();
   else if (tab === "comparisons") showComparison();
+  else if (tab === "params") showParams();
   else showLagSeries();
 }
 
@@ -995,6 +1143,9 @@ function download(fmt) {
     $("tab-comparisons").classList.add("hidden");
   if (!(MANIFEST.lag_series || []).length)
     $("tab-lags").classList.add("hidden");
+  // An older bundle may carry no params.json at all.
+  if (!MANIFEST.params) $("tab-params").classList.add("hidden");
+  else fillParamGroups();
 
   $("recording").addEventListener("change", fillLags);
   $("lag").addEventListener("change", () => { fillFigures(); fillSubnetworks(); });

--- a/src/meanap/viewer/server.py
+++ b/src/meanap/viewer/server.py
@@ -142,10 +142,26 @@ class ViewerService:
                          for f in available_group_families(self.ctx)],
             "comparisons": self.comparisons(),
             "lag_series": self.lag_series(),
+            # The settings this run used, grouped and with the non-defaults
+            # marked. From the bundle's own params.json, which is already
+            # redacted at write time; summarise_params redacts again for a
+            # folder, whose copy is not.
+            "params": self._params_summary(),
             "controls": control_schema(),
             "comparison_controls": comparison_control_schema(),
             "formats": list(ALLOWED_FORMATS),
         }
+
+    def _params_summary(self) -> dict | None:
+        """What the run was configured with, or ``None`` if it didn't record it."""
+        from meanap.params_summary import summarise_params
+
+        params = self._bundle.params if self._bundle is not None else self.ctx.params
+        if params is None:
+            return None
+        unknown = (dict.fromkeys(self._bundle.unknown_param_keys)
+                   if self._bundle is not None else {})
+        return summarise_params(params, unknown=unknown).as_dict()
 
     def comparisons(self) -> list[dict]:
         """The facets behind the comparison tab: one entry per family.


### PR DESCRIPTION
`params.json` is the authoritative record of how a result was produced, and it
is unreadable: ~140 keys in declaration order, nearly all sitting at their
defaults. The question a reader actually has is narrower — *what was different
about this run?* — and the answer is usually a dozen fields.

Both artifacts now show the same summary, from one module, so they cannot
disagree about what a run was.

**`report.html`** gets a **⚙ Run parameters** entry above the folder tree.
**The viewer** gets a **Parameters** tab, with the left column filtering to one
section.

Both open on **only what changed**, with the default each field departed from
shown beside it, and a toggle to expand to everything.

## Two things worth a look in review

**The grouping is read off the dataclass source, not kept in a list.** `Params`
marks its sections with `# ── Spike detection ──` comments and declares fields
in order, so walking the source assigns each field to the section it was written
under. A field added tomorrow lands in the right place with nothing here to
update. `test_params_summary.py` asserts all 137 fields are covered, so the day
that stops being true is the day it fails rather than the day someone notices a
setting missing. If the source is unreadable (a frozen build) everything falls
into one group rather than nothing being shown.

**Share links are redacted.** A report is a file people attach to papers and
email onward, and a Dropbox link in one is a credential — the same reason
`SECRET_URL_FIELDS` already exists on the bundle side. Asserted by putting a
link in and grepping the built HTML for it.

## Verification

`python/test_params_summary.py` — 34 checks, exit 0. Covers the grouping, change
detection (including that list defaults compare by value, not identity, or they
would read as always-changed), redaction, and the degenerate `params.json`
cases: missing, unparseable, not an object, and one from a newer version
carrying fields this build has no slot for.

Three existing suites re-run: `test_bundle_render` 156/156,
`test_check_figures_bundle` 100/100, `test_gui_bundle_viewer` 31/31.

## What I could not check

**I did not see either page rendered.** The Chrome extension shows an error page
for `127.0.0.1`, though the servers respond 200 to curl — a site-permission
thing I could not resolve from here. Instead I extracted the `<script>` bodies
and ran `node --check` on both, and verified every `$("id")` / `getElementById`
reference resolves to an element that exists in the markup. That catches the
realistic failure mode for hand-written JS in a template string, but it is not
the same as looking at it. Worth a glance before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qy7WTRssP7UJXNvByd5jcu