### PR TITLE
CAT-NAP: show the peak-detection traces, and make the Data tab read as CAT-NAP's (1.0.1)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -416,9 +416,10 @@ uv run meanap-preflight '<share link>'          # check first; seconds, no trans
 uv run meanap-preflight '<link>' --write-spreadsheet fixed.csv
 ```
 
-In the GUI, the same link works in **Raw data folder** and in the CAT-NAP tab's
-**Scan for suite2p folders**, which lists what is behind the link without
-transferring anything. The batch spreadsheet is still a local file; build it
+In the GUI, the same link works in the Data tab's input folder — **Raw data
+folder** in the ephys modes, **Recordings folder (suite2p)** in CAT-NAP — and in
+the CAT-NAP tab's **Scan for suite2p folders**, which lists what is behind the
+link without transferring anything. The batch spreadsheet is still a local file; build it
 from the scan (see below) or with `--write-spreadsheet` above.
 
 A remote run pre-flights automatically and refuses to start if recordings are

--- a/python/diagnose_bundle_traces.py
+++ b/python/diagnose_bundle_traces.py
@@ -1,0 +1,88 @@
+"""Why a bundle shows no peak-detection traces.
+
+    uv run python python/diagnose_bundle_traces.py <run>.meanap
+
+Reads the bundle's own manifest and params, so it answers the question without
+the output folder, the raw data or the run's log.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from meanap.pipeline.bundle import open_bundle  # noqa: E402
+from meanap.pipeline.render import (  # noqa: E402
+    TRACE_DIR, available_trace_figures, load_context,
+)
+
+NEEDS_DENOISING = ("peaks", "denoised F", "spks")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__)
+        return 2
+
+    path = Path(argv[1])
+    with open_bundle(path) as bundle:
+        ctx = load_context(bundle)
+        params = bundle.params
+
+        print(f"{path.name}")
+        print(f"  mode              {bundle.manifest.get('mode')}")
+        print(f"  express           {bundle.manifest.get('express')}")
+        print(f"  embedded figures  {bundle.manifest.get('embedded_figures') or 'none'}")
+
+        if params is not None:
+            print(f"  num_2p_traces     {params.num_2p_traces}")
+            print(f"  twop_activity     {params.twop_activity!r}")
+            print(f"  twop_redo_denoising {params.twop_redo_denoising}")
+        else:
+            print("  (no params.json in this bundle)")
+
+        packed = sorted((bundle.root / TRACE_DIR).rglob("*.png"))
+        print(f"\n  {len(packed)} trace PNG(s) packed under {TRACE_DIR}")
+        for p in packed[:6]:
+            print(f"    {p.relative_to(bundle.root)}")
+        if len(packed) > 6:
+            print(f"    …and {len(packed) - 6} more")
+
+        print("\n  What the viewer would list, per recording:")
+        for name in ctx.recordings:
+            figs = available_trace_figures(ctx, name)
+            print(f"    {name}: {len(figs)}"
+                  + (f"  ({', '.join(f.label for f in figs[:4])})" if figs else ""))
+
+        # The diagnosis.
+        print()
+        if packed:
+            listed = any(available_trace_figures(ctx, n) for n in ctx.recordings)
+            if listed:
+                print("  → The figures are here and the viewer can find them. If the "
+                      "page shows none, it is a viewer/browser problem, not the run.")
+            else:
+                print("  → The figures are packed but the viewer cannot match them to "
+                      "a recording — the folder names under\n"
+                      f"    {TRACE_DIR}/<group>/<recording>/ do not match the "
+                      "spreadsheet's recording names.")
+        elif params is not None and not params.num_2p_traces:
+            print("  → The run had 'Trace figures to save per recording' set to 0, so "
+                  "they were never drawn.\n    They cannot be recovered from the "
+                  "bundle; set it above 0 (CAT-NAP tab → Denoising settings → "
+                  "Advanced) and re-run.")
+        elif params is not None and params.twop_activity not in NEEDS_DENOISING:
+            print(f"  → Activity type is {params.twop_activity!r}, which skips "
+                  "denoising — and these figures plot the\n    denoised trace "
+                  "against the detected events. Set it to 'peaks' and re-run.")
+        else:
+            print("  → The run meant to draw them and did not. The run log says why; "
+                  "look for lines\n    containing '2P trace' or 'could not re-read "
+                  "suite2p data'.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/python/test_gui_advanced.py
+++ b/python/test_gui_advanced.py
@@ -20,6 +20,9 @@ from PyQt6.QtWidgets import QApplication, QLabel, QWidget  # noqa: E402
 
 from meanap.gui.advanced import AdvancedSection, set_all_expanded  # noqa: E402
 from meanap.gui.panels.connectivity import ConnectivityPanel  # noqa: E402
+from meanap.gui.panels.data import (  # noqa: E402
+    CATNAP_DATA_LABEL, DataPanel, RAW_DATA_LABEL,
+)
 from meanap.params import Params  # noqa: E402
 
 app = QApplication.instance() or QApplication([])
@@ -84,10 +87,10 @@ panel.show()
 app.processEvents()
 
 sections = panel.findChildren(AdvancedSection)
-check("connectivity has advanced sections", len(sections) == 2, str(len(sections)))
+check("connectivity has an advanced section", len(sections) == 1, str(len(sections)))
 
 # Loaded into a collapsed panel, read straight back out.
-loaded = Params(trunc_rec=True, trunc_length=45.0, prob_thresh_tail=0.02,
+loaded = Params(prob_thresh_tail=0.02,
                 prob_thresh_plot_checks=True, prob_thresh_plot_checks_n=7)
 panel.load(loaded)
 check("loading does not force sections open",
@@ -96,11 +99,10 @@ check("loading does not force sections open",
 out = Params()
 panel.save(out)
 check("collapsed values round-trip",
-      (out.trunc_rec, out.trunc_length, out.prob_thresh_tail,
-       out.prob_thresh_plot_checks, out.prob_thresh_plot_checks_n)
-      == (True, 45.0, 0.02, True, 7),
-      f"{out.trunc_rec} {out.trunc_length} {out.prob_thresh_tail} "
-      f"{out.prob_thresh_plot_checks} {out.prob_thresh_plot_checks_n}")
+      (out.prob_thresh_tail, out.prob_thresh_plot_checks,
+       out.prob_thresh_plot_checks_n) == (0.02, True, 7),
+      f"{out.prob_thresh_tail} {out.prob_thresh_plot_checks} "
+      f"{out.prob_thresh_plot_checks_n}")
 
 # And the same when they were opened, edited, and closed again.
 set_all_expanded(panel, True)
@@ -114,7 +116,63 @@ check("an edit made while open survives closing",
 # The settings that a run is normally configured with stay in the open.
 check("lag values stay visible", panel.lag_vals.isVisibleTo(panel))
 check("iterations stay visible", panel.prob_thresh_rep_num.isVisibleTo(panel))
-check("truncation is folded away", not panel.trunc_rec.isVisibleTo(panel))
+
+# Truncation says how much of each recording to read, so it lives with the
+# input folder on the Data tab rather than under the STTC settings.
+data_panel = DataPanel()
+data_panel.show()
+app.processEvents()
+check("truncation is folded away on the Data tab",
+      not data_panel.trunc_rec.isVisibleTo(data_panel))
+check("connectivity no longer owns truncation",
+      not hasattr(panel, "trunc_rec"))
+
+trunc_out = Params()
+data_panel.load(Params(trunc_rec=True, trunc_length=45.0))
+data_panel.save(trunc_out)
+check("truncation round-trips from the Data tab",
+      (trunc_out.trunc_rec, trunc_out.trunc_length) == (True, 45.0),
+      f"{trunc_out.trunc_rec} {trunc_out.trunc_length}")
+
+
+# ── What each mode shows of the Data tab ──────────────────────────────────────
+
+print("\nThe Data tab reads differently per pipeline")
+
+form = data_panel._input_form
+raw_label = form.labelForField(data_panel.raw_data)
+adv = data_panel._input_advanced
+
+data_panel.set_mode("meanap")
+app.processEvents()
+check("ephys calls the input folder raw data",
+      raw_label.text() == RAW_DATA_LABEL, raw_label.text())
+check("ephys offers a spike data folder",
+      adv.form().isRowVisible(data_panel.spike_detected_data))
+ephys_count = adv.count()
+
+data_panel.set_mode("catnap")
+app.processEvents()
+check("CAT-NAP names the folder for what it holds",
+      raw_label.text() == CATNAP_DATA_LABEL, raw_label.text())
+check("CAT-NAP hides the spike data folder — it has no spike step",
+      not adv.form().isRowVisible(data_panel.spike_detected_data))
+check("and the header stops counting the row it hid",
+      adv.count() == ephys_count - 1, f"{adv.count()} vs {ephys_count}")
+
+# Hidden, not dropped: a CAT-NAP window still saves whatever was in it.
+data_panel.load(Params(spike_detected_data="/tmp/spikes"))
+hidden_out = Params()
+data_panel.save(hidden_out)
+check("a hidden spike data folder is still saved",
+      hidden_out.spike_detected_data == "/tmp/spikes",
+      hidden_out.spike_detected_data)
+
+data_panel.set_mode("meanap")
+app.processEvents()
+check("switching back brings the row and the name with it",
+      raw_label.text() == RAW_DATA_LABEL
+      and adv.form().isRowVisible(data_panel.spike_detected_data))
 
 
 # ── The window's toggle ───────────────────────────────────────────────────────
@@ -171,8 +229,9 @@ FOLDED = dict(
     spreadsheet_range="A5:A99", custom_grp_order=["KO", "WT"],
     spike_detected_data="/tmp/spikes", d_samp_f=500.0,
     potential_difference_unit="mV",
+    trunc_rec=True, trunc_length=45.0,
     # Connectivity
-    trunc_rec=True, trunc_length=45.0, prob_thresh_tail=0.02,
+    prob_thresh_tail=0.02,
     prob_thresh_plot_checks=True, prob_thresh_plot_checks_n=9,
     # Spike detection
     run_spike_check_on_prev_spike_data=True, abs_thresholds=[12.0, 18.0],
@@ -246,6 +305,21 @@ for mode_key in ("meanap", "meastim", "catnap"):
             invisible.append(f"{mode_key}: {step.title}")
         tutorial._next()
         app.processEvents()
+
+# ── Tab order ─────────────────────────────────────────────────────────────────
+
+print("\nTab order")
+
+from meanap.gui.modes import TAB_CATNAP, TAB_CONNECTIVITY  # noqa: E402
+
+window._apply_mode("catnap", sync_params=False)
+app.processEvents()
+check("CAT-NAP comes before Connectivity",
+      0 <= window._tab_index(TAB_CATNAP) < window._tab_index(TAB_CONNECTIVITY),
+      f"catnap={window._tab_index(TAB_CATNAP)} "
+      f"connectivity={window._tab_index(TAB_CONNECTIVITY)}")
+check("the Data tab still leads", window._tab_index("data") == 0,
+      str(window._tab_index("data")))
 
 check("every tutorial target is on screen when its step is shown",
       not invisible, "; ".join(invisible))

--- a/python/test_viewer_server.py
+++ b/python/test_viewer_server.py
@@ -621,6 +621,18 @@ def _trace_checks() -> list[Check]:
             status, body, _ = _get(base + "/")
             checks.append(("the page has a section for them",
                            b"Peak detection traces" in body, ""))
+
+            # …and the pane the image loads into is actually shown. Everything
+            # above passed while a click on "Unit 1" displayed nothing: the PNG
+            # was fetched into #figure-img, and setMode hid the <figure> around
+            # it, because its list of one-image kinds did not name "trace".
+            from meanap.viewer.page import PAGE_HTML
+
+            one_expr = PAGE_HTML.split("const one =", 1)[1].split(";", 1)[0]
+            checks.append(("a trace counts as a single-figure view",
+                           '"trace"' in one_expr, " ".join(one_expr.split())))
+            checks.append(("…so the PNG download is offered",
+                           'const downloadable = one' in PAGE_HTML, ""))
         finally:
             httpd.shutdown()
     return checks

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -630,6 +630,28 @@ def _reload_for_plots(params, rec, state, log, source=None):
     return data, state.background
 
 
+def _no_trace_reason(params, data) -> str | None:
+    """Why this recording can draw no peak-detection figures, or ``None``.
+
+    Every branch here used to be a silent ``return []`` inside
+    :func:`plot_2p_traces` — the figures simply did not appear, in a run that
+    reported no error, and the express bundle that travelled afterwards was the
+    only record anyone had.
+    """
+    if data is None:
+        return "its suite2p folder could not be re-read (see the warning above)"
+    if data.F_denoised is None or data.peak_start_frames is None:
+        if params.twop_activity not in _NEEDS_DENOISING:
+            return (f"activity type {params.twop_activity!r} does not denoise, "
+                    "and these figures plot the denoised trace against the "
+                    "detected events — use 'peaks' to get them")
+        return ("no denoised traces were found for it — denoising did not run "
+                "or its output is missing from the derived-data folder")
+    if not int(data.cell_mask.sum()):
+        return "iscell.npy labels none of its ROIs as cells"
+    return None
+
+
 def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, log,
                     data=None, background=None) -> None:
     """Per-unit trace figures + the full step-4A figure set for one recording.
@@ -653,15 +675,27 @@ def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, 
     from meanap.catnap.plotting import plot_2p_traces
     from meanap.pipeline.step4 import _plot_recording_lag
 
-    if params.num_2p_traces and data is not None:
-        try:
-            trace_dir = (output_root / "2_NeuronalActivity" / "2A_IndividualNeuronalAnalysis"
-                         / rec.group / rec.filename)
-            log(f"  [{rec.filename}] plotting 2P traces…")
-            plot_2p_traces(data, trace_dir, rec.filename,
-                           num_traces=params.num_2p_traces)
-        except Exception as e:
-            log(f"  [{rec.filename}] warning: 2P trace plots failed: {e}")
+    if params.num_2p_traces:
+        # Say why when there is nothing to draw. These are the one family a
+        # bundle cannot rebuild, so a run that quietly skips them leaves the
+        # reader looking at an empty section in the viewer with nothing in the
+        # log to explain it — and no way to get them back but another run.
+        reason = _no_trace_reason(params, data)
+        if reason:
+            log(f"  [{rec.filename}] no peak-detection trace figures: {reason}")
+        else:
+            try:
+                trace_dir = (output_root / "2_NeuronalActivity"
+                             / "2A_IndividualNeuronalAnalysis"
+                             / rec.group / rec.filename)
+                log(f"  [{rec.filename}] plotting 2P traces…")
+                drawn = plot_2p_traces(data, trace_dir, rec.filename,
+                                       num_traces=params.num_2p_traces)
+                if not drawn:
+                    log(f"  [{rec.filename}] warning: 2P trace plots produced "
+                        "no figures")
+            except Exception as e:
+                log(f"  [{rec.filename}] warning: 2P trace plots failed: {e}")
 
     if params.express_mode:
         return

--- a/src/meanap/gui/advanced.py
+++ b/src/meanap/gui/advanced.py
@@ -100,7 +100,18 @@ class AdvancedSection(QWidget):
         return self._form
 
     def count(self) -> int:
-        return self._form.rowCount()
+        """How many settings are in here — not counting rows a mode hid.
+
+        A panel may take a row out for the running pipeline (see
+        ``DataPanel.set_mode``), and a header promising three settings that
+        opens onto two is a small lie the count exists to avoid.
+        """
+        return sum(1 for row in range(self._form.rowCount())
+                   if self._form.isRowVisible(row))
+
+    def refresh_label(self) -> None:
+        """Re-read the count, for a caller that just showed or hid a row."""
+        self._relabel()
 
     # ── Open and closed ───────────────────────────────────────────────────────
 

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -26,7 +26,9 @@ from meanap.gui.modes import (
 )
 from meanap.gui.pipeline_worker import PipelineWorker, QueueWorker
 from meanap.gui.viewer_session import ViewerSessions
-from meanap.gui.panels.data import DataPanel
+from meanap.gui.panels.data import (
+    CATNAP_DATA_LABEL, DataPanel, RAW_DATA_LABEL,
+)
 from meanap.gui.panels.spike_detection import SpikeDetectionPanel
 from meanap.gui.panels.connectivity import ConnectivityPanel
 from meanap.gui.panels.stim import StimPanel
@@ -233,10 +235,14 @@ class MainWindow(QMainWindow):
         self._tab_specs: list[tuple[str, QWidget, str]] = [
             (TAB_DATA, _scrollable(self._data_panel), "  Data  "),
             (TAB_SPIKE, _scrollable(self._spike_panel), "  Spike detection  "),
+            # CAT-NAP before Connectivity: in 2P mode this tab is where the
+            # recordings are found and prepared, so it comes before the
+            # settings that act on them — the same place Spike detection holds
+            # in the ephys modes.
+            (TAB_CATNAP, self._catnap_panel, "  CAT-NAP (2P)  "),
             (TAB_CONNECTIVITY, _scrollable(self._connectivity_panel), "  Connectivity  "),
             (TAB_STIM, _scrollable(self._stim_panel), "  Stimulation  "),
             (TAB_STIM_PREVIEW, self._stim_preview_panel, "  Stim Preview  "),
-            (TAB_CATNAP, self._catnap_panel, "  CAT-NAP (2P)  "),
             (TAB_RUN, self._run_panel, "  Run  "),
             (TAB_RESULTS, self._results_panel, "  Results  "),
         ]
@@ -248,7 +254,7 @@ class MainWindow(QMainWindow):
         self._tabs.currentChanged.connect(self._on_tab_changed)
         self._queue_panel.changed.connect(self._run_panel.refresh)
 
-        # The Data tab's "Raw data folder" and the CAT-NAP "Recordings folder" are
+        # The Data tab's recordings folder and the CAT-NAP tab's are
         # two views of one setting (Params.raw_data), and both panels write it
         # in _collect_params — so whichever saves last silently wins. Mirror
         # them instead. Without this, setting the folder on Data and pressing
@@ -748,8 +754,12 @@ class MainWindow(QMainWindow):
         missing = []
         # Only step 1 reads the raw recordings; later steps work from the spike
         # files, so a resumed run doesn't need the raw data mounted at all.
+        # Named as the Data tab names it in this mode — see DataPanel.set_mode.
         if not params.raw_data and params.start_analysis_step == 1:
-            missing.append("Raw data folder (needed for step 1 — spike detection)")
+            missing.append(
+                f"{CATNAP_DATA_LABEL} (needed to find the suite2p recordings)"
+                if self._mode == "catnap" else
+                f"{RAW_DATA_LABEL} (needed for step 1 — spike detection)")
         if not params.output_data_folder:
             missing.append("Output data folder")
         if not params.spreadsheet_file_name:

--- a/src/meanap/gui/panels/connectivity.py
+++ b/src/meanap/gui/panels/connectivity.py
@@ -16,28 +16,16 @@ class ConnectivityPanel(QWidget):
         layout.setContentsMargins(12, 12, 12, 12)
 
         # ── STTC / lag ────────────────────────────────────────────────────────
+        # Just the lags. Truncation was folded away here too, but it says how
+        # much of each recording to read — a fact about the input, not about
+        # the STTC — so it sits with the input folder on the Data tab.
         sttc_box = QGroupBox("Spike time tiling coefficient (STTC)")
         form = QFormLayout(sttc_box)
 
         self.lag_vals = QLineEdit("10, 15, 25")
         self.lag_vals.setPlaceholderText("Comma-separated lag values in ms")
 
-        self.trunc_rec = QCheckBox()
-        self.trunc_length = QDoubleSpinBox()
-        self.trunc_length.setRange(1, 100000)
-        self.trunc_length.setDecimals(0)
-        self.trunc_length.setSuffix(" s")
-        self.trunc_length.setValue(120)
-
         form.addRow("Lag values (ms)", self.lag_vals)
-
-        # Truncating is something a particular experiment needs, not something
-        # a run is configured with; the lags are the setting people come here
-        # to change.
-        self.sttc_advanced = AdvancedSection()
-        self.sttc_advanced.form().addRow("Truncate recording", self.trunc_rec)
-        self.sttc_advanced.form().addRow("Truncation length", self.trunc_length)
-        form.addRow(self.sttc_advanced)
 
         # ── Adjacency matrix ──────────────────────────────────────────────────
         adj_box = QGroupBox("Adjacency matrix")
@@ -91,8 +79,6 @@ class ConnectivityPanel(QWidget):
 
     def load(self, params: Params) -> None:
         self.lag_vals.setText(", ".join(str(v) for v in params.func_con_lag_val))
-        self.trunc_rec.setChecked(params.trunc_rec)
-        self.trunc_length.setValue(params.trunc_length)
         if params.adj_m_type == "binary":
             self.binary_btn.setChecked(True)
         else:
@@ -105,8 +91,6 @@ class ConnectivityPanel(QWidget):
     def save(self, params: Params) -> None:
         raw = self.lag_vals.text().strip()
         params.func_con_lag_val = [int(x) for x in raw.split(",") if x.strip()]
-        params.trunc_rec = self.trunc_rec.isChecked()
-        params.trunc_length = self.trunc_length.value()
         params.adj_m_type = "binary" if self.binary_btn.isChecked() else "weighted"
         params.prob_thresh_rep_num = self.prob_thresh_rep_num.value()
         params.prob_thresh_tail = self.prob_thresh_tail.value()

--- a/src/meanap/gui/panels/data.py
+++ b/src/meanap/gui/panels/data.py
@@ -15,7 +15,10 @@ nothing to do with, and its on/off switch was on another tab. It has moved to si
 with that switch — see :mod:`meanap.gui.panels.prior`.
 
 The Recording group is hidden in CAT-NAP mode, where none of it applies: suite2p
-recordings carry their own frame rate and have no electrodes.
+recordings carry their own frame rate and have no electrodes. So is the
+spike-data folder, which names spikes detected outside the pipeline for a step
+CAT-NAP does not have — and the input folder is renamed there, since "raw data"
+describes nothing a suite2p run reads. See :meth:`DataPanel.set_mode`.
 """
 
 from __future__ import annotations
@@ -23,18 +26,39 @@ from __future__ import annotations
 from pathlib import Path
 
 from PyQt6.QtWidgets import (
-    QComboBox, QDoubleSpinBox, QFormLayout, QGroupBox, QHBoxLayout, QLineEdit,
-    QPushButton, QVBoxLayout, QWidget,
+    QCheckBox, QComboBox, QDoubleSpinBox, QFormLayout, QGroupBox, QHBoxLayout,
+    QLineEdit, QPushButton, QVBoxLayout, QWidget,
 )
 
 from meanap.gui.advanced import AdvancedSection
 from meanap.gui.panels.paths import PathRow
 from meanap.params import Params, is_remote_url
 
-__all__ = ["DataPanel", "CHANNEL_LAYOUTS", "POTENTIAL_UNITS"]
+__all__ = ["DataPanel", "CHANNEL_LAYOUTS", "POTENTIAL_UNITS",
+           "RAW_DATA_LABEL", "CATNAP_DATA_LABEL"]
 
 CHANNEL_LAYOUTS = ["MCS60", "Axion64", "Mea256", "Custom"]
 POTENTIAL_UNITS = ["uV", "mV", "V"]
+
+#: What the input folder is called, per pipeline. The ephys modes read raw
+#: traces off the recorder; CAT-NAP reads suite2p output, where "raw data" names
+#: nothing the user has. See :meth:`DataPanel.set_mode`.
+RAW_DATA_LABEL = "Raw data folder"
+CATNAP_DATA_LABEL = "Recordings folder (suite2p)"
+
+RAW_DATA_TOOLTIP = (
+    "Folder holding your recordings — or paste a Dropbox folder share link to "
+    "analyse them without downloading the whole dataset. Recordings are then "
+    "fetched one at a time and discarded once analysed; the cache and denoising "
+    "outputs go under the output folder."
+)
+CATNAP_DATA_TOOLTIP = (
+    "The folder holding every recording — not one recording's folder. Each "
+    "sub-folder's name becomes that recording's name, and each holds a "
+    "suite2p/plane0 directory. A Dropbox folder share link works here too: it "
+    "is scanned without downloading anything and the run fetches one recording "
+    "at a time. This is the same setting as the CAT-NAP tab's folder box."
+)
 
 
 class DataPanel(QWidget):
@@ -54,16 +78,11 @@ class DataPanel(QWidget):
 
     def _build_input(self) -> QWidget:
         box = QGroupBox("Input")
-        form = QFormLayout(box)
+        form = self._input_form = QFormLayout(box)
         form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
 
         self.raw_data = PathRow(self)
-        self.raw_data.setToolTip(
-            "Folder holding your recordings — or paste a Dropbox folder share "
-            "link to analyse them without downloading the whole dataset. "
-            "Recordings are then fetched one at a time and discarded once "
-            "analysed; the cache and denoising outputs go under the output "
-            "folder.")
+        self.raw_data.setToolTip(RAW_DATA_TOOLTIP)
 
         self.spreadsheet = PathRow(
             self, is_file=True, file_filter="Spreadsheets (*.csv *.xlsx *.xls)")
@@ -82,7 +101,7 @@ class DataPanel(QWidget):
         sheet_row.addWidget(self.spreadsheet)
         sheet_row.addWidget(self.edit_spreadsheet_btn)
 
-        form.addRow("Raw data folder", self.raw_data)
+        form.addRow(RAW_DATA_LABEL, self.raw_data)
         form.addRow("Spreadsheet file", sheet_row)
 
         self.spreadsheet_range = QLineEdit("A2:A100000")
@@ -95,14 +114,31 @@ class DataPanel(QWidget):
             "step 1. Leave empty unless you have them."
         )
 
+        # Truncation is a property of the input — "analyse only the first N
+        # seconds of each recording" — so it sits with the data it applies to.
+        # It used to live under the STTC settings on the Connectivity tab,
+        # which is where it is *used* rather than what it is about, and that
+        # tab is not shown at all until connectivity is the thing being set up.
+        self.trunc_rec = QCheckBox()
+        self.trunc_rec.setToolTip(
+            "Analyse only the first part of every recording, so recordings of "
+            "different lengths are compared over the same window.")
+        self.trunc_length = QDoubleSpinBox()
+        self.trunc_length.setRange(1, 100000)
+        self.trunc_length.setDecimals(0)
+        self.trunc_length.setSuffix(" s")
+        self.trunc_length.setValue(120)
+
         # The default range covers any spreadsheet anyone will write, the group
-        # order only changes how figures are ordered, and most people have no
-        # externally-detected spikes — none of the three is part of setting a
-        # run up.
-        advanced = AdvancedSection()
+        # order only changes how figures are ordered, most people have no
+        # externally-detected spikes, and most recordings are analysed whole —
+        # none of these is part of setting a run up.
+        advanced = self._input_advanced = AdvancedSection()
         advanced.form().addRow("Spreadsheet range", self.spreadsheet_range)
         advanced.form().addRow("Custom group order", self.custom_grp_order)
         advanced.form().addRow("Spike data folder", self.spike_detected_data)
+        advanced.form().addRow("Truncate recording", self.trunc_rec)
+        advanced.form().addRow("Truncation length", self.trunc_length)
         form.addRow(advanced)
         return box
 
@@ -196,14 +232,32 @@ class DataPanel(QWidget):
     # ── Modes ─────────────────────────────────────────────────────────────────
 
     def set_mode(self, mode_key: str) -> None:
-        """Hide what this pipeline has no use for.
+        """Hide — and rename — what this pipeline has no use for.
 
         CAT-NAP reads suite2p output, which carries its own frame rate and has
         no electrodes, so every setting in the Recording group is meaningless
-        there. Hidden rather than removed: the values stay in ``Params`` and
-        come back if the mode does.
+        there, as is a folder of spikes detected elsewhere: CAT-NAP has no
+        spike-detection step to skip. Hidden rather than removed: the values
+        stay in ``Params`` and come back if the mode does.
+
+        "Raw data" is an ephys word — there is no raw trace in a CAT-NAP run,
+        only suite2p output — so the folder is named for what it holds in each
+        mode, matching the CAT-NAP tab's own wording.
         """
-        self.recording_box.setVisible(mode_key != "catnap")
+        catnap = mode_key == "catnap"
+        self.recording_box.setVisible(not catnap)
+
+        label = self._input_form.labelForField(self.raw_data)
+        if label is not None:
+            label.setText(CATNAP_DATA_LABEL if catnap else RAW_DATA_LABEL)
+        self.raw_data.setToolTip(
+            CATNAP_DATA_TOOLTIP if catnap else RAW_DATA_TOOLTIP)
+
+        self._input_advanced.form().setRowVisible(
+            self.spike_detected_data, not catnap)
+        # The header's count is now one out; it only recomputes on show, and a
+        # mode can be switched while this tab is the one being looked at.
+        self._input_advanced.refresh_label()
 
     # ── The spreadsheet editor ────────────────────────────────────────────────
 
@@ -230,6 +284,8 @@ class DataPanel(QWidget):
         self.spreadsheet_range.setText(params.spreadsheet_range)
         self.custom_grp_order.setText(",".join(params.custom_grp_order))
         self.spike_detected_data.set_value(params.spike_detected_data)
+        self.trunc_rec.setChecked(params.trunc_rec)
+        self.trunc_length.setValue(params.trunc_length)
         self.output_data_folder.set_value(params.output_data_folder)
         self.output_data_folder_name.setText(params.output_data_folder_name)
         self.cache_dir.set_value(params.cache_dir)
@@ -257,6 +313,8 @@ class DataPanel(QWidget):
         params.custom_grp_order = [
             g.strip() for g in self.custom_grp_order.text().split(",") if g.strip()]
         params.spike_detected_data = self.spike_detected_data.value
+        params.trunc_rec = self.trunc_rec.isChecked()
+        params.trunc_length = self.trunc_length.value()
         params.output_data_folder = self.output_data_folder.value
         params.output_data_folder_name = self.output_data_folder_name.text()
         params.cache_dir = self.cache_dir.value

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -219,9 +219,16 @@ def run_pipeline(
             progress=reporter,
         )
         if params.express_mode:
+            # Claimed from what is on disk, not from the setting that asked for
+            # it: a recording can be skipped, or have nothing to draw, and a
+            # manifest promising figures the bundle does not carry is worse
+            # than one that says nothing (see bundle.RECONSTRUCTABLE_FAMILIES).
+            from meanap.pipeline.render import TRACE_DIR
+
+            drew_traces = any((output_root / TRACE_DIR).rglob("*.png"))
             bundle = _write_run_bundle(
                 params, recordings, output_root, log, mode="catnap",
-                embedded_figures=["2p_traces"] if params.num_2p_traces else [])
+                embedded_figures=["2p_traces"] if drew_traces else [])
             output_root = _discard_folder_for_bundle(output_root, bundle, log)
         _report_working_dirs(params, log)
         reporter.finish()

--- a/src/meanap/version.py
+++ b/src/meanap/version.py
@@ -108,7 +108,7 @@ def pipeline_version(mode: str) -> str:
 
 
 def pipeline_label(mode: str) -> str:
-    """``"CAT-NAP 1.0.0"`` — the form shown in the GUI and written into output."""
+    """``"CAT-NAP 1.0.1"`` — the form shown in the GUI and written into output."""
     name = PIPELINE_NAMES.get(mode, mode)
     return f"{name} {pipeline_version(mode)}"
 

--- a/src/meanap/viewer/page.py
+++ b/src/meanap/viewer/page.py
@@ -966,9 +966,13 @@ function markCurrent() {
 }
 
 function setMode(kind) {
+  // Every kind that shows one image in #single. "trace" belongs here: it is a
+  // stored PNG rather than a render, but it still goes in the same <figure>,
+  // and leaving it out hid the pane the image had just been loaded into — the
+  // button highlighted, the PNG arrived, and the reader saw nothing.
   const one = kind === "figure" || kind === "activity" || kind === "lagseries"
               || kind === "spikecheck" || kind === "edgecheck"
-              || kind === "subnetwork";
+              || kind === "subnetwork" || kind === "trace";
   // Hidden, not disabled: the styling controls describe spatial network plots.
   // A raster, a violin and a line plot read none of them, so offering the
   // knobs there would imply they do something.

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
   "_comment": "Per-subsystem versions. MEA-NAP's own version lives in version.txt, which MATLAB reads and the update check compares against GitHub; it is not duplicated here.",
-  "catnap": "1.0.0",
+  "catnap": "1.0.1",
   "meastim": "0.4.0"
 }


### PR DESCRIPTION
Two things, both about a CAT-NAP run saying what it actually did.

## The bug: peak-detection traces were invisible

Open an express CAT-NAP bundle in the viewer, click **Unit 1** under *Peak
detection traces*, and nothing appears.

The figures were never missing. The bundle carried them, the manifest listed
them, and `/api/trace` returned the PNG with a 200 — and then `setMode()` hid
the `<figure>` the image had just been loaded into, because its list of
one-image kinds named `figure`/`activity`/`lagseries`/`spikecheck`/`edgecheck`/
`subnetwork` but not `trace`. So `#single` got `hidden` on every click.

The giveaway sits three lines below, in code that hides the SVG and PDF buttons
for a trace "because it is a stored PNG" — which only makes sense if the PNG
button were showing, and it never was.

Verified against a real bundle in a browser, before and after:

| | before | after |
|---|---|---|
| `#single` hidden | `true` | `false` |
| image loaded | — | 840×660, visible |
| PNG download button | hidden | shown |
| status | stuck on "rendering…" | `unit_1_2ptraces` |

`test_viewer_server.py` already covered the server side thoroughly — manifest
listing, unit ordering (9 before 10), byte-for-byte serving, path-traversal
refusal — which is exactly why this survived: nothing checked that the page
would *display* what the server handed it. That check is now there.

### Two silences found while chasing it

**`plot_2p_traces` gave up without a word.** It returned `[]` whenever the
denoised traces or the peak frames were missing. The easiest way to hit that is
an activity type that does not denoise (`F` is not in `_NEEDS_DENOISING`), and
the run then completes cleanly, writes a bundle, and shows an empty section with
nothing anywhere to explain it — for the one figure family a bundle cannot
rebuild. The run now logs the reason per recording, and names the setting to
change:

```
[rec] no peak-detection trace figures: activity type 'F' does not denoise, and
these figures plot the denoised trace against the detected events — use 'peaks'
to get them
```

The other two branches — the suite2p folder could not be re-read, and
`iscell.npy` labels no ROIs as cells — get their own messages.

**The manifest overclaimed.** `embedded_figures: ["2p_traces"]` was written from
the setting that *asked* for the figures rather than from whether any were
written, so a bundle carrying none still advertised them. Now probed from disk.

**New:** `python/diagnose_bundle_traces.py` answers "why does this bundle show no
traces" from the bundle alone — no output folder, no raw data, no run log.

## The GUI: making the Data tab read as CAT-NAP's

- **CAT-NAP tab before Connectivity**, where Spike detection sits in the ephys
  modes: it is where the recordings are found and prepared, and Connectivity
  acts on what it produces.
- **"Raw data folder" is an ephys word.** A CAT-NAP run reads suite2p output and
  has no raw trace. The row is named per mode — "Recordings folder (suite2p)" —
  with a matching tooltip, and the missing-paths warning uses the same name
  instead of telling a 2P user about step 1 and spike detection.
- **"Spike data folder" hidden in CAT-NAP mode.** It names spikes detected
  outside the pipeline, to skip a step CAT-NAP does not have. Hidden, not
  dropped: the value still loads and saves and comes back with the mode.
  `AdvancedSection.count()` now skips hidden rows, so a header cannot promise a
  setting the section does not open onto.
- **Truncation moves to the Data tab.** It says how much of each recording to
  read — a fact about the input, not about the STTC — and the Connectivity tab
  is not where anyone goes to set up what they are analysing. The STTC group
  keeps just the lags; its advanced section held nothing else and is gone.

## Version

CAT-NAP `1.0.0` → `1.0.1`. A patch: everything here is a fix, nothing was added.

## Testing

Green: `test_gui_advanced`, `test_catnap_derived`, `test_catnap_resume`,
`test_bundle_render`, `test_gui_bundle_viewer`, `test_gui_toolbar`,
`test_gui_tooltips`, `test_gui_window_resize`.

`test_viewer_server` is 117/118. The one failure — "the tab strip drives all
three panes", which expects `data-tab="` three times and finds four — fails
identically on `main` and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLEnr5hkfXiggD8qjB1jxd
