### PR TITLE
fix(gui): keep the Mode selector reachable, and settle on the light t…

### DIFF
--- a/docs/python/gui-guide.md
+++ b/docs/python/gui-guide.md
@@ -21,8 +21,8 @@ automatically.
 
 Most tabs keep their everyday settings in the open and fold the rest into a
 collapsible **Advanced settings** group, labelled with how many it holds so
-nothing is hidden silently. **⚙ Advanced settings** in the toolbar opens every
-one at once and remembers that between sessions.
+nothing is hidden silently. **⚙ Advanced** in the toolbar opens every one at
+once and remembers that between sessions.
 
 Advanced does not mean dangerous or inactive: a collapsed setting loads, holds
 and saves its value exactly as an open one does, and every field is documented

--- a/python/README.md
+++ b/python/README.md
@@ -115,7 +115,7 @@ The tabs run left to right in the order you use them:
 
 Each tab keeps its everyday settings in the open and folds the rest into a
 collapsible **Advanced settings** group, labelled with how many it holds.
-**⚙ Advanced settings** in the toolbar opens every one at once and remembers
+**⚙ Advanced** in the toolbar opens every one at once and remembers
 that between sessions. Folding changes only what is on screen — a collapsed
 setting loads, holds and saves its value exactly as an open one does. See
 [Advanced settings](../docs/python/gui-guide.md#advanced-settings).

--- a/python/test_gui_toolbar.py
+++ b/python/test_gui_toolbar.py
@@ -1,0 +1,126 @@
+"""The toolbar, and what happens to it when the window is not wide.
+
+A QToolBar that does not fit folds its trailing items into an overflow chevron.
+That is fine for Tutorial. It was not fine for the Mode selector, which sat at
+the far end behind an expanding spacer and a logo: adding two actions during the
+GUI reorganisation pushed it out of reach at the default window size, and picking
+a pipeline is the first thing anyone does.
+
+So Mode leads the toolbar, the logo moved to the tab strip's corner where
+nothing competes with it, and the default window is wide enough for the whole
+row. These checks hold all three in place.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from PyQt6.QtCore import Qt  # noqa: E402
+from PyQt6.QtGui import QAction  # noqa: E402
+from PyQt6.QtWidgets import QApplication, QToolBar, QToolButton  # noqa: E402
+
+from meanap.gui import theme  # noqa: E402
+
+app = QApplication.instance() or QApplication([])
+# Widths depend on the style, so measure under the one the app actually ships.
+theme.apply(app)
+
+from meanap.gui.main_window import MainWindow  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if condition else 'FAIL'}  {name}"
+          + (f"   [{detail}]" if detail and not condition else ""))
+    if not condition:
+        FAILURES.append(f"{name}: {detail}" if detail else name)
+
+
+window = MainWindow()
+window.show()
+app.processEvents()
+app.processEvents()
+toolbar = window.findChild(QToolBar)
+
+
+def hidden_buttons() -> list[str]:
+    return [b.text() for b in toolbar.findChildren(QToolButton)
+            if b.text() and not b.isVisible()]
+
+
+# ── Nothing overflows at the size the window opens at ─────────────────────────
+
+print("\nAt the default window size")
+
+check("the whole toolbar fits", not hidden_buttons(), ", ".join(hidden_buttons()))
+check("including the Mode selector", window._mode_combo.isVisible(), "")
+
+
+# ── Mode survives a narrow window ─────────────────────────────────────────────
+
+print("\nWhen the window is narrower than the toolbar")
+
+for width in (1000, 900, 800, 700, 640):
+    window.resize(width, 800)
+    app.processEvents()
+    app.processEvents()
+    check(f"Mode is still reachable at {width}px",
+          window._mode_combo.isVisible(), ", ".join(hidden_buttons()))
+
+window.resize(1120, 800)
+app.processEvents()
+
+# Mode leading the toolbar is *why* the above holds: Qt drops trailing items.
+texts = [a.text() for a in toolbar.actions()]
+first_named = next((t for t in texts if t), "")
+check("and it comes before every action, which is what makes that true",
+      toolbar.actions()[0].text() == ""  # the Mode label is a widget action
+      and first_named == "New", f"{first_named!r} / {texts[:4]}")
+
+
+# ── Switching it still works ──────────────────────────────────────────────────
+
+print("\nPicking a pipeline")
+
+for key, expected in (("catnap", "CAT-NAP (2P)"), ("meastim", "Stimulation"),
+                      ("meanap", "Spike detection")):
+    window._mode_combo.setCurrentIndex(window._mode_combo.findData(key))
+    app.processEvents()
+    titles = [window._tabs.tabText(i).strip() for i in range(window._tabs.count())]
+    check(f"choosing {key} re-tabs the window", expected in titles, str(titles))
+
+
+# ── One theme, and the logo out of the way ────────────────────────────────────
+
+print("\nTheme and branding")
+
+action_texts = {a.text() for a in window.findChildren(QAction)}
+check("there is no light/dark toggle any more",
+      not any("Light" in t or "Dark" in t for t in action_texts),
+      str(sorted(t for t in action_texts if t)))
+check("and nothing else offers to change the theme",
+      not hasattr(window, "_act_theme") and not hasattr(window, "_current_theme"), "")
+check("theme.toggle and theme.reapply are gone with it",
+      not hasattr(theme, "toggle") and not hasattr(theme, "reapply"), "")
+check("the default is light",
+      theme.apply.__defaults__ == ("light",), str(theme.apply.__defaults__))
+
+corner = window._tabs.cornerWidget(Qt.Corner.TopRightCorner)
+check("the logo sits in the tab strip, not the toolbar",
+      corner is not None and corner.pixmap() is not None
+      and corner.parent() is not toolbar, str(corner))
+
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} FAILED:")
+    for f in FAILURES:
+        print(f"  - {f}")
+    raise SystemExit(1)
+print("All toolbar checks passed.")

--- a/src/meanap/gui/app.py
+++ b/src/meanap/gui/app.py
@@ -38,7 +38,7 @@ def main() -> None:
     # not just the main window.
     app.setWindowIcon(logo_icon())
 
-    theme.apply(app, theme="auto")
+    theme.apply(app)
 
     window = MainWindow(mode=args.mode)
     window.show()

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from PyQt6.QtWidgets import (
     QApplication, QComboBox, QFileDialog, QLabel, QMainWindow, QMessageBox,
-    QLineEdit, QScrollArea, QSizePolicy, QTabWidget, QToolBar, QWidget,
+    QLineEdit, QScrollArea, QTabWidget, QToolBar, QWidget,
 )
 from PyQt6.QtGui import QAction
 from PyQt6.QtCore import Qt, QSettings, QSignalBlocker
@@ -16,7 +16,6 @@ from meanap.params import Params
 from meanap.pipeline.bundle import BUNDLE_SUFFIX
 from meanap.pipeline.example_data import download_example_data
 from meanap.pipeline.report import generate_report
-from meanap.gui import theme
 from meanap.gui.branding import logo_icon, logo_pixmap
 from meanap.gui import advanced
 from meanap.gui.modes import (
@@ -60,7 +59,11 @@ class MainWindow(QMainWindow):
         # Also set in app.main() so dialogs inherit it; repeated here so the
         # window is branded however it was constructed (tests, embedding, …).
         self.setWindowIcon(logo_icon())
-        self.resize(980, 780)
+        # Wide enough for the toolbar to lay out in full. Below this Qt
+        # folds its trailing actions into an overflow chevron, which is a
+        # reasonable thing for Tutorial but was not for the Mode selector —
+        # hence Mode leading the toolbar rather than ending it.
+        self.resize(1120, 800)
 
         self._params = Params()
         # Stamp the launch mode onto the defaults before anything reads them:
@@ -69,7 +72,6 @@ class MainWindow(QMainWindow):
         apply_mode_to_params(mode, self._params)
         self._last_output_root: Path | None = None
         self._last_bundle: Path | None = None
-        self._current_theme = "dark"
         self._worker: PipelineWorker | None = None
         self._queue_worker: QueueWorker | None = None
         self._tutorial: TutorialOverlay | None = None
@@ -125,10 +127,6 @@ class MainWindow(QMainWindow):
         )
         self._act_bundle.triggered.connect(self._on_open_bundle)
 
-        self._act_theme = QAction("☀  Light", self)
-        self._act_theme.setToolTip("Toggle light / dark theme")
-        self._act_theme.triggered.connect(self._on_toggle_theme)
-
         act_tutorial = QAction("?  Tutorial", self)
         act_tutorial.setToolTip("Launch the guided tutorial")
         act_tutorial.triggered.connect(self._start_tutorial)
@@ -136,7 +134,7 @@ class MainWindow(QMainWindow):
         # One switch for every folded section in the window, for someone who
         # would rather see all of it than open sections one at a time. It only
         # changes what is shown: see meanap.gui.advanced.
-        self._act_advanced = QAction("⚙  Advanced settings", self)
+        self._act_advanced = QAction("⚙  Advanced", self)
         self._act_advanced.setCheckable(True)
         self._act_advanced.setToolTip(
             "Show the less-used settings on every tab at once. They are saved "
@@ -144,19 +142,11 @@ class MainWindow(QMainWindow):
         )
         self._act_advanced.toggled.connect(self._on_toggle_advanced)
 
-        tb.addAction(act_new)
-        tb.addSeparator()
-        tb.addAction(act_open)
-        tb.addAction(act_save)
-        tb.addSeparator()
-        tb.addAction(self._act_bundle)
-        tb.addSeparator()
-        tb.addAction(self._act_theme)
-        tb.addAction(self._act_advanced)
-        tb.addAction(act_tutorial)
-        tb.addSeparator()
-
-        # Mode selector: switching it re-tabs the window for that pipeline.
+        # Mode selector first, and deliberately so. It decides which pipeline
+        # the window is for, which is a bigger choice than anything after it —
+        # and a toolbar that overflows drops its *trailing* items, so the last
+        # thing to go should not be the first thing you set. (It used to sit at
+        # the far end, and a narrow window hid it behind the overflow chevron.)
         tb.addWidget(QLabel("  Mode "))
         self._mode_combo = QComboBox()
         for key, mode in MODES.items():
@@ -165,25 +155,43 @@ class MainWindow(QMainWindow):
         self._mode_combo.setToolTip(MODES[self._mode].blurb)
         self._mode_combo.currentIndexChanged.connect(self._on_mode_changed)
         tb.addWidget(self._mode_combo)
+        tb.addSeparator()
 
-        # Logo sits at the far right, past a stretch, so it reads as branding
-        # rather than competing with the actions for the eye.
-        spacer = QWidget()
-        spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
-        tb.addWidget(spacer)
+        tb.addAction(act_new)
+        tb.addSeparator()
+        tb.addAction(act_open)
+        tb.addAction(act_save)
+        tb.addSeparator()
+        tb.addAction(self._act_bundle)
+        tb.addSeparator()
+        tb.addAction(self._act_advanced)
+        tb.addAction(act_tutorial)
+        tb.addSeparator()
 
-        pixmap = logo_pixmap(32, self.devicePixelRatioF())
-        if pixmap is not None:
-            logo = QLabel()
-            logo.setPixmap(pixmap)
-            logo.setContentsMargins(0, 0, 10, 0)
-            logo.setToolTip("MEA-NAP — MEA Network Analysis Pipeline")
-            tb.addWidget(logo)
+
+    def _add_logo(self) -> None:
+        """Branding in the tab strip's right-hand corner, not on the toolbar.
+
+        It used to sit at the far end of the toolbar past an expanding spacer,
+        which meant it competed for width with the actions: at the default
+        window size the spacer took what was left and pushed Tutorial — and
+        before that the Mode selector — into the overflow chevron. There is
+        always room beside five tabs, and nothing there to be pushed out.
+        """
+        pixmap = logo_pixmap(28, self.devicePixelRatioF())
+        if pixmap is None:
+            return
+        logo = QLabel()
+        logo.setPixmap(pixmap)
+        logo.setContentsMargins(0, 0, 10, 0)
+        logo.setToolTip("MEA-NAP — MEA Network Analysis Pipeline")
+        self._tabs.setCornerWidget(logo, Qt.Corner.TopRightCorner)
 
     def _build_tabs(self) -> None:
         self._tabs = QTabWidget()
         self._tabs.setDocumentMode(True)
         self.setCentralWidget(self._tabs)
+        self._add_logo()
 
         self._data_panel = DataPanel()
         self._spike_panel = SpikeDetectionPanel()
@@ -592,11 +600,6 @@ class MainWindow(QMainWindow):
         return params
 
     # ── Toolbar actions ───────────────────────────────────────────────────────
-
-    def _on_toggle_theme(self) -> None:
-        self._current_theme = theme.toggle(self._current_theme)
-        theme.reapply(self._current_theme)
-        self._act_theme.setText("☀  Light" if self._current_theme == "dark" else "🌙  Dark")
 
     def _on_new(self) -> None:
         if QMessageBox.question(

--- a/src/meanap/gui/theme.py
+++ b/src/meanap/gui/theme.py
@@ -107,8 +107,14 @@ QSplitter::handle {{
 """
 
 
-def apply(app: QApplication, theme: str = "auto") -> None:
-    """Apply qdarktheme + custom overrides to *app*."""
+def apply(app: QApplication, theme: str = "light") -> None:
+    """Apply qdarktheme + custom overrides to *app*.
+
+    Light, and only light. A dark variant existed behind a toolbar toggle, but
+    the figures the window is mostly showing are drawn on white, so half the
+    screen stayed light whichever way it was set. The parameter is kept so a
+    dark build is a one-line change rather than a revert.
+    """
     qdarktheme.enable_hi_dpi()
     qdarktheme.setup_theme(
         theme,
@@ -120,18 +126,3 @@ def apply(app: QApplication, theme: str = "auto") -> None:
     font = QFont("Segoe UI", 10)
     font.setStyleHint(QFont.StyleHint.SansSerif)
     app.setFont(font)
-
-
-def toggle(current: str) -> str:
-    """Return the next theme name."""
-    return "light" if current == "dark" else "dark"
-
-
-def reapply(theme: str) -> None:
-    """Re-apply qdarktheme after a toggle (call without recreating QApplication)."""
-    qdarktheme.setup_theme(
-        theme,
-        corner_shape="rounded",
-        custom_colors={"primary": ACCENT},
-        additional_qss=_EXTRA_QSS,
-    )


### PR DESCRIPTION
…heme

Mode sat at the far end of the toolbar, behind an expanding spacer and the logo. A QToolBar that does not fit folds its *trailing* items into an overflow chevron, so the two actions added during the reorganisation — Open bundle and Advanced — pushed the Mode selector out of reach at the default window size. Picking a pipeline is the first thing anyone does, so it should be the last thing to go, not the first.

Mode now leads the toolbar. The logo moved to the tab strip's right-hand corner, where there is always room beside five tabs and nothing to be pushed out by it. The default window is 1120px, wide enough for the whole row; the old 980 predates three added items.

The light/dark toggle is gone and the app is light, as asked. It was following the OS before, which meant a dark desktop got a dark window around figures drawn on white — half the screen stayed light whichever way it was set. theme.apply keeps its parameter, so a dark build is a one-line change rather than a revert.

test_gui_toolbar.py checks Mode stays reachable from 1120px down to 640, that it precedes every action (which is what makes that true), that switching it still re-tabs the window, and that nothing offers to change the theme any more.


Claude-Session: https://claude.ai/code/session_01Qy7WTRssP7UJXNvByd5jcu