### PR TITLE
fix(gui): let the window be resized vertically, not just horizontally

### DIFF
--- a/python/test_gui_window_resize.py
+++ b/python/test_gui_window_resize.py
@@ -1,0 +1,86 @@
+"""Can the window actually be resized vertically?
+
+On a Mac the window could be made wider and narrower but its height would not
+budge. Nothing pinned it: the Results tab's network-viewer control column is
+five stacked group boxes, and an unscrolled panel hands its full height to the
+window as a *minimum*. That minimum came to 1144px — taller than the usable
+height of a laptop screen — so macOS clamped the window to the screen and it
+could neither grow (screen limit) nor shrink (minimum). Width had a minimum of
+~400px, so width stayed free, which is exactly what it looked like from
+outside.
+
+The guard here is the same one the bug broke: no mode's window may demand more
+vertical space than a modest laptop screen leaves. 800px is the height of the
+smallest display anyone runs this on, less the menu bar and the Dock.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from meanap.gui.main_window import MainWindow  # noqa: E402
+from meanap.gui.modes import MODES  # noqa: E402
+
+app = QApplication.instance() or QApplication([])
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if condition else 'FAIL'}  {name}"
+          + (f"   [{detail}]" if detail and not condition else ""))
+    if not condition:
+        FAILURES.append(f"{name}: {detail}" if detail else name)
+
+
+# A 1280x800 display with the menu bar and Dock taken off it.
+USABLE_HEIGHT = 700
+USABLE_WIDTH = 1100
+
+for mode in MODES:
+    print(f"\n{MODES[mode].label}")
+    window = MainWindow(mode=mode)
+    window.show()
+    app.processEvents()
+
+    min_h = window.minimumSizeHint().height()
+    min_w = window.minimumSizeHint().width()
+    check(f"[{mode}] fits the height of a small laptop screen",
+          min_h <= USABLE_HEIGHT, f"minimum height {min_h}px > {USABLE_HEIGHT}px")
+    check(f"[{mode}] fits the width too", min_w <= USABLE_WIDTH,
+          f"minimum width {min_w}px > {USABLE_WIDTH}px")
+
+    # And it really does resize, not just report a small minimum: shrink it and
+    # see the height follow. (Offscreen has no window manager to clamp against,
+    # so a refused resize here means a layout constraint refused it.)
+    window.resize(900, USABLE_HEIGHT)
+    app.processEvents()
+    check(f"[{mode}] height follows a resize down",
+          window.height() <= USABLE_HEIGHT,
+          f"asked for {USABLE_HEIGHT}px, got {window.height()}px")
+
+    # Every tab, not just the one showing — switching tabs must not re-lock it.
+    for i in range(window._tabs.count()):
+        window._tabs.setCurrentIndex(i)
+        app.processEvents()
+        title = window._tabs.tabText(i).strip()
+        h = window.minimumSizeHint().height()
+        check(f"[{mode}] the {title} tab does not raise the floor",
+              h <= USABLE_HEIGHT, f"minimum height {h}px with {title} showing")
+
+    window.close()
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} FAILED:")
+    for f in FAILURES:
+        print(f"  - {f}")
+    raise SystemExit(1)
+print("All window-resize checks passed.")

--- a/src/meanap/gui/panels/network_viewer.py
+++ b/src/meanap/gui/panels/network_viewer.py
@@ -9,8 +9,8 @@ from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtWidgets import (
     QComboBox, QDoubleSpinBox, QFileDialog, QFormLayout, QGroupBox,
     QHBoxLayout, QLabel, QLineEdit, QListWidget, QListWidgetItem,
-    QPushButton, QSizePolicy, QSpinBox, QSplitter, QTextEdit, QVBoxLayout,
-    QWidget,
+    QPushButton, QScrollArea, QSizePolicy, QSpinBox, QSplitter, QStyle,
+    QTextEdit, QVBoxLayout, QWidget,
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
@@ -137,9 +137,31 @@ class NetworkViewerPanel(QWidget):
         splitter = QSplitter(Qt.Orientation.Horizontal)
         main_layout.addWidget(splitter)
 
-        splitter.addWidget(self._build_left())
+        # The control column is taller than it looks — five stacked group
+        # boxes — and a plain widget hands its full height to the window as a
+        # minimum, which on a laptop screen leaves the window unable to be
+        # resized vertically at all. Scrolling it keeps that height off the
+        # window's minimum.
+        left_scroll = QScrollArea()
+        left_controls = self._build_left()
+        left_scroll.setWidget(left_controls)
+        left_scroll.setWidgetResizable(True)
+        left_scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        splitter.addWidget(left_scroll)
         splitter.addWidget(self._build_right())
-        splitter.setSizes([320, 700])
+        # Keep the column wide enough for the controls *and* the vertical
+        # scrollbar beside them. Measured from the widgets rather than set to a
+        # round number, so a relabelled control or a wider platform scrollbar
+        # cannot clip the column or force a horizontal scrollbar under it. Only
+        # the width is pinned — the height is what scrolls.
+        scrollbar_w = self.style().pixelMetric(
+            QStyle.PixelMetric.PM_ScrollBarExtent, None, left_scroll)
+        left_scroll.setMinimumWidth(
+            left_controls.sizeHint().width() + scrollbar_w + 4)
+        # Spare width goes to the plot, not the controls.
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([left_scroll.minimumWidth(), 700])
 
         # Start on the example network so every control does something on launch.
         self._load_example_network()


### PR DESCRIPTION
## The bug

On a Mac the MEA-NAP window could be made wider and narrower, but its height would not budge.

Nothing pinned the height directly — the cause was a *minimum* that had grown past what the screen can show. The Results tab's network-viewer control column is five stacked group boxes sitting in the splitter as a plain widget, and an unscrolled panel hands its full natural height to its window as a hard minimum. That column alone contributed 905px, making the whole window's minimum **1144 × 397**.

1144px is taller than the usable height of a laptop screen, so macOS clamped the window to the display: it could not grow (screen limit) and could not shrink (Qt's minimum). The minimum *width* was only ~400px, so width stayed free — exactly the asymmetry that was reported. On a taller Linux/Windows display the same build resizes fine, which is why it went unnoticed.

## The fix

`src/meanap/gui/panels/network_viewer.py` — the control column now lives in a `QScrollArea`, so its height scrolls instead of becoming a floor on the window.

Its *width* is pinned to the controls plus the platform scrollbar extent (measured via `PM_ScrollBarExtent` rather than hard-coded), so nothing is clipped and no horizontal scrollbar appears underneath it. Spare width goes to the plot via splitter stretch factors.

Window minimum height, per mode:

| Mode | Before | After |
|---|---|---|
| MEA-NAP | 1144px | 665px |
| MEA-Stim | 1144px | 665px |
| CAT-NAP | 1144px | 688px |

What remains is genuine stacked content on the Run (599px) and CAT-NAP (622px) tabs — comfortably inside any display.

## Verification

- New `python/test_gui_window_resize.py` guards the same thing the bug broke: for every mode, and with **every** tab showing, the window minimum must fit a 1280×800 screen and a resize down must be honoured. It fails on the old code and passes here.
- Screenshotted the Results tab headlessly at 1120×800 and squeezed to 665px: plot fills, controls scroll, nothing clipped, no stray horizontal scrollbar.
- Existing GUI suite green (`test_gui_results`, `toolbar`, `advanced`, `tooltips`, `bundle_viewer`, `cell_type_groups`, `spreadsheet_builder`), exit codes checked per file.

One caveat worth stating plainly: the diagnosis and all measurements come from Qt size hints on Linux. macOS is where the clamp actually bites, so it is worth a quick launch there to confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcEjpH2JTFBHj3PH6qhrUw