### PR TITLE
Open bundles from the Results tab only, not the toolbar

### DIFF
--- a/docs/python/express-mode.md
+++ b/docs/python/express-mode.md
@@ -57,7 +57,7 @@ Three routes, all equivalent to running `meanap-viewer` yourself:
 - **🌐 View report** after an express run — the button notices the run was
   express and opens the bundle in the viewer instead of building a
   near-empty `report.html` from the handful of figures on disk;
-- **📦 Open bundle…**, on the Results tab or in the toolbar;
+- **📦 Open bundle…** on the Results tab;
 - **drag the `.meanap` file onto the window**.
 
 Each bundle gets its own viewer; they all shut down when MEA-NAP closes. See

--- a/docs/python/gui-guide.md
+++ b/docs/python/gui-guide.md
@@ -5,8 +5,8 @@ interface: one tab per section of the pipeline. Parameters round-trip to and
 from a `Params` dataclass (`meanap.params.Params`, see the
 [API reference](api/index.rst)) via each panel's `load()`/`save()` methods, and
 can be saved/reloaded as JSON from the toolbar (**New**, **Open params…**,
-**Save params…**). The toolbar also has **Open bundle…**, which opens a
-`.meanap` run bundle in the viewer without running anything — see
+**Save params…**). To open a `.meanap` run bundle in the viewer without
+running anything, use **📦 Open bundle…** on the [Results](#results) tab — see
 [Opening a bundle](#opening-a-bundle).
 
 ```{admonition} In a hurry?
@@ -250,8 +250,8 @@ The last tab: what to do once something has finished.
   - an **express run** → opens its `.meanap` bundle in the viewer, which draws
     any figure on demand in PNG or editable SVG, and can export the whole
     output folder back out for sharing.
-- **📦 Open bundle…** — the same action as the toolbar's, for a bundle from
-  anywhere. See [Opening a bundle](#opening-a-bundle).
+- **📦 Open bundle…** — for a bundle from anywhere, with no run of your own
+  needed. See [Opening a bundle](#opening-a-bundle).
 - **Network viewer** — interactive exploration of a completed run's functional
   connectivity network, with optional cell-type overlays. Full walkthrough:
   [Network Viewer](network-viewer.md).
@@ -267,8 +267,7 @@ pressing it.
 A `.meanap` bundle does not need a run, or even the data it came from — it is a
 file people email each other. Two ways to open one:
 
-- **📦 Open bundle…**, on the Results tab or in the toolbar (one action, in two
-  places);
+- **📦 Open bundle…** on the Results tab;
 - **drag the `.meanap` file onto the window**, anywhere.
 
 Either starts the viewer and opens a browser on it. Each bundle gets its own

--- a/docs/python/output-report.md
+++ b/docs/python/output-report.md
@@ -86,5 +86,5 @@ without MEA-NAP.
 
 The GUI picks between them for you: **🌐 View report** opens the viewer for an
 express run and builds `report.html` for a full one. You can also open any
-bundle directly with **📦 Open bundle…** (Results tab or toolbar), or by dragging the
+bundle directly with **📦 Open bundle…** on the Results tab, or by dragging the
 `.meanap` file onto the window.

--- a/python/test_gui_bundle_viewer.py
+++ b/python/test_gui_bundle_viewer.py
@@ -296,21 +296,33 @@ def _drop_checks(app: QApplication, express_root: Path) -> list[Check]:
                        len(window._viewers) == 2 and len(urls) == 2, str(sorted(urls))))
         window._viewers.close_all()
 
-    # The toolbar route exists and is discoverable.
-    actions = {a.text(): a for a in window.findChildren(QAction)}
-    bundle_action = next(
-        (a for text, a in actions.items() if "Open bundle" in text), None)
-    checks.append(("the toolbar offers 'Open bundle…'", bundle_action is not None,
-                   str(sorted(actions))))
+    # Opening a bundle belongs with the other things you do to a finished run,
+    # not in the toolbar beside New and Save params.
+    button = window._results_panel.bundle_btn
+    checks.append(("the Results tab offers 'Open bundle…'",
+                   "Open bundle" in button.text(), button.text()))
     checks.append(("…and says drag-and-drop works too",
-                   bundle_action is not None and "drag" in bundle_action.toolTip().lower(),
-                   bundle_action.toolTip() if bundle_action else ""))
+                   "drag" in button.toolTip().lower(), button.toolTip()))
+    checks.append(("it is not also in the toolbar",
+                   not any("Open bundle" in a.text()
+                           for a in window.findChildren(QAction)),
+                   str(sorted(a.text() for a in window.findChildren(QAction) if a.text()))))
 
-    # The Results tab offers it too — as the *same* action, so the two cannot
-    # drift apart in wording, tooltip or behaviour.
-    checks.append(("the Results tab offers the same action, not a copy of it",
-                   window._results_panel.bundle_btn.defaultAction() is bundle_action,
-                   str(window._results_panel.bundle_btn.defaultAction())))
+    # Pressing it reaches the window's handler — the same one drag-and-drop
+    # uses. The file chooser is stubbed out, or this would sit on a modal
+    # dialog forever.
+    from PyQt6.QtWidgets import QFileDialog
+
+    asked: list[str] = []
+    original = QFileDialog.getOpenFileName
+    QFileDialog.getOpenFileName = staticmethod(
+        lambda *a, **k: (asked.append("chooser opened"), ("", ""))[1])
+    try:
+        button.click()
+    finally:
+        QFileDialog.getOpenFileName = original
+    checks.append(("pressing it asks the window for a bundle to open",
+                   asked == ["chooser opened"], str(asked)))
     return checks
 
 

--- a/python/test_gui_toolbar.py
+++ b/python/test_gui_toolbar.py
@@ -83,6 +83,11 @@ check("and it comes before every action, which is what makes that true",
       toolbar.actions()[0].text() == ""  # the Mode label is a widget action
       and first_named == "New", f"{first_named!r} / {texts[:4]}")
 
+# Opening a bundle lives with the other things you do to a finished run.
+check("the toolbar is parameters, advanced and help — nothing about results",
+      not any("bundle" in t.lower() or "report" in t.lower() for t in texts),
+      ", ".join(t for t in texts if t))
+
 
 # ── Switching it still works ──────────────────────────────────────────────────
 

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -119,14 +119,6 @@ class MainWindow(QMainWindow):
         act_save.setToolTip("Save current parameters to a JSON file")
         act_save.triggered.connect(self._on_save)
 
-        self._act_bundle = QAction("📦  Open bundle…", self)
-        self._act_bundle.setToolTip(
-            "Open a .meanap run bundle — from an express run of your own, or "
-            "one someone sent you — and draw any of its figures in the viewer. "
-            "You can also drag the file onto this window."
-        )
-        self._act_bundle.triggered.connect(self._on_open_bundle)
-
         act_tutorial = QAction("?  Tutorial", self)
         act_tutorial.setToolTip("Launch the guided tutorial")
         act_tutorial.triggered.connect(self._start_tutorial)
@@ -161,8 +153,6 @@ class MainWindow(QMainWindow):
         tb.addSeparator()
         tb.addAction(act_open)
         tb.addAction(act_save)
-        tb.addSeparator()
-        tb.addAction(self._act_bundle)
         tb.addSeparator()
         tb.addAction(self._act_advanced)
         tb.addAction(act_tutorial)
@@ -204,10 +194,9 @@ class MainWindow(QMainWindow):
         # cares about one — loading parameters, or the queue's list.
         self._pipeline_panel = self._run_panel.settings
         self._queue_panel = self._run_panel.queue
-        # The Results tab reuses the toolbar's own Open bundle action rather
-        # than a second button calling the same slot.
-        self._results_panel = ResultsPanel(self._act_bundle)
+        self._results_panel = ResultsPanel()
         self._results_panel.view_report_requested.connect(self._on_view_report)
+        self._results_panel.open_bundle_requested.connect(self._on_open_bundle)
         self._network_viewer_panel = self._results_panel.viewer
 
         # Every tab is built once and kept alive here; the current mode decides
@@ -986,7 +975,7 @@ class MainWindow(QMainWindow):
                 "Run the pipeline first, or set the Output data folder / name "
                 "(Data tab) to an existing MEA-NAP output folder.\n\n"
                 "To open an express run from another machine, use "
-                "'Open bundle…' here or in the toolbar, or drag its .meanap file onto "
+                "'Open bundle…' above, or drag its .meanap file onto "
                 "this window.",
             )
             return

--- a/src/meanap/gui/panels/results.py
+++ b/src/meanap/gui/panels/results.py
@@ -2,9 +2,10 @@
 
 Looking at results was spread across the window. **View report** was a fourth
 button in the Run tab's row, beside Run and Stop, which is the row you look at
-while something is *running*. **Open bundle…** was in the toolbar, next to New
-and Save params. The Network Viewer was a tab of its own, sitting before Run in
-the strip — so the workflow ran left to right until the very end, then jumped
+while something is *running*. **Open bundle…** was in the toolbar, next to New and
+Save params, which is where you look for a file you are about to open — not for
+a run you are about to read. The Network Viewer was a tab of its own, sitting
+before Run in the strip — so the workflow ran left to right until the very end, then jumped
 backwards.
 
 They are one tab now, and it is the last one: configure on the left, run, then
@@ -22,10 +23,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import (
-    QGroupBox, QHBoxLayout, QLabel, QPushButton, QToolButton, QVBoxLayout,
-    QWidget,
+    QGroupBox, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget,
 )
 
 from meanap.gui.panels.network_viewer import NetworkViewerPanel
@@ -37,11 +36,10 @@ class ResultsPanel(QWidget):
     """Open a finished run, and explore its networks."""
 
     view_report_requested = pyqtSignal()
+    open_bundle_requested = pyqtSignal()
 
-    def __init__(self, bundle_action: QAction | None = None,
-                 parent: QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self._bundle_action = bundle_action
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
@@ -70,18 +68,16 @@ class ResultsPanel(QWidget):
         self.view_report_btn.clicked.connect(self.view_report_requested)
         row.addWidget(self.view_report_btn)
 
-        # The same QAction the toolbar holds, rather than a second button that
-        # calls the same slot — one tooltip, one shortcut, no chance of the two
-        # drifting apart.
-        if self._bundle_action is not None:
-            self.bundle_btn = QToolButton()
-            self.bundle_btn.setDefaultAction(self._bundle_action)
-            self.bundle_btn.setToolButtonStyle(
-                Qt.ToolButtonStyle.ToolButtonTextOnly)
-            self.bundle_btn.setFixedHeight(40)
-            self.bundle_btn.setObjectName("secondary")
-            self.bundle_btn.setSizePolicy(self.view_report_btn.sizePolicy())
-            row.addWidget(self.bundle_btn)
+        self.bundle_btn = QPushButton("📦  Open bundle…")
+        self.bundle_btn.setFixedHeight(40)
+        self.bundle_btn.setObjectName("secondary")
+        self.bundle_btn.setToolTip(
+            "Open a .meanap run bundle — from an express run of your own, or "
+            "one someone sent you — and draw any of its figures in the viewer. "
+            "You can also drag the file onto this window."
+        )
+        self.bundle_btn.clicked.connect(self.open_bundle_requested)
+        row.addWidget(self.bundle_btn)
         outer.addLayout(row)
 
         # What the buttons above would act on. Written out because "View report"


### PR DESCRIPTION
Follow-up to #118.

**Open bundle… was in two places.** The toolbar's copy sat beside New and Save params — where you look for a file you are about to open, not for a run you are about to read. #118 put the same thing on the Results tab beside **View report**, which is where it belongs. This removes the toolbar one.

```
before   Mode │ New │ Open params… │ Save params… │ 📦 Open bundle… │ ⚙ Advanced │ ? Tutorial
after    Mode │ New │ Open params… │ Save params… │ ⚙ Advanced │ ? Tutorial
```

The toolbar is now parameters, advanced and help. The test asserts it mentions neither bundles nor reports.

**Dropping the shared QAction.** #118 had the two buttons share one `QAction` so they could not drift apart in wording, tooltip or behaviour. With only one place left, that indirection buys nothing. `ResultsPanel` now owns a plain `QPushButton` and emits `open_bundle_requested`, matching `view_report_requested` exactly.

That also restores the ellipsis: `QToolButton` strips a trailing one from an action's text, so the button read *Open bundle* while its neighbour read *🌐 View report*. Both are `QPushButton` now and match.

**Drag-and-drop onto the window is unchanged** — it never went through the action.

## Testing

`test_gui_bundle_viewer.py` swaps its "same action, not a copy" identity check for four behavioural ones: the button exists on Results, its tooltip still mentions dragging, it is *not* also in the toolbar, and pressing it reaches the window's handler.

That last one hung the suite on first run — the click opened a real modal file chooser. It now stubs `QFileDialog.getOpenFileName`, asserts the chooser was asked for, and restores it in a `finally`.

All twelve suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qy7WTRssP7UJXNvByd5jcu
