### PR TITLE
stats: separate the size confound from the cohort controlling it selects

### DIFF
--- a/python/PIPELINE_PORT_STATUS.md
+++ b/python/PIPELINE_PORT_STATUS.md
@@ -340,7 +340,7 @@ about.
   induced subgraph of a common size *before* thresholding (that order matters —
   the reverse lands at an uncontrolled density), repeated over
   `sweep_subsamples` draws and averaged. Default `"auto"`, which takes the
-  `sweep_node_percentile` (10th) percentile of the run's own counts.
+  `sweep_node_percentile` (20th) percentile of the run's own counts.
 - **Subsampling trades the size confound for a SELECTION one, and the trade
   has to be watched.** Recordings with fewer nodes than the target are dropped,
   and smallness is not randomly distributed: on the Yin run a target of 80
@@ -432,10 +432,213 @@ the family-Shapley conclusion rather than contradicting it.
 **Measured runtimes** (378 recordings, 20 densities, 20 draws, 16 cores):
 N=50 took 25 min, N=22 over 278 recordings took 9 min. Subsampling multiplies
 the sweep by the draw count, so it is much more expensive than the unsubsampled
-sweep (~15 min) despite the smaller graphs.
+sweep (~15 min) despite the smaller graphs. Per-recording cost is close to
+*linear* in the target, not cubic as the betweenness term suggests — measured
+over a five-target ladder at 10 draws on 32 cores: N=20 129s, N=30 178s, N=40
+242s, N=60 351s, N=80 452s, 23 min for all five.
+
+### Selection and resolution, in code (2026-09-02)
+
+The A/B/C design above is no longer a manual recipe. The asymmetry that makes
+it cheap is that **C is free**: a recording's swept result depends only on its
+matrix, the target and the seed, never on which cohort it sits in, so C is a
+row subset of A rather than a second sweep. Only B needs one.
+
+- **The selection half runs automatically** whenever subsampling is on.
+  `density_sweep.selection_sensitivity` re-reads the sweep just computed over
+  only the recordings clearing a higher node count (`sweep_selection_percentile`,
+  p40 by default), recomputes every pairwise group gap, and writes
+  `density_sweep_selection_check.csv`. A gap is **flagged** when it moves by at
+  least 0.1 SD *and* either changes sign or moves by half its own size — both
+  conditions, since a large relative move on a gap of 0.02 is noise and a small
+  relative move on a gap of 1.0 is not worth a warning. Flagged gaps are logged
+  and land in the run summary under `density_sweep_selection`.
+- **The full decomposition is opt-in**: `--sweep-nodes 22,50` (or
+  `sweep_n_nodes_high`) sweeps at both targets and writes
+  `density_sweep_target_decomposition.csv` with `GapA`/`GapC`/`GapB` and the two
+  terms they split into, `Selection` (C − A) and `Resolution` (B − C), plus a
+  `Dominant` column naming the larger. This doubles the sweep's cost.
+- **Two figures cover the size half** (2026-09-02), which until then had none —
+  the density half had three while size, the larger confound here, was CSV-only.
+  `5E5_size_control` is the counterpart to `5E3`: node counts per recording
+  against the target they were reduced to, with everything below it marked as
+  dropped, and retention per group beside it, titled in the warning colour when
+  the spread exceeds the same 20 points the runner warns on. `5E6_selection_check`
+  draws the check above as one dumbbell per metric per group pair — open marker
+  over every swept recording, filled over the restricted cohort — with flagged
+  comparisons in the warning colour. Both are offered by the viewer and the HTML
+  report, and both redraw from the CSVs alone: `_load_sweep` recovers the target
+  from `NNodesUsed` and `_load_selection` rebuilds the check from its table.
+  The target decomposition is still CSV-only. `5E7`-`5E9` cover the effects
+  under control; see the section below.
+- **Every gap is standardised within its own condition**, which is what an
+  analysis restricted to that cohort would actually report. So a delta mixes a
+  change in group means with a change in spread — deliberately, because both are
+  things the restriction did to the number you would quote. It also means a
+  delta is never exactly zero even when the means are untouched.
+- `group_gaps` excludes `lccFraction`: comparing it between groups is a
+  statement about connectedness, not topology.
+
+**Result on the Yin timecourse (378 recordings, 10 draws, N = 20/30/40/60/80).**
+Holding the cohort fixed at N=80's 206 recordings, so only resolution varies,
+the WT−KO gap barely moves across a 4x range in target:
+
+| | N=20 | N=30 | N=40 | N=60 | N=80 |
+|---|---|---|---|---|---|
+| CC | 0.888 | 1.005 | 1.048 | 1.029 | 0.994 |
+| ElocMean | 1.016 | 1.138 | 1.144 | 1.110 | 1.073 |
+| nMod | −0.820 | −0.824 | −0.758 | −0.716 | −0.705 |
+| BCmean | 0.264 | 0.265 | 0.295 | 0.320 | 0.311 |
+| Q | 0.371 | 0.342 | 0.482 | 0.538 | 0.609 |
+| Eglob | 0.124 | 0.127 | 0.109 | 0.183 | 0.162 |
+| PL | 0.074 | 0.085 | 0.141 | 0.145 | 0.144 |
+
+Nothing flips sign and the headline metrics move 12–19%; **`Q` is the exception**,
+nearly doubling. (Standardised per condition against the cost-integrated
+feature's own spread, so these are on a different scale from the N=22/50 table
+above — compare within a table, not between.)
+
+The **selection** term is the larger one. Natural cohort minus fixed cohort at
+N=20: CC −0.115, ElocMean −0.171, nMod +0.194, BCmean −0.164, **Q −0.235** —
+for CC that exceeds the entire N=20→80 resolution term (0.106). Its *sign* also
+runs opposite to the earlier N=22/50 pair, so it depends on which recordings the
+cut removes and has to be measured per dataset rather than assumed. This is the
+case for running the check rather than picking a target and hoping.
+
+**Subsampling does remove the size dependence** it was built for. Residual
+Spearman against the original node count, fixed cohort, flat across N:
+
+| | CC | PL | ElocMean | BCmean | nMod | Eglob | Q |
+|---|---|---|---|---|---|---|---|
+| density only | +0.43 | +0.42 | +0.34 | −0.64 | +0.47 | −0.01 | −0.04 |
+| + subsampling | −0.05 | −0.03 | −0.10 | −0.09 | +0.12 | **−0.20** | **−0.22** |
+
+`BCmean` −0.64 → −0.05 is the striking one. But subsampling *introduces* a ~−0.2
+residual in `Eglob` and `Q`, the two that were already clean under density
+control alone — worth knowing before trusting `Q` under this control.
+
+### Effects before and after the controls (2026-09-02)
+
+The sweep figures answer "do the curves separate". The question a reader of the
+5A heatmaps actually asks is "does *this* effect survive the control", and
+`density_sweep.control_effects` answers it directly: the same statistic 5A
+reports, recomputed on the controlled features. Standardised betas from the
+mixed model and its "SD change across age range" for the pooled terms; Hedges'
+g from the per-age Welch tests for the per-age genotype contrasts, kept apart by
+a `Scope` column because the two are not on one scale and must never share a
+panel. `control_values` reports the metrics themselves — mean, SD, SEM, N,
+median per (control, metric, group, age) — because an effect size in units of
+each condition's own spread cannot say what either group measured.
+
+Three levels of control, written to `control_effects.csv` and
+`control_metric_values.csv`:
+
+| | what it is |
+|---|---|
+| `none` | step 4's own metrics, each network at its own density and size |
+| `density` | cost-integrated over the density grid, size left alone |
+| `density+size` | the same, on networks first cut to a common node count |
+
+`none`→`density` is the density control alone and `density`→`density+size` is
+**the node-subsampling effect alone**. The middle condition needs the sweep run
+twice, so it is opt-in: `--sweep-density-only` / `sweep_density_only`. Without
+it the outputs carry two conditions and cannot attribute a change to
+subsampling; the figure says so in its own caption rather than letting the
+reader assume otherwise.
+
+**Raw counterparts are the unnormalised ones.** `RAW_COUNTERPART` pairs `CC`
+with `CC_rawMean` and `PL` with `PL_raw`, *not* with the null-model-normalised
+`NetMet.CC`/`NetMet.PL` saved under the same short names — the sweep measures
+raw quantities on binary graphs, and pairing against the normalised ones would
+compare two different quantities. `BCmean` has no recording-level counterpart in
+step 4 at all and so appears only in the controlled conditions; 5E9 labels that
+panel rather than leaving it blank.
+
+**Every condition is put on one cohort** (`match_cohort`, on by default). A
+subsampled sweep drops every recording too small to reach the target while the
+raw metrics and an unsubsampled sweep keep all of them, so without this the step
+between two conditions mixes the control being applied with the cohort changing
+underneath it. This is not a hypothetical: on the Yin run the unmatched tables
+read CC's pooled age effect as `none` +1.09, `density` −0.53, `density+size`
+−1.06, which looks like subsampling doubling the effect. Matched on the 306
+recordings all three conditions have, it is +1.24, −1.13, −1.06 — **the density
+control does essentially all of the work and subsampling adds nothing**. The
+unmatched reading would have attributed to node subsampling something that was
+the retention cut. The cost is that the `none` column no longer matches the 5A
+tables, which is the honest trade: those answer "what does this run show", this
+one answers "what did the control do".
+
+**Result on the Yin timecourse** (pooled age effect, SD change across the age
+range, 306 recordings, matched cohort):
+
+| | none | density | density+size |
+|---|---|---|---|
+| CC | +1.24 | −1.13 | −1.06 |
+| ElocMean | +1.16 | −1.11 | −1.08 |
+| Eglob | +1.67 | −0.14 | +0.18 |
+| PL | −1.75 | −1.02 | −0.66 |
+| Q | −0.72 | −0.84 | −0.70 |
+| nMod | −0.93 | +0.56 | +0.98 |
+| BCmean | — | −0.54 | −0.51 |
+
+`CC`, `ElocMean` and `nMod` **change sign** under control: clustering and local
+efficiency rise steeply with age at each network's own density and *fall* once
+density is matched, which is the confound stated as plainly as it can be. Almost
+all of that is the density control; subsampling moves `nMod` (+0.56 → +0.98) and
+`PL` (−1.02 → −0.66) and little else. `Eglob`'s large raw age effect (+1.67)
+essentially vanishes.
+
+**Three figures.** `5E7_control_effects` is the pooled view, one dumbbell per
+metric per term with filled markers surviving FDR. `5E8_genotype_effect_by_age`
+is the per-age view — one panel per (metric, genotype pair), age on the x axis,
+a line per control — which is where a difference that only appears late, or only
+before the control, becomes visible as a shape. `5E9_metric_values_by_control`
+is the metrics themselves, mean ± SEM against age with one line per group,
+repeated per control; its controlled columns share a y axis so the subsampling
+step reads directly, while the uncontrolled column is scaled on its own because
+it is a different measurement (raw `nMod` is ~2 against ~10-35 controlled, and a
+shared axis flattens it to a line).
+
+### How small can the target be? Draw noise vs attenuation
+
+Two different costs, and only one of them is fixed by more draws. Measured on 30
+large Yin recordings, 20 independent subgraphs each at a fixed 20% density,
+variance split into draw noise and real between-recording signal:
+
+| N | CC signal SD | reliability, 1 draw | 10 draws | 20 draws |
+|---|---|---|---|---|
+| 20 | 0.047 | 0.29 | 0.80 | 0.89 |
+| 30 | 0.050 | 0.40 | 0.87 | 0.93 |
+| 40 | 0.058 | 0.61 | 0.94 | 0.97 |
+| 60 | 0.058 | 0.73 | 0.96 | 0.98 |
+| 80 | 0.059 | 0.86 | 0.98 | 0.99 |
+
+- **A single draw at a small target is worthless** — at N=20 the draw-to-draw SD
+  *exceeds* the between-recording SD (ratio 1.5 for CC, 1.6 for `ElocMean`). The
+  `sweep_subsamples=20` default is load-bearing, not polish.
+- **Averaging fixes noise but not attenuation.** Real signal SD still rises
+  0.047 → 0.059 from N=20 to N=80 *after* draw noise is removed: a 20-node
+  subgraph genuinely makes different networks look more alike. So effect sizes
+  shrink toward zero as the target falls — a null at a small target is weak
+  evidence, a positive one is conservative.
+- **For per-recording features, N≥40.** Rank agreement with the well-resolved
+  N=80 values: at N=20 it is CC 0.83, `ElocMean` 0.76, `Q` 0.75, `PL` 0.67; by
+  N=40 everything except `PL` is ≥0.90. Group means tolerate N=20; feeding
+  `*_costInt` into decoding or regression does not. This is why
+  `sweep_node_percentile` was **raised from p10 to p20 on 2026-09-02**: p10
+  landed at 23 nodes on this run, below that line, where p20 lands at 37. The
+  extra retention loss that costs falls unevenly, which is the trade being made:
+  measured over the 370 recordings that reach the sweep at all, wildtype goes
+  88% → 74% while KO only goes 95% → 93%, widening the between-group spread from
+  7 to 19 points. That sits just under the runner's own 20-point warning, so p20
+  does not trip it on this dataset — but it is close enough that a run with more
+  small wildtype recordings would, and the selection check now reports what the
+  tighter cohort does to every gap either way.
 
 **Verify:** `uv run python python/test_density_sweep.py [<extracted run folder>]`
-— 37 checks. Section A works on ring lattices and random graphs, where the
+— 68 checks, of which sections A8–A10 cover the gap tables, the selection check
+and the decomposition (including that `Selection + Resolution == Total`, and
+that C really is A read over B's recordings rather than a second measurement). Section A works on ring lattices and random graphs, where the
 answer is known by construction: the sweep must separate a lattice from a
 random graph *at the same density*, and must give identical results for two
 graphs that differ only in edge strength.

--- a/python/test_density_sweep.py
+++ b/python/test_density_sweep.py
@@ -41,9 +41,11 @@ sys.path.insert(0, str(REPO_ROOT / "src"))
 warnings.simplefilter("ignore")
 
 from meanap.stats.density_sweep import (  # noqa: E402
-    DEFAULT_DENSITIES, SWEEP_METRICS, _largest_component_fraction,
-    attach_labels, binarise_at_density, cost_integrate, lag_key_to_label,
-    retention, run_density_sweep, subsample_nodes, sweep_one_matrix,
+    CONTROL_LEVELS, DEFAULT_DENSITIES, RAW_COUNTERPART, SWEEP_METRICS,
+    _largest_component_fraction, attach_labels, binarise_at_density,
+    control_effects, control_values, cost_integrate, decompose_targets,
+    group_gaps, lag_key_to_label, retention, run_density_sweep,
+    selection_sensitivity, subsample_nodes, sweep_one_matrix,
 )
 
 Check = tuple[str, bool, str]
@@ -370,6 +372,364 @@ def _retention_checks() -> list[Check]:
     return checks
 
 
+def _frame(values_by_group: dict, metric: str = "CC") -> pd.DataFrame:
+    """A cost-integrated table: ``{group: [values]}`` laid out one row each."""
+    rows = []
+    for group, values in values_by_group.items():
+        for value in values:
+            rows.append({"FileName": f"r{len(rows)}", "Grp": group,
+                         f"{metric}_costInt": float(value)})
+    return pd.DataFrame(rows)
+
+
+def _gap_checks() -> list[Check]:
+    """Pairwise group gaps - the quantity both new analyses are differences of."""
+    checks: list[Check] = []
+
+    frame = _frame({"A": [1.0] * 4, "B": [0.0] * 4})
+    table = group_gaps(frame)
+    spread = float(np.std([1, 1, 1, 1, 0, 0, 0, 0], ddof=1))
+    row = table[table.Metric == "CC"].iloc[0]
+    checks.append((
+        "a gap is the difference in means over the pooled SD",
+        abs(row.Gap - 1.0 / spread) < 1e-12, f"{row.Gap:.6f} vs {1/spread:.6f}"))
+    checks.append((
+        "and the pair is ordered by the group labels, so signs are stable",
+        row.GroupA == "A" and row.GroupB == "B", f"{row.GroupA}/{row.GroupB}"))
+    checks.append((
+        "group sizes are carried alongside",
+        row.NA == 4 and row.NB == 4, f"{row.NA}/{row.NB}"))
+
+    three = group_gaps(_frame({"A": [1.0] * 3, "B": [0.0] * 3, "C": [2.0] * 3}))
+    checks.append((
+        "three groups give all three pairs",
+        len(three) == 3, str(len(three))))
+
+    # lccFraction is a fragmentation diagnostic; comparing it between groups is
+    # a statement about connectedness, not topology, so it is not a gap metric.
+    with_lcc = _frame({"A": [1.0] * 4, "B": [0.0] * 4})
+    with_lcc["lccFraction_costInt"] = 1.0
+    checks.append((
+        "lccFraction is excluded from gap tables",
+        "lccFraction" not in set(group_gaps(with_lcc).Metric), ""))
+
+    checks.append((
+        "a group too small to compare is skipped rather than guessed at",
+        group_gaps(_frame({"A": [1.0] * 2, "B": [0.0] * 4})).empty, ""))
+    checks.append((
+        "a metric with no spread is skipped rather than dividing by zero",
+        group_gaps(_frame({"A": [1.0] * 4, "B": [1.0] * 4})).empty, ""))
+    checks.append((
+        "an empty table gives an empty result",
+        group_gaps(pd.DataFrame()).empty, ""))
+    return checks
+
+
+def _selection_checks() -> list[Check]:
+    """The free half of A/B/C: re-reading one sweep over the larger networks."""
+    checks: list[Check] = []
+
+    # Built so the answer is known: over everything the two groups are
+    # identical, and over the large networks alone they are as far apart as the
+    # data allows. Any honest check must call that out.
+    integrated = pd.DataFrame({
+        "FileName": [f"r{i}" for i in range(40)],
+        "Grp": (["WT"] * 10 + ["KO"] * 10) * 2,
+        "CC_costInt": ([1.0] * 10 + [0.0] * 10) + ([0.0] * 10 + [1.0] * 10),
+    })
+    observed = pd.DataFrame({
+        "FileName": [f"r{i}" for i in range(40)],
+        "NNodes": [100] * 20 + [30] * 20,
+    })
+
+    check = selection_sensitivity(integrated, observed, threshold=100)
+    checks.append((
+        "the check runs and reports the cohort it restricted to",
+        check.ran and check.threshold == 100 and check.n_all == 40
+        and check.n_restricted == 20,
+        f"{check.n_restricted}/{check.n_all} at {check.threshold}"))
+    row = check.table[check.table.Metric == "CC"].iloc[0]
+    checks.append((
+        "a gap that is zero overall but real in the large networks is caught",
+        abs(row.GapAll) < 1e-12 and abs(row.GapRestricted) > 0.5,
+        f"{row.GapAll:.3f} -> {row.GapRestricted:.3f}"))
+    checks.append((
+        "Delta is exactly the movement between the two cohorts",
+        abs(row.Delta - (row.GapRestricted - row.GapAll)) < 1e-12, ""))
+    checks.append((
+        "and it is flagged, since that is selection rather than topology",
+        bool(row.Flagged) and ("CC", "KO", "WT") in check.flagged,
+        str(check.flagged)))
+
+    # The opposite case: restricting changes nothing, so nothing is flagged.
+    steady = pd.DataFrame({
+        "FileName": [f"r{i}" for i in range(40)],
+        "Grp": (["WT"] * 10 + ["KO"] * 10) * 2,
+        "CC_costInt": ([1.0] * 10 + [0.0] * 10) * 2,
+    })
+    quiet = selection_sensitivity(steady, observed, threshold=100)
+    checks.append((
+        "a gap with the same group means in both cohorts is not flagged",
+        quiet.ran and not quiet.flagged
+        # Not exactly zero: each gap is standardised within its own cohort, so
+        # the pooled SD moves with the sample even when the means do not.
+        and abs(quiet.table.iloc[0].Delta) < 0.05,
+        f"delta {quiet.table.iloc[0].Delta:.4f}, flagged {quiet.flagged}"))
+
+    thin = selection_sensitivity(integrated, observed, threshold=1000)
+    checks.append((
+        "a threshold nothing clears is refused, with a reason",
+        not thin.ran and "clear" in thin.note, thin.note))
+
+    same = selection_sensitivity(integrated, observed, threshold=1)
+    checks.append((
+        "a threshold that drops almost nothing is refused too",
+        not same.ran and "drops only" in same.note, same.note))
+
+    checks.append((
+        "a sweep with no node counts is refused rather than guessed at",
+        not selection_sensitivity(
+            integrated, observed.drop(columns=["NNodes"])).ran, ""))
+    checks.append((
+        "an unlabelled table is refused rather than compared with no groups",
+        not selection_sensitivity(
+            integrated.drop(columns=["Grp"]), observed).ran, ""))
+    return checks
+
+
+def _decomposition_checks() -> list[Check]:
+    """The full A/B/C design: selection and resolution split apart."""
+    checks: list[Check] = []
+    rng = np.random.default_rng(5)
+
+    names = [f"r{i}" for i in range(40)]
+    groups = ["WT"] * 20 + ["KO"] * 20
+    low = pd.DataFrame({
+        "FileName": names, "Grp": groups,
+        "CC_costInt": np.concatenate([rng.normal(0.3, 0.3, 20),
+                                      rng.normal(0.0, 0.3, 20)]),
+    })
+    # B keeps only the first half of each group, and resolves them far better -
+    # the separation has to grow against the within-group spread, since a
+    # standardised gap carries the separation in its denominator too.
+    keep = names[:10] + names[20:30]
+    high = pd.DataFrame({
+        "FileName": keep, "Grp": ["WT"] * 10 + ["KO"] * 10,
+        "CC_costInt": np.concatenate([rng.normal(1.5, 0.3, 10),
+                                      rng.normal(0.0, 0.3, 10)]),
+    })
+
+    table = decompose_targets(low, high)
+    row = table[table.Metric == "CC"].iloc[0]
+    checks.append((
+        "the decomposition reports all three conditions",
+        {"GapA", "GapC", "GapB"} <= set(table.columns), str(table.columns.tolist())))
+    checks.append((
+        "selection and resolution sum to the whole difference between targets",
+        abs((row.Selection + row.Resolution) - row.Total) < 1e-12,
+        f"{row.Selection:.4f}+{row.Resolution:.4f} vs {row.Total:.4f}"))
+    checks.append((
+        "C is A read over B's recordings, not a separate measurement",
+        abs(row.GapC - group_gaps(low[low.FileName.isin(keep)]).iloc[0].Gap) < 1e-12,
+        ""))
+    checks.append((
+        "the cohort sizes are those of the three conditions",
+        row.NA == 40 and row.NC == 20 and row.NB == 20,
+        f"{row.NA}/{row.NC}/{row.NB}"))
+    checks.append((
+        "the dominant term is named, and here it is resolution",
+        row.Dominant == "resolution"
+        and abs(row.Resolution) > abs(row.Selection),
+        f"{row.Dominant}: sel {row.Selection:.3f} res {row.Resolution:.3f}"))
+
+    # A high target whose cohort is a *biased* subset moves the gap without any
+    # change of target - that is the selection term, and it must show up as one.
+    biased_keep = names[:4] + names[20:]
+    biased = decompose_targets(
+        low, low[low.FileName.isin(biased_keep)].copy())
+    checks.append((
+        "with B measured identically to A, the whole difference is selection",
+        abs(biased.iloc[0].Resolution) < 1e-12
+        and biased.iloc[0].Dominant == "selection",
+        f"res {biased.iloc[0].Resolution:.4f}"))
+
+    checks.append((
+        "no shared recordings gives an empty result rather than an error",
+        decompose_targets(
+            low, high.assign(FileName=lambda d: d.FileName + "_x")).empty, ""))
+    checks.append((
+        "an empty target table gives an empty result",
+        decompose_targets(low, pd.DataFrame()).empty, ""))
+    return checks
+
+
+def _control_dataset():
+    """A small run: two genotypes, three ages, six cultures each."""
+    from meanap.stats.dataset import StatsDataset, metric_labels
+
+    rng = np.random.default_rng(3)
+    rows = []
+    for group, shift in (("WT", 0.0), ("KO", 1.0)):
+        for culture in range(6):
+            for age in (14.0, 21.0, 28.0):
+                name = f"{group}{culture}_DIV{int(age)}"
+                rows.append({
+                    "FileName": name, "Culture": f"{group}{culture}",
+                    "Grp": group, "DIV": age, "Lag": "25mslag",
+                    # Raw metrics carry a strong age effect on top of genotype.
+                    "CC_rawMean": 0.3 * shift + 0.05 * age + rng.normal(0, 0.1),
+                    "Eglob": 0.2 * shift + 0.04 * age + rng.normal(0, 0.1),
+                    "Q": 0.4 * shift + rng.normal(0, 0.1),
+                    # The null-model-normalised CC, which must NOT be used.
+                    "CC": 99.0 + rng.normal(0, 0.1),
+                })
+    table = pd.DataFrame(rows)
+    ds = StatsDataset(table=table, metrics=["CC_rawMean", "Eglob", "Q", "CC"],
+                      labels=metric_labels())
+    # Controlled features: genotype kept, the age effect removed.
+    integrated = pd.DataFrame({
+        "FileName": table["FileName"], "Lag": "adjM25mslag",
+        "CC_costInt": [0.3 * (g == "KO") + rng.normal(0, 0.1)
+                       for g in table["Grp"]],
+        "Eglob_costInt": [0.2 * (g == "KO") + rng.normal(0, 0.1)
+                          for g in table["Grp"]],
+        "Q_costInt": [0.4 * (g == "KO") + rng.normal(0, 0.1)
+                      for g in table["Grp"]],
+    })
+    return ds, integrated
+
+
+def _control_effect_checks() -> list[Check]:
+    """Effects recomputed under each level of control."""
+    checks: list[Check] = []
+    ds, integrated = _control_dataset()
+
+    checks.append((
+        "the raw counterpart of CC is the unnormalised one, not NetMet.CC",
+        RAW_COUNTERPART["CC"] == "CC_rawMean" and RAW_COUNTERPART["PL"] == "PL_raw",
+        str(RAW_COUNTERPART)))
+    checks.append((
+        "betweenness has no step-4 counterpart and is not invented one",
+        "BCmean" not in RAW_COUNTERPART, ""))
+
+    two = control_effects(ds, density_and_size=integrated)
+    checks.append((
+        "a single sweep gives the uncontrolled and the controlled condition",
+        set(two["Control"]) == {"none", "density+size"},
+        str(sorted(set(two["Control"])))))
+    checks.append((
+        "columns are named by the swept metric, not by the source column",
+        set(two["Metric"]) <= {"CC", "Eglob", "Q"}, str(sorted(set(two["Metric"])))))
+    checks.append((
+        "both an age term and a genotype contrast are reported",
+        "age" in set(two["Term"])
+        and any(" vs " in str(t) for t in two["Term"]), str(sorted(set(two["Term"])))))
+
+    # The fixture removes the age effect under control and keeps genotype, so
+    # the table must show exactly that - this is the figure's whole reading.
+    age = two[two["Term"] == "age"].set_index(["Metric", "Control"])["EffectSize"]
+    shrank = all(abs(age[(m, "density+size")]) < abs(age[(m, "none")])
+                 for m in ("CC", "Eglob") if (m, "none") in age.index)
+    checks.append((
+        "an age effect the control removes shows as a smaller effect size",
+        shrank, age.round(2).to_dict()))
+
+    three = control_effects(ds, density_only=integrated,
+                            density_and_size=integrated)
+    checks.append((
+        "with both sweeps present all three levels of control appear",
+        set(three["Control"]) == set(CONTROL_LEVELS),
+        str(sorted(set(three["Control"])))))
+
+    # NetMet.CC is a different quantity from what the sweep measures, so a run
+    # carrying only it must not silently pair the two.
+    without_raw = ds.table.drop(columns=["CC_rawMean"])
+    bare = control_effects(ds._with_table(without_raw),
+                           density_and_size=integrated)
+    uncontrolled = bare[bare["Control"] == "none"]
+    checks.append((
+        "with no raw counterpart, the normalised metric is not substituted",
+        "CC" not in set(uncontrolled["Metric"]),
+        str(sorted(set(uncontrolled["Metric"])))))
+
+    checks.append((
+        "no sweep at all gives only the uncontrolled condition",
+        set(control_effects(ds)["Control"]) == {"none"}, ""))
+    checks.append((
+        "a table that joins onto nothing gives an empty result",
+        control_effects(
+            ds._with_table(ds.table.drop(columns=["CC_rawMean", "Eglob", "Q"])),
+            density_and_size=integrated.assign(
+                FileName=lambda d: d.FileName + "_x")).empty, ""))
+    return checks
+
+
+def _per_age_checks() -> list[Check]:
+    """Genotype contrasts measured at each age, and the metrics themselves."""
+    checks: list[Check] = []
+    ds, integrated = _control_dataset()
+    effects = control_effects(ds, density_and_size=integrated)
+
+    per_age = effects[effects["Scope"] == "per-age"]
+    checks.append((
+        "the table separates pooled models from per-age contrasts",
+        set(effects["Scope"]) == {"pooled", "per-age"},
+        str(sorted(set(effects["Scope"])))))
+    checks.append((
+        "every age in the run gets its own contrast",
+        set(per_age["Age"].dropna()) == {14.0, 21.0, 28.0},
+        str(sorted(set(per_age["Age"].dropna())))))
+    checks.append((
+        "the age is stripped off the term, so a pair can be followed across ages",
+        all(" at DIV " not in str(c) for c in per_age["Contrast"]),
+        str(sorted(set(per_age["Contrast"])))))
+    checks.append((
+        "per-age contrasts are Hedges' g, never the model's beta",
+        set(per_age["EffectSizeName"]) == {"Hedges g"},
+        str(set(per_age["EffectSizeName"]))))
+    checks.append((
+        "and they are reported under each level of control",
+        set(per_age["Control"]) == {"none", "density+size"},
+        str(sorted(set(per_age["Control"])))))
+
+    values = control_values(ds, density_and_size=integrated)
+    checks.append((
+        "the value table carries a row per control, metric, group and age",
+        len(values) == len(set(map(tuple, values[
+            ["Control", "Metric", "Group", "Age"]].to_numpy()))),
+        f"{len(values)} rows"))
+    checks.append((
+        "with the summary statistics an effect size cannot give",
+        {"Mean", "SD", "SEM", "N", "Median"} <= set(values.columns),
+        str(values.columns.tolist())))
+
+    # The means must be the data's own, not something rescaled on the way.
+    raw = values[(values.Control == "none") & (values.Metric == "CC")
+                 & (values.Group == "WT") & (values.Age == 14.0)]
+    expected = ds.table[(ds.table.Grp == "WT") & (ds.table.DIV == 14.0)][
+        "CC_rawMean"].mean()
+    checks.append((
+        "a mean is the mean of the metric it names",
+        abs(float(raw["Mean"].iloc[0]) - float(expected)) < 1e-12,
+        f"{float(raw['Mean'].iloc[0]):.4f} vs {float(expected):.4f}"))
+    checks.append((
+        "the standard error is the SD over root n",
+        abs(float(raw["SEM"].iloc[0])
+            - float(raw["SD"].iloc[0]) / np.sqrt(float(raw["N"].iloc[0]))) < 1e-12,
+        ""))
+    checks.append((
+        "the uncontrolled column reads the raw metric, never the normalised one",
+        abs(float(raw["Mean"].iloc[0]) - 99.0) > 1.0,
+        f"{float(raw['Mean'].iloc[0]):.3f} (NetMet.CC was set to 99)"))
+    checks.append((
+        "no sweep gives values for the uncontrolled condition only",
+        set(control_values(ds)["Control"]) == {"none"}, ""))
+    checks.append((
+        "an empty dataset gives an empty table rather than an error",
+        control_values(ds._with_table(ds.table.iloc[0:0])).empty, ""))
+    return checks
+
+
 # ── Section B ────────────────────────────────────────────────────────────────
 
 def _folder_checks() -> list[Check]:
@@ -484,6 +844,11 @@ def main() -> int:
         ("Section A5 — joining labels:", _label_checks),
         ("Section A6 — node subsampling:", _subsample_checks),
         ("Section A7 — retention:", _retention_checks),
+        ("Section A8 — group gaps:", _gap_checks),
+        ("Section A9 — selection sensitivity:", _selection_checks),
+        ("Section A10 — selection vs resolution:", _decomposition_checks),
+        ("Section A11 — effects under control:", _control_effect_checks),
+        ("Section A12 — per-age contrasts and metric values:", _per_age_checks),
         ("Section B — a whole output folder:", _folder_checks),
     ]:
         p, n = _report(title, build())

--- a/src/meanap/stats/cli.py
+++ b/src/meanap/stats/cli.py
@@ -64,9 +64,20 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Common node count the density sweep subsamples "
                              "every network to, so size is controlled as well "
                              "as density. 'auto' picks a low percentile of the "
-                             "run's own counts; 0 leaves size uncontrolled.")
+                             "run's own counts; 0 leaves size uncontrolled. "
+                             "Give two counts ('22,50') to sweep at both and "
+                             "split the difference into a selection and a "
+                             "resolution term — that doubles the sweep's "
+                             "cost. The selection half alone is free and is "
+                             "always reported.")
     effort.add_argument("--sweep-subsamples", type=int, default=20,
                         help="Random node draws averaged per recording")
+    effort.add_argument("--sweep-density-only", action="store_true",
+                        help="Also sweep with subsampling off, so the density "
+                             "control and the size control can be told apart "
+                             "in control_effects.csv and on 5E7. Costs a "
+                             "second sweep; without it a change under control "
+                             "cannot be attributed to subsampling.")
     effort.add_argument("--shapley-features", type=int, default=15,
                         help="How many representative metrics the per-age "
                              "decoding attribution runs over")
@@ -82,15 +93,43 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _sweep_nodes(value):
-    """``--sweep-nodes`` as ``"auto"``, an int, or ``None`` for uncontrolled."""
+    """``--sweep-nodes`` as ``(target, second target or None)``.
+
+    The target is ``"auto"``, an int, or ``None`` for uncontrolled. A comma
+    gives a second, larger target, which turns the sweep into the three-
+    condition design that separates selection from resolution; the smaller of
+    the two is always the one the ordinary outputs are measured at.
+    """
     if value is None or str(value).lower() in ("auto", ""):
-        return "auto"
-    try:
-        count = int(value)
-    except (TypeError, ValueError):
-        raise SystemExit(
-            f"--sweep-nodes must be 'auto', 0, or a node count, not {value!r}") from None
-    return count if count > 0 else None
+        return "auto", None
+
+    parts = [p.strip() for p in str(value).split(",") if p.strip()]
+    if len(parts) > 2:
+        raise SystemExit("--sweep-nodes takes at most two node counts")
+
+    def one(text):
+        if text.lower() == "auto":
+            return "auto"
+        try:
+            count = int(text)
+        except (TypeError, ValueError):
+            raise SystemExit("--sweep-nodes must be 'auto', 0, or a node count, "
+                             f"not {text!r}") from None
+        return count if count > 0 else None
+
+    if len(parts) == 1:
+        return one(parts[0]), None
+
+    low, high = one(parts[0]), one(parts[1])
+    if not isinstance(high, int):
+        raise SystemExit("the second --sweep-nodes count must be a node count")
+    if isinstance(low, int) and low >= high:
+        # Order is the whole point: C is the low target read over the high
+        # target's cohort, so a reversed pair would decompose nothing.
+        low, high = high, low
+        if low == high:
+            raise SystemExit("--sweep-nodes needs two different node counts")
+    return low, high
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -104,8 +143,10 @@ def main(argv: list[str] | None = None) -> int:
         decoding="decoding" in enabled,
         regression="regression" in enabled,
         density_sweep=args.density_sweep,
-        sweep_n_nodes=_sweep_nodes(args.sweep_nodes),
+        sweep_n_nodes=_sweep_nodes(args.sweep_nodes)[0],
+        sweep_n_nodes_high=_sweep_nodes(args.sweep_nodes)[1],
         sweep_subsamples=args.sweep_subsamples,
+        sweep_density_only=args.sweep_density_only,
         metrics=tuple(args.metrics or ()),
         decoding_target=args.decoding_target,
         regression_target=args.regression_target,

--- a/src/meanap/stats/density_sweep.py
+++ b/src/meanap/stats/density_sweep.py
@@ -77,9 +77,17 @@ __all__ = [
     "SWEEP_METRICS",
     "COST_INT_SUFFIX",
     "DensitySweep",
+    "CONTROL_LEVELS",
+    "RAW_COUNTERPART",
+    "SelectionCheck",
     "binarise_at_density",
+    "control_effects",
+    "control_values",
     "cost_integrate",
+    "decompose_targets",
+    "group_gaps",
     "run_density_sweep",
+    "selection_sensitivity",
     "subsample_nodes",
     "sweep_one_matrix",
 ]
@@ -569,3 +577,561 @@ def attach_labels(frame: pd.DataFrame, ds) -> pd.DataFrame:
             if c in ds.table.columns]
     labels = ds.table[keys].drop_duplicates(subset=[ds.name_col])
     return out.merge(labels, on=ds.name_col, how="inner")
+
+
+# -- separating selection from resolution ------------------------------------
+#
+# Raising the subsample target does two things at once. Topology is measured on
+# bigger subgraphs, so real differences between recordings are less attenuated
+# (*resolution*); and a smaller, non-random set of recordings clears the cut, so
+# the comparison is over a different cohort (*selection*). Comparing one target
+# against another moves both, which is why a target cannot be chosen by trying
+# two and keeping whichever showed the larger effect.
+#
+# The three-condition design that separates them:
+#
+#     A   target N, every recording reaching N
+#     B   target M > N, every recording reaching M
+#     C   target N, but only B's recordings
+#
+# A vs C is then selection alone and C vs B resolution alone. The useful
+# asymmetry is that **C is free**: a recording's swept result depends only on
+# its matrix, the target and the seed, never on which cohort it sits in, so C is
+# a row subset of A rather than a second sweep. ``selection_sensitivity``
+# exploits that to report the selection term from the sweep already run;
+# ``decompose_targets`` completes the design once a second sweep supplies B.
+#
+# Every gap here is standardised by the spread of that metric *within its own
+# condition*, which is what an analysis restricted to that cohort would report.
+# So a delta between two conditions mixes a change in group means with a change
+# in spread - deliberately, because both are things the restriction really did
+# to the number you would quote.
+
+#: Dropped from gap tables: a fragmentation diagnostic for reading ``PL``
+#: against, not a topology measure anyone compares between groups.
+_NOT_A_GAP_METRIC = ("lccFraction",)
+
+
+def _gap_columns(frame: pd.DataFrame, metrics) -> list[str]:
+    """The ``<metric>_costInt`` columns present in *frame*, diagnostics excluded."""
+    return [f"{m}{COST_INT_SUFFIX}" for m in metrics
+            if m not in _NOT_A_GAP_METRIC
+            and f"{m}{COST_INT_SUFFIX}" in frame.columns]
+
+
+def _keyed(frame: pd.DataFrame) -> pd.Series:
+    """A per-recording key, including the lag when the table carries one."""
+    if "Lag" in frame.columns:
+        return frame["FileName"].astype(str) + " " + frame["Lag"].astype(str)
+    return frame["FileName"].astype(str)
+
+
+def group_gaps(
+    integrated: pd.DataFrame,
+    *,
+    group_col: str = "Grp",
+    metrics=SWEEP_METRICS,
+    min_per_group: int = 3,
+) -> pd.DataFrame:
+    """Standardised difference between every pair of groups, per metric.
+
+    One row per (metric, group pair): the difference in means divided by the
+    metric's SD across every recording in *integrated*. Pairs are ordered by
+    the group labels' sort order, so ``Gap`` keeps a stable sign between calls
+    and two conditions can be subtracted row for row.
+    """
+    from itertools import combinations
+
+    if integrated is None or integrated.empty or group_col not in integrated.columns:
+        return pd.DataFrame()
+
+    groups = sorted(g for g in integrated[group_col].dropna().unique())
+    rows = []
+    for col in _gap_columns(integrated, metrics):
+        spread = integrated[col].std()
+        if not np.isfinite(spread) or spread == 0:
+            continue
+        for a, b in combinations(groups, 2):
+            xa = integrated.loc[integrated[group_col] == a, col].dropna()
+            xb = integrated.loc[integrated[group_col] == b, col].dropna()
+            if len(xa) < min_per_group or len(xb) < min_per_group:
+                continue
+            rows.append({
+                "Metric": col[: -len(COST_INT_SUFFIX)],
+                "GroupA": a, "GroupB": b,
+                "NA": int(len(xa)), "NB": int(len(xb)),
+                "Gap": float((xa.mean() - xb.mean()) / spread),
+            })
+    return pd.DataFrame(rows)
+
+
+@dataclass
+class SelectionCheck:
+    """How much the group differences move when the cohort is restricted.
+
+    The free half of the three-condition design: no second sweep, just the
+    sweep already run read over a smaller cohort. A large ``Delta`` means the
+    reported effect is partly a statement about *which recordings were big
+    enough to keep*, not about topology.
+    """
+
+    #: One row per (metric, group pair): ``GapAll``, ``GapRestricted``,
+    #: ``Delta``, and whether the sign changed. Empty when the check could not
+    #: be run, with :attr:`note` saying why.
+    table: pd.DataFrame = field(default_factory=pd.DataFrame)
+    #: Node count the restricted cohort required, or ``None`` if not run.
+    threshold: int | None = None
+    n_all: int = 0
+    n_restricted: int = 0
+    #: ``(metric, group A, group B)`` for every gap that moved enough to be
+    #: worth reading as selection rather than topology.
+    flagged: list = field(default_factory=list)
+    note: str = ""
+
+    @property
+    def ran(self) -> bool:
+        return not self.table.empty
+
+
+def selection_sensitivity(
+    integrated: pd.DataFrame,
+    observed: pd.DataFrame,
+    *,
+    group_col: str = "Grp",
+    metrics=SWEEP_METRICS,
+    threshold: int | None = None,
+    percentile: float = 40.0,
+    min_restricted: int = 20,
+    min_dropped: float = 0.1,
+    min_delta: float = 0.1,
+    delta_ratio: float = 0.5,
+) -> SelectionCheck:
+    """Re-read one sweep over a higher-node-count cohort - the A vs C contrast.
+
+    *integrated* is a labelled cost-integrated table and *observed* supplies
+    ``NNodes``; both come from a finished :class:`DensitySweep`. Recordings
+    below *threshold* nodes are dropped and the group gaps recomputed. Nothing
+    is swept again - the same per-recording numbers are simply aggregated over
+    fewer recordings, which is exactly what raising the target would have done
+    to the cohort while leaving resolution alone.
+
+    *threshold* defaults to the *percentile* of the node counts actually swept.
+    A gap is flagged when it moves by at least *min_delta* **and** either
+    changes sign or moves by *delta_ratio* of its own size - the combination
+    matters, since a large relative move on a gap of 0.02 is noise and a small
+    relative move on a gap of 1.0 is not worth a warning.
+    """
+    if integrated is None or integrated.empty or observed is None or observed.empty:
+        return SelectionCheck(note="nothing to check")
+    if "NNodes" not in observed.columns:
+        return SelectionCheck(note="the sweep recorded no node counts")
+    if group_col not in integrated.columns:
+        return SelectionCheck(note=f"no {group_col} column to compare groups by")
+
+    join = ["FileName", "Lag"] if ("Lag" in integrated.columns
+                                   and "Lag" in observed.columns) else ["FileName"]
+    sizes = observed[join + ["NNodes"]].drop_duplicates(subset=join)
+    merged = integrated.merge(sizes, on=join, how="inner")
+    if merged.empty:
+        return SelectionCheck(note="node counts did not join onto the swept table")
+
+    counts = merged["NNodes"].to_numpy(dtype=float)
+    if threshold is None:
+        threshold = int(np.percentile(counts, percentile))
+    threshold = int(threshold)
+
+    restricted = merged[merged["NNodes"] >= threshold]
+    dropped = 1.0 - len(restricted) / len(merged)
+    if len(restricted) < min_restricted:
+        return SelectionCheck(
+            threshold=threshold, n_all=len(merged), n_restricted=len(restricted),
+            note=f"only {len(restricted)} recordings clear {threshold} nodes")
+    if dropped < min_dropped:
+        return SelectionCheck(
+            threshold=threshold, n_all=len(merged), n_restricted=len(restricted),
+            note=(f"{threshold} nodes drops only {dropped:.0%} of the swept "
+                  "recordings - too few to say anything about selection"))
+
+    all_gaps = group_gaps(merged, group_col=group_col, metrics=metrics)
+    restricted_gaps = group_gaps(restricted, group_col=group_col, metrics=metrics)
+    if all_gaps.empty or restricted_gaps.empty:
+        return SelectionCheck(
+            threshold=threshold, n_all=len(merged), n_restricted=len(restricted),
+            note="not enough recordings per group to form gaps")
+
+    keys = ["Metric", "GroupA", "GroupB"]
+    table = all_gaps.merge(restricted_gaps, on=keys, how="inner",
+                           suffixes=("All", "Restricted"))
+    if table.empty:
+        return SelectionCheck(
+            threshold=threshold, n_all=len(merged), n_restricted=len(restricted),
+            note="no metric could be compared across both cohorts")
+
+    table["Delta"] = table["GapRestricted"] - table["GapAll"]
+    table["SignFlip"] = np.sign(table["GapRestricted"]) != np.sign(table["GapAll"])
+    table["Flagged"] = (table["Delta"].abs() >= min_delta) & (
+        table["SignFlip"] | (table["Delta"].abs()
+                             >= delta_ratio * table["GapAll"].abs()))
+    table["NodeThreshold"] = threshold
+    table = table.sort_values("Delta", key=lambda s: s.abs(), ascending=False)
+
+    flagged = [(r.Metric, r.GroupA, r.GroupB)
+               for r in table.itertuples() if r.Flagged]
+    return SelectionCheck(
+        table=table.reset_index(drop=True), threshold=threshold,
+        n_all=len(merged), n_restricted=len(restricted), flagged=flagged)
+
+
+def decompose_targets(
+    low: pd.DataFrame,
+    high: pd.DataFrame,
+    *,
+    group_col: str = "Grp",
+    metrics=SWEEP_METRICS,
+    min_per_group: int = 3,
+) -> pd.DataFrame:
+    """The full A/B/C decomposition, given cost-integrated tables at two targets.
+
+    *low* is the sweep at the smaller target and *high* the sweep at the larger
+    one; both must already carry group labels. Condition C - the low target
+    over the high target's recordings - is derived from *low* by subsetting, so
+    the only cost beyond the ordinary sweep is having run *high* at all.
+
+    Returns one row per (metric, group pair) with ``GapA``/``GapC``/``GapB``
+    and the two terms they decompose into: ``Selection`` (C - A, the cohort
+    changing) and ``Resolution`` (B - C, the target changing). ``Total`` is
+    their sum, and is what comparing the two targets naively would have shown.
+    """
+    if low is None or low.empty or high is None or high.empty:
+        return pd.DataFrame()
+
+    cohort = set(_keyed(high))
+    middle = low[_keyed(low).isin(cohort)]
+    if middle.empty:
+        return pd.DataFrame()
+
+    keys = ["Metric", "GroupA", "GroupB"]
+    a = group_gaps(low, group_col=group_col, metrics=metrics,
+                   min_per_group=min_per_group)
+    c = group_gaps(middle, group_col=group_col, metrics=metrics,
+                   min_per_group=min_per_group)
+    b = group_gaps(high, group_col=group_col, metrics=metrics,
+                   min_per_group=min_per_group)
+    if a.empty or c.empty or b.empty:
+        return pd.DataFrame()
+
+    out = (a[keys + ["Gap"]].rename(columns={"Gap": "GapA"})
+           .merge(c[keys + ["Gap"]].rename(columns={"Gap": "GapC"}), on=keys)
+           .merge(b[keys + ["Gap"]].rename(columns={"Gap": "GapB"}), on=keys))
+    if out.empty:
+        return out
+
+    out["Selection"] = out["GapC"] - out["GapA"]
+    out["Resolution"] = out["GapB"] - out["GapC"]
+    out["Total"] = out["GapB"] - out["GapA"]
+    # Which term dominates is the reading: "selection" means the apparent
+    # effect of raising the target was mostly the cohort changing under it.
+    out["Dominant"] = np.where(out["Selection"].abs() >= out["Resolution"].abs(),
+                               "selection", "resolution")
+    out["NA"] = len(low)
+    out["NC"] = len(middle)
+    out["NB"] = len(high)
+    return out.sort_values("Total", key=lambda s: s.abs(), ascending=False
+                           ).reset_index(drop=True)
+
+
+# -- effects under each level of control --------------------------------------
+#
+# "Does this genotype difference survive the control?" is a different question
+# from "do the curves separate", and it is the one a reader of the 5A heatmaps
+# will ask. The answer is the same effect statistic the heatmaps use, recomputed
+# on the controlled features: standardised betas from the mixed model for
+# genotype, and its "SD change across age range" for age, both FDR-corrected.
+#
+# Three levels of control, because the sweep moves two things at once:
+#
+#     none          step 4's own metrics, at each network's own density and size
+#     density       cost-integrated over the density grid, size left alone
+#     density+size  the same, on networks first cut to a common node count
+#
+# The step from "density" to "density+size" is the subsampling effect on its
+# own. It needs the sweep run twice, which is why the middle condition is
+# optional; with only one sweep the table simply carries the two conditions it
+# has, and the figure draws whatever is there.
+
+#: Levels of control, weakest first. Also the plotting order.
+CONTROL_LEVELS: tuple[str, ...] = ("none", "density", "density+size")
+
+#: The step-4 column each swept metric is compared against. The sweep measures
+#: the *raw* quantities on binary graphs, so ``CC`` and ``PL`` pair with
+#: ``CC_rawMean`` and ``PL_raw`` — **not** with the null-model-normalised
+#: ``CC``/``PL`` the pipeline saves under those same short names, which are a
+#: different quantity and would make the comparison meaningless. ``BCmean`` has
+#: no recording-level counterpart in step 4 at all, so it appears only in the
+#: controlled conditions.
+RAW_COUNTERPART: dict[str, str] = {
+    "CC": "CC_rawMean",
+    "PL": "PL_raw",
+    "Eglob": "Eglob",
+    "ElocMean": "ElocMean",
+    "Q": "Q",
+    "nMod": "nMod",
+}
+
+#: Effect sizes the pooled comparison keeps: the two the mixed model reports,
+#: over the whole timecourse at once.
+_POOLED_EFFECTS = ("standardised beta", "SD change across age range")
+
+#: The per-age genotype contrasts are Hedges' g from a Welch t-test at each age.
+#: A different statistic on a different subset from the pooled ones, which is
+#: why the table carries a ``Scope`` column rather than stacking them on one
+#: axis: the two are not comparable and must not share a panel.
+_PER_AGE_EFFECT = "Hedges g"
+
+
+def _swept_name(column: str, metrics) -> str:
+    """The swept metric a raw or cost-integrated column belongs to."""
+    if column.endswith(COST_INT_SUFFIX):
+        return column[: -len(COST_INT_SUFFIX)]
+    for swept in metrics:
+        if RAW_COUNTERPART.get(swept) == column:
+            return swept
+    return column
+
+
+def _model_rows(table: pd.DataFrame, control: str, metrics) -> pd.DataFrame:
+    """The comparison rows worth carrying, tagged with *control*.
+
+    Two scopes, kept apart by a ``Scope`` column: ``"pooled"`` is the mixed
+    model over the whole timecourse, ``"per-age"`` is the genotype contrast
+    measured separately at each age. ``Contrast`` strips the age off the term,
+    so the same genotype pair can be followed across ages and across controls.
+    """
+    if table is None or table.empty:
+        return pd.DataFrame()
+    keep = table[table["EffectSize"].notna()].copy()
+    if keep.empty:
+        return pd.DataFrame()
+    at_age = keep["Term"].astype(str).str.contains(" at DIV ")
+
+    pooled = keep[keep["EffectSizeName"].isin(_POOLED_EFFECTS) & ~at_age].copy()
+    pooled["Scope"] = "pooled"
+    pooled["Age"] = np.nan
+    pooled["Contrast"] = pooled["Term"].astype(str)
+
+    per_age = keep[(keep["EffectSizeName"] == _PER_AGE_EFFECT) & at_age].copy()
+    per_age["Scope"] = "per-age"
+    per_age["Age"] = (per_age["Term"].astype(str)
+                      .str.extract(r" at DIV ([-\d.]+)$")[0].astype(float))
+    per_age["Contrast"] = (per_age["Term"].astype(str)
+                           .str.replace(r" at DIV [-\d.]+$", "", regex=True))
+
+    out = pd.concat([pooled, per_age], ignore_index=True)
+    if out.empty:
+        return pd.DataFrame()
+    out["Control"] = control
+    out["Metric"] = [_swept_name(m, metrics) for m in out["Metric"]]
+    columns = [c for c in ("Lag", "Control", "Scope", "Metric", "Term",
+                           "Contrast", "Age", "EffectSize", "EffectSizeName",
+                           "PValue", "PValueFDR", "N")
+               if c in out.columns]
+    return out[columns]
+
+
+def _dataset_with_integrated(ds, integrated: pd.DataFrame, metrics):
+    """*ds* with the cost-integrated features joined on, as its only metrics."""
+    cols = _gap_columns(integrated, metrics)
+    if not cols:
+        return None
+    table = integrated.copy()
+    if "Lag" in table.columns:
+        table["Lag"] = table["Lag"].map(lag_key_to_label)
+    join = ["FileName", "Lag"] if ("Lag" in ds.table.columns
+                                   and "Lag" in table.columns) else ["FileName"]
+    # Only the join keys and the features: an integrated table that has already
+    # had labels attached would otherwise duplicate ``Grp``/``DIV`` on merge.
+    slim = table[join + cols].drop_duplicates(subset=join)
+    merged = ds.table.merge(slim, on=join, how="inner")
+    if merged.empty:
+        return None
+    return ds._with_table(merged).with_metrics(cols)
+
+
+def _common_cohort(ds, tables, *, match: bool):
+    """Restrict *ds* and *tables* to the recordings every condition has.
+
+    Without this the comparison is not like-for-like. A sweep with subsampling
+    on drops every recording too small to reach the target, while the
+    uncontrolled metrics and an unsubsampled sweep keep all of them — so the
+    step between two conditions would mix the control being applied with the
+    cohort changing underneath it, which is precisely the confound the
+    selection check exists to expose. Matching costs recordings and makes the
+    uncontrolled column differ from the 5A tables, which is the honest trade:
+    those tables answer "what does this run show", this one answers "what did
+    the control do".
+    """
+    live = [t for t in tables if t is not None and not t.empty]
+    if not match or not live:
+        return ds, tables
+
+    # Key on (name, lag) as a tuple rather than a joined string: recording
+    # names come from filenames and may contain anything, spaces included.
+    use_lag = ("Lag" in ds.table.columns
+               and all("Lag" in t.columns for t in live))
+
+    def keys(frame):
+        names = frame["FileName"].astype(str)
+        if not use_lag:
+            return list(zip(names, [""] * len(frame)))
+        return list(zip(names, frame["Lag"].map(lag_key_to_label).astype(str)))
+
+    shared = None
+    for table in live:
+        found = set(keys(table))
+        shared = found if shared is None else (shared & found)
+    if not shared:
+        return ds, tables
+
+    trimmed = [None if (t is None or t.empty)
+               else t[[k in shared for k in keys(t)]] for t in tables]
+    kept = ds.table[[k in shared for k in keys(ds.table)]]
+    return (ds._with_table(kept) if not kept.empty else ds), trimmed
+
+
+def control_effects(
+    ds,
+    *,
+    density_only: pd.DataFrame | None = None,
+    density_and_size: pd.DataFrame | None = None,
+    metrics=SWEEP_METRICS,
+    match_cohort: bool = True,
+) -> pd.DataFrame:
+    """Age and genotype effects for each metric, under each level of control.
+
+    *ds* is the run's own metric table; *density_only* and *density_and_size*
+    are cost-integrated tables from a sweep run without and with node
+    subsampling. Either may be ``None``, and the result then simply carries the
+    conditions that exist.
+
+    Returns one row per (lag, control, metric, term): the same effect size and
+    FDR-corrected p-value the 5A comparisons report, so a metric's genotype
+    effect before and after the control are directly comparable. The step from
+    ``"density"`` to ``"density+size"`` is the subsampling effect isolated;
+    ``"none"`` to ``"density"`` is the density control on its own.
+
+    With *match_cohort* every condition is restricted to the recordings all of
+    them have, so a step between two conditions is the control changing and not
+    the cohort. Leave it on unless you want each condition on all the data it
+    could use, in which case the steps stop being attributable.
+    """
+    from meanap.stats.comparisons import compare_metrics
+
+    ds, (density_only, density_and_size) = _common_cohort(
+        ds, [density_only, density_and_size], match=match_cohort)
+
+    frames = []
+
+    raw_cols = [RAW_COUNTERPART[m] for m in metrics
+                if m in RAW_COUNTERPART and RAW_COUNTERPART[m] in ds.table.columns]
+    if raw_cols:
+        frames.append(_model_rows(
+            compare_metrics(ds.with_metrics(raw_cols)).table, "none", metrics))
+
+    for label, integrated in (("density", density_only),
+                              ("density+size", density_and_size)):
+        if integrated is None or integrated.empty:
+            continue
+        subset = _dataset_with_integrated(ds, integrated, metrics)
+        if subset is None:
+            continue
+        frames.append(_model_rows(
+            compare_metrics(subset).table, label, metrics))
+
+    frames = [f for f in frames if f is not None and not f.empty]
+    if not frames:
+        return pd.DataFrame()
+    out = pd.concat(frames, ignore_index=True)
+    order = {level: i for i, level in enumerate(CONTROL_LEVELS)}
+    out["_order"] = out["Control"].map(order).fillna(len(order))
+    return (out.sort_values(["Scope", "Contrast", "Metric", "Age", "_order"])
+            .drop(columns="_order").reset_index(drop=True))
+
+
+def _values_for(table: pd.DataFrame, columns: dict, ds, control: str) -> pd.DataFrame:
+    """Group-by-age summaries of *columns* (``swept name -> column``)."""
+    rows = []
+    for swept, column in columns.items():
+        if column not in table.columns:
+            continue
+        sub = table[[ds.group_col, ds.age_col, column]].dropna()
+        if sub.empty:
+            continue
+        stat = (sub.groupby([ds.group_col, ds.age_col])[column]
+                .agg(Mean="mean", SD="std", N="count", Median="median")
+                .reset_index())
+        stat["SEM"] = stat["SD"] / np.sqrt(stat["N"].clip(lower=1))
+        stat["Control"] = control
+        stat["Metric"] = swept
+        stat = stat.rename(columns={ds.group_col: "Group", ds.age_col: "Age"})
+        rows.append(stat)
+    if not rows:
+        return pd.DataFrame()
+    return pd.concat(rows, ignore_index=True)
+
+
+def control_values(
+    ds,
+    *,
+    density_only: pd.DataFrame | None = None,
+    density_and_size: pd.DataFrame | None = None,
+    metrics=SWEEP_METRICS,
+    match_cohort: bool = True,
+) -> pd.DataFrame:
+    """The metrics themselves, per group and age, under each level of control.
+
+    The companion to :func:`control_effects`: an effect size says how far apart
+    two groups are in units of their own spread, and says nothing about what
+    either group actually measured. This returns one row per (control, metric,
+    group, age) with ``Mean``, ``SD``, ``SEM``, ``N`` and ``Median``, so a
+    difference can be read in the metric's own units and a control that moves
+    every group together can be told from one that moves them apart.
+
+    Note the conditions are not the same measurement: ``"none"`` is step 4 on
+    each network at its own density and size, the others are cost-integrated
+    over the density grid. Both are on the metric's natural scale, but a shift
+    between conditions is a change of definition as well as of control.
+
+    *match_cohort* restricts every condition to the recordings all of them
+    have, for the same reason :func:`control_effects` does.
+    """
+    ds, (density_only, density_and_size) = _common_cohort(
+        ds, [density_only, density_and_size], match=match_cohort)
+
+    frames = []
+
+    raw = {m: RAW_COUNTERPART[m] for m in metrics
+           if m in RAW_COUNTERPART and RAW_COUNTERPART[m] in ds.table.columns}
+    if raw:
+        frames.append(_values_for(ds.table, raw, ds, "none"))
+
+    for label, integrated in (("density", density_only),
+                              ("density+size", density_and_size)):
+        if integrated is None or integrated.empty:
+            continue
+        subset = _dataset_with_integrated(ds, integrated, metrics)
+        if subset is None:
+            continue
+        columns = {c[: -len(COST_INT_SUFFIX)]: c
+                   for c in _gap_columns(subset.table, metrics)}
+        frames.append(_values_for(subset.table, columns, ds, label))
+
+    frames = [f for f in frames if f is not None and not f.empty]
+    if not frames:
+        return pd.DataFrame()
+    out = pd.concat(frames, ignore_index=True)
+    order = {level: i for i, level in enumerate(CONTROL_LEVELS)}
+    out["_order"] = out["Control"].map(order).fillna(len(order))
+    columns = ["Control", "Metric", "Group", "Age", "Mean", "SD", "SEM", "N",
+               "Median"]
+    return (out.sort_values(["_order", "Metric", "Group", "Age"])
+            .drop(columns="_order")[columns].reset_index(drop=True))

--- a/src/meanap/stats/figures.py
+++ b/src/meanap/stats/figures.py
@@ -92,6 +92,17 @@ class StatsResults:
     #: The family decomposition with topology measured under density and size
     #: control, for comparison against :attr:`families`.
     families_controlled: object = None
+    #: How far the group differences move when the sweep is re-read over only
+    #: the larger networks — the selection half of the A/B/C design, which
+    #: costs nothing beyond the sweep already run.
+    sweep_selection: object = None
+    #: The full A/B/C decomposition, when a second subsample target was run.
+    sweep_decomposition: object = None
+    #: Age and genotype effects per metric under each level of control — the
+    #: 5A statistic recomputed on the controlled features.
+    control_effects: object = None
+    #: The metrics themselves, per group and age, under each level of control.
+    control_values: object = None
     regression: RegressionResults | None = None
     #: How many metrics the trajectory figure draws. Carried on the results
     #: rather than passed to every call, because the figure catalogue has to
@@ -232,6 +243,56 @@ _PROSE: dict[str, tuple[str, str]] = {
         "answer — if controlling topology does not lift it off zero, topology "
         "is redundant with activity and coupling rather than mismeasured.",
     ),
+    "size_control": (
+        "Controlling for network size",
+        "How many connected nodes each recording had, against the common size "
+        "every network was reduced to, and what fraction of each group survived "
+        "that cut. Recordings below the line cannot be subsampled up and are "
+        "dropped, and smallness is not spread evenly across groups — "
+        "if the retention bars are uneven, the size confound has been traded "
+        "for a selection one rather than removed.",
+    ),
+    "selection_check": (
+        "Do the group differences survive a stricter size cut?",
+        "Each group difference measured over every swept recording (open "
+        "marker) and over only those clearing a higher node count (filled). "
+        "Nothing is re-swept between the two, so the movement is the cohort "
+        "changing rather than the measurement. A long line marks a difference "
+        "that is partly about which recordings were big enough to keep, and "
+        "should not be quoted from one subsample target alone.",
+    ),
+    "control_effects": (
+        "Age and genotype effects, before and after the controls",
+        "Every swept metric's age effect and genotype contrasts, measured as "
+        "step 4 measured them and again on the density- and size-controlled "
+        "features, joined by a line. An effect that collapses toward zero was "
+        "a statement about how dense or how large the networks were rather "
+        "than about their organisation; one that holds its position survived "
+        "the control. Filled markers survive FDR correction. Where a sweep "
+        "with subsampling switched off was also run, the step from matched "
+        "density to matched density and size is the node-subsampling effect "
+        "on its own.",
+    ),
+    "genotype_effect_by_age": (
+        "Genotype differences at each age, before and after the controls",
+        "The genotype contrasts again, but measured separately at each age "
+        "rather than pooled over the timecourse, so a difference that only "
+        "appears late — or one that only appears before the control — is "
+        "visible as a shape rather than as a single number. Hedges' g from a "
+        "Welch t-test at each age, with filled markers surviving FDR "
+        "correction; this is not the mixed model's standardised beta and the "
+        "two are never drawn on one axis.",
+    ),
+    "metric_values": (
+        "The metrics themselves, under each level of control",
+        "Mean and SEM of every swept metric against age, one line per group, "
+        "repeated for each level of control. An effect size says how far apart "
+        "two groups are in units of their own spread and nothing about what "
+        "either group measured; this says what they measured. The controlled "
+        "columns share a y axis so the subsampling step can be read directly, "
+        "while the uncontrolled column is a different measurement of the same "
+        "quantity and is scaled on its own.",
+    ),
     "sweep_context": (
         "Reading the density sweep",
         "The densities the recordings actually have, against the range the "
@@ -276,6 +337,11 @@ _FILENAMES: dict[str, str] = {
     "sweep_by_age": "5E2_density_sweep_by_age",
     "sweep_context": "5E3_density_sweep_context",
     "topology_controlled": "5E4_topology_controlled",
+    "size_control": "5E5_size_control",
+    "selection_check": "5E6_selection_check",
+    "control_effects": "5E7_control_effects",
+    "genotype_effect_by_age": "5E8_genotype_effect_by_age",
+    "metric_values": "5E9_metric_values_by_control",
 }
 
 #: Filename stems for the effect heatmaps: the pooled mixed model first, then
@@ -305,6 +371,11 @@ _GROUPS: dict[str, str] = {
     "sweep_by_age": "density",
     "sweep_context": "density",
     "topology_controlled": "density",
+    "size_control": "density",
+    "selection_check": "density",
+    "control_effects": "density",
+    "genotype_effect_by_age": "density",
+    "metric_values": "density",
 }
 
 _EFFECTS_POOLED = (
@@ -396,6 +467,20 @@ def stats_figures(results: StatsResults) -> list[StatsFigure]:
             out.append(_fixed("sweep_by_age"))
         if not sweep.observed.empty:
             out.append(_fixed("sweep_context"))
+            # Only when size was actually controlled: with no target there is
+            # no line to draw and nothing was dropped for being too small.
+            if sweep.n_nodes is not None:
+                out.append(_fixed("size_control"))
+    if getattr(results.sweep_selection, "ran", False):
+        out.append(_fixed("selection_check"))
+    effects = results.control_effects
+    if effects is not None and not effects.empty:
+        out.append(_fixed("control_effects"))
+        if "Scope" in effects.columns and (effects["Scope"] == "per-age").any():
+            out.append(_fixed("genotype_effect_by_age"))
+    measured = results.control_values
+    if measured is not None and not measured.empty:
+        out.append(_fixed("metric_values"))
     if (results.families is not None and results.families_controlled is not None
             and not results.families_controlled.table.empty):
         out.append(_fixed("topology_controlled"))
@@ -523,6 +608,20 @@ def draw_stats_figure(
     if key == "topology_controlled":
         return plots.plot_topology_controlled(
             results.families, results.families_controlled, out_path)
+    if key == "size_control":
+        sweep = results.sweep
+        return plots.plot_size_control(
+            sweep.observed, out_path, n_nodes=sweep.n_nodes,
+            group_col=sweep.group_col, age_col=sweep.age_col, scheme=scheme)
+    if key == "selection_check":
+        return plots.plot_selection_check(results.sweep_selection, out_path)
+    if key == "control_effects":
+        return plots.plot_control_effects(results.control_effects, out_path)
+    if key == "genotype_effect_by_age":
+        return plots.plot_genotype_effect_by_age(results.control_effects, out_path)
+    if key == "metric_values":
+        return plots.plot_metric_values(results.control_values, out_path,
+                                        scheme=scheme)
     if key in ("sweep_by_group", "sweep_by_age", "sweep_context"):
         sweep = results.sweep
         if key == "sweep_context":
@@ -595,7 +694,15 @@ def load_results(folder: Path | str, dataset: StatsDataset, *, lag=None,
     results.by_age = _read(folder, "decoding_by_age.csv")
     results.shapley = _load_shapley(folder)
     results.families = _load_families(folder)
+    # The controlled decomposition travels as its own CSV and 5E4 is drawn from
+    # the pair; without this the figure exists in a fresh run but vanishes as
+    # soon as the results are read back from a folder or a bundle.
+    results.families_controlled = _load_families(
+        folder, "feature_family_contributions_controlled.csv")
     results.sweep = _load_sweep(folder, dataset)
+    results.sweep_selection = _load_selection(folder)
+    results.control_effects = _read(folder, "control_effects.csv")
+    results.control_values = _read(folder, "control_metric_values.csv")
 
     reg_scores = _read(folder, "regression_scores.csv")
     if reg_scores is not None:
@@ -653,7 +760,34 @@ def _load_sweep(folder: Path, ds: StatsDataset):
     sweep.labelled = attach_labels(curves, ds)
     if observed is not None and ds.group_col not in observed.columns:
         sweep.observed = attach_labels(observed, ds)
+    # ``NNodesUsed`` is the target when subsampling and the recording's own
+    # count otherwise, so a single distinct value that differs from ``NNodes``
+    # recovers the target the run used.
+    if observed is not None and {"NNodesUsed", "NNodes"} <= set(observed.columns):
+        used = observed["NNodesUsed"].dropna()
+        if used.nunique() == 1 and (observed["NNodes"] != used.iloc[0]).any():
+            sweep.n_nodes = int(used.iloc[0])
     return sweep
+
+
+def _load_selection(folder: Path):
+    """Rebuild the selection check from its CSV.
+
+    The cohort sizes are not stored - they are a property of the run, not of
+    the comparison - so they come back as zero and the figure simply omits
+    them. The threshold and the flags, which are what the figure needs, are
+    columns.
+    """
+    from meanap.stats.density_sweep import SelectionCheck
+
+    table = _read(folder, "density_sweep_selection_check.csv")
+    if table is None or "GapAll" not in table.columns:
+        return None
+    threshold = (int(table["NodeThreshold"].iloc[0])
+                 if "NodeThreshold" in table.columns else None)
+    flagged = [(r.Metric, r.GroupA, r.GroupB)
+               for r in table.itertuples() if bool(getattr(r, "Flagged", False))]
+    return SelectionCheck(table=table, threshold=threshold, flagged=flagged)
 
 
 def _load_families(folder: Path, name: str = "feature_family_contributions.csv"):

--- a/src/meanap/stats/plots.py
+++ b/src/meanap/stats/plots.py
@@ -27,6 +27,7 @@ import pandas as pd
 
 from meanap.pipeline.figure_output import savefig
 from meanap.pipeline.palette import DEFAULT_SCHEME, GROUP_SCHEMES, ColorScheme
+from meanap.stats.density_sweep import CONTROL_LEVELS, SWEEP_METRICS
 
 __all__ = [
     "plot_confusion",
@@ -35,8 +36,13 @@ __all__ = [
     "plot_decoding_by_age",
     "plot_decoding_importance",
     "plot_decoding_scores",
+    "plot_control_effects",
     "plot_density_context",
+    "plot_genotype_effect_by_age",
+    "plot_metric_values",
     "plot_density_sweep",
+    "plot_selection_check",
+    "plot_size_control",
     "plot_effect_heatmap",
     "plot_family_alone_vs_unique",
     "plot_family_contributions",
@@ -1150,4 +1156,480 @@ def plot_topology_controlled(raw, controlled, out_path: Path) -> Path | None:
              "step 4 measured them. Activity and correlation strength are left "
              "uncontrolled in both — they are what topology is being tested "
              "against.", fontsize=7.5, color=MUTED)
+    return _save(fig, out_path)
+
+
+#: Marks a comparison the selection check flagged. One accent, used nowhere
+#: else, so a flagged row reads as a warning rather than as another category.
+FLAGGED = "#c1443c"
+
+
+def plot_size_control(
+    observed: pd.DataFrame, out_path: Path, *, n_nodes: int | None,
+    group_col: str, age_col: str, scheme: ColorScheme = DEFAULT_SCHEME,
+) -> Path | None:
+    """The size half of the confound: what was subsampled to, and what it cost.
+
+    The counterpart to :func:`plot_density_context`, which covers the density
+    half. Left: how many connected nodes every recording actually had, against
+    the common size they were all reduced to - the recordings below that line
+    are the ones the sweep had to drop, since a network cannot be subsampled up.
+    Right: what fraction of each group survived, which is the number to read
+    before believing anything the sweep says. Smallness is not randomly
+    distributed across groups, so an uneven bar chart means the size confound
+    was traded for a selection one rather than removed.
+
+    Returns ``None`` when size was not controlled, since then there is no target
+    to draw and no recording was dropped for being too small.
+    """
+    if observed is None or observed.empty or n_nodes is None:
+        return None
+    if "NNodes" not in observed.columns:
+        return None
+
+    fig, (ax_size, ax_keep) = plt.subplots(1, 2, figsize=(10.5, 4.0))
+    groups = (list(pd.unique(observed[group_col].dropna()))
+              if group_col in observed.columns else [])
+    colours = _group_colors([str(g) for g in groups], scheme)
+    has_age = age_col in observed.columns and observed[age_col].notna().any()
+    rng = np.random.default_rng(0)
+
+    # Left: node counts, on a log axis because they span an order of magnitude
+    # and the target would otherwise sit squashed against the bottom.
+    if has_age:
+        ages = sorted(pd.unique(observed[age_col].dropna()))
+        for offset, group in enumerate(groups):
+            sub = observed[observed[group_col] == group]
+            jitter = (offset - (len(groups) - 1) / 2) * 0.9
+            ax_size.scatter(sub[age_col] + jitter + rng.normal(0, 0.25, len(sub)),
+                            sub["NNodes"], s=16, alpha=0.55, linewidths=0,
+                            color=colours[str(group)], label=str(group))
+            stat = sub.groupby(age_col)["NNodes"].median()
+            ax_size.plot(stat.index + jitter, stat.values, color=colours[str(group)],
+                         linewidth=2, marker="o", markersize=5)
+        ax_size.set_xlabel(f"Age ({age_col})")
+        ax_size.set_xticks(ages)
+    else:
+        for offset, group in enumerate(groups):
+            sub = observed[observed[group_col] == group]
+            ax_size.scatter(np.full(len(sub), offset) + rng.normal(0, 0.08, len(sub)),
+                            sub["NNodes"], s=16, alpha=0.55, linewidths=0,
+                            color=colours[str(group)], label=str(group))
+        ax_size.set_xticks(range(len(groups)))
+        ax_size.set_xticklabels([str(g) for g in groups], fontsize=8)
+
+    ax_size.set_yscale("log")
+    ax_size.axhline(n_nodes, color=INK, linestyle="--", linewidth=1.2)
+    ax_size.axhspan(ax_size.get_ylim()[0], n_nodes, color=FLAGGED, alpha=0.10,
+                    linewidth=0)
+    ax_size.text(ax_size.get_xlim()[0], n_nodes, f" subsampled to {n_nodes}",
+                 va="bottom", ha="left", fontsize=8, color=INK)
+    ax_size.set_ylabel("Connected nodes per recording")
+    ax_size.set_title("Sizes the recordings actually have", fontsize=10)
+    if groups and has_age:
+        # Lower right is the emptiest corner here: it is inside the band of
+        # sizes too small to keep, where by definition few points sit.
+        ax_size.legend(frameon=False, fontsize=8.5, loc="lower right")
+    _bare(ax_size)
+
+    # Right: retention. Recomputed here rather than read, so the figure needs
+    # only the table it is already handed.
+    if groups:
+        kept = (observed.assign(_kept=observed["NNodes"] >= n_nodes)
+                .groupby(group_col)["_kept"].agg(["mean", "sum", "size"]))
+        kept = kept.reindex([g for g in groups if g in kept.index])
+        positions = np.arange(len(kept))
+        ax_keep.bar(positions, kept["mean"], width=0.62,
+                    color=[colours[str(g)] for g in kept.index])
+        for pos, (_, row) in zip(positions, kept.iterrows()):
+            ax_keep.text(pos, row["mean"] + 0.02,
+                         f"{row['mean']:.0%}\n{int(row['sum'])}/{int(row['size'])}",
+                         ha="center", va="bottom", fontsize=8, color=INK)
+        ax_keep.set_xticks(positions)
+        ax_keep.set_xticklabels([str(g) for g in kept.index], fontsize=8.5)
+        ax_keep.set_ylim(0, 1.18)
+        spread = float(kept["mean"].max() - kept["mean"].min())
+        # The same 20-point rule the runner warns on, drawn rather than logged.
+        if spread > 0.2:
+            ax_keep.set_title(
+                f"Kept per group - {spread:.0%} spread, uneven", fontsize=10,
+                color=FLAGGED)
+        else:
+            ax_keep.set_title("Kept per group", fontsize=10)
+    ax_keep.set_ylabel("Fraction of recordings retained")
+    _bare(ax_keep)
+
+    fig.suptitle("Controlling for network size", fontsize=11)
+    # Footnotes are wrapped by hand: the figure is saved with a tight bounding
+    # box, so one long line silently widens the whole canvas.
+    fig.tight_layout(rect=(0, 0.15, 1, 1))
+    fig.text(0.01, 0.015,
+             "Left: every recording below the dashed line was dropped — it "
+             "cannot be subsampled up to the common size.\n"
+             "Right: if the groups were not dropped evenly, the comparison is "
+             "now between the largest networks of one group\n"
+             "and typical ones of another, and the size confound has been "
+             "traded rather than removed.",
+             fontsize=7.5, color=MUTED, va="bottom", linespacing=1.5)
+    return _save(fig, out_path)
+
+
+def plot_selection_check(check, out_path: Path) -> Path | None:
+    """Do the group differences survive a stricter size cut?
+
+    One panel per group pair, one row per metric: an open marker at the gap over
+    every swept recording, a filled one at the gap over only those clearing a
+    higher node count, joined by a line. Since nothing is re-swept between the
+    two - the same per-recording numbers are simply aggregated over fewer
+    recordings - the movement is *selection* alone, with resolution held fixed.
+
+    A long line means the difference is partly a statement about which
+    recordings were big enough to keep. Those are drawn in the warning colour;
+    they should not be quoted from a single subsample target.
+    """
+    if check is None or not getattr(check, "ran", False):
+        return None
+    table = check.table
+    pairs = list(table.groupby(["GroupA", "GroupB"]).groups)
+    if not pairs:
+        return None
+
+    # One shared metric order across panels, worst mover at the top, so a row
+    # can be read straight across.
+    order = (table.groupby("Metric")["Delta"].apply(lambda s: s.abs().max())
+             .sort_values(ascending=True).index.tolist())
+
+    fig, axes = plt.subplots(1, len(pairs), figsize=(3.6 * len(pairs) + 1.2, 4.2),
+                             squeeze=False, sharex=True, sharey=True)
+    for idx, (a, b) in enumerate(pairs):
+        ax = axes[0][idx]
+        sub = table[(table["GroupA"] == a) & (table["GroupB"] == b)]
+        sub = sub.set_index("Metric").reindex(order).dropna(subset=["GapAll"])
+        for row_idx, (metric, row) in enumerate(sub.iterrows()):
+            colour = FLAGGED if bool(row["Flagged"]) else MUTED
+            ax.plot([row["GapAll"], row["GapRestricted"]], [row_idx, row_idx],
+                    color=colour, linewidth=2, alpha=0.85, zorder=1)
+            ax.scatter(row["GapAll"], row_idx, s=34, facecolors="white",
+                       edgecolors=colour, linewidths=1.4, zorder=2)
+            ax.scatter(row["GapRestricted"], row_idx, s=34, color=colour,
+                       linewidths=0, zorder=3)
+        ax.axvline(0, color=INK, linewidth=0.9, linestyle=":")
+        ax.set_yticks(range(len(sub)))
+        ax.set_yticklabels(
+            [_SWEEP_LABELS.get(m, m) for m in sub.index], fontsize=8)
+        ax.set_xlabel("Standardised group difference", fontsize=8.5)
+        ax.set_title(f"{a} vs {b}", fontsize=9.5)
+        ax.tick_params(labelsize=8)
+        _bare(ax)
+
+    threshold = getattr(check, "threshold", None)
+    cohort = ""
+    if getattr(check, "n_restricted", 0) and getattr(check, "n_all", 0):
+        cohort = f" ({check.n_restricted} of {check.n_all} recordings)"
+    fig.suptitle("Do the group differences survive a stricter size cut?",
+                 fontsize=11)
+    fig.tight_layout(rect=(0, 0.18, 1, 1))
+    fig.text(0.01, 0.015,
+             "Open marker: every swept recording. Filled: only those with at "
+             f"least {threshold} nodes{cohort}.\n"
+             "Nothing is re-swept between the two, so the movement is the "
+             "cohort changing, not the measurement —\n"
+             "a long line in the warning colour means the difference is partly "
+             "about which recordings were big enough to keep.",
+             fontsize=7.5, color=MUTED, va="bottom", linespacing=1.5)
+    return _save(fig, out_path)
+
+
+#: One colour per level of control, darkening as more is controlled for, so the
+#: direction of the reading is legible before the legend is.
+_CONTROL_COLOURS = {
+    "none": "#b7b7b7",
+    "density": "#6f9fd0",
+    "density+size": "#1f4e79",
+}
+
+_CONTROL_LABELS = {
+    "none": "no control (step 4)",
+    "density": "matched density",
+    "density+size": "matched density + size",
+}
+
+
+def plot_control_effects(
+    table: pd.DataFrame, out_path: Path, *, alpha: float = 0.05,
+) -> Path | None:
+    """Each metric's age and genotype effect, before and after the controls.
+
+    The question the 5A heatmaps leave open: an effect measured at each
+    network's own density and size may be a statement about density and size.
+    Every metric appears once per level of control, joined by a line, so an
+    effect that shrinks to nothing under the control is visible as a collapse
+    toward zero and one that survives is visible as a flat run.
+
+    Where all three levels are present the step from matched density to matched
+    density *and* size is the node-subsampling effect on its own; with only two
+    the density and size controls cannot be separated, and the caption says so.
+
+    Filled markers survive FDR correction at *alpha*, open ones do not — a
+    marker that empties out between conditions is an effect the control removed.
+    """
+    if table is None or table.empty:
+        return None
+    # Pooled rows only. The per-age contrasts also read "<a> vs <b> ...", and
+    # matching on that alone would put every age in its own panel.
+    if "Scope" in table.columns:
+        table = table[table["Scope"] == "pooled"]
+    terms = [t for t in pd.unique(table["Term"])
+             if str(t) == "age" or (" vs " in str(t) and " at DIV " not in str(t))]
+    terms = [t for t in terms if not str(t).startswith("age within")]
+    if not terms:
+        return None
+    # Age first, then the genotype contrasts in a stable order.
+    terms = ([t for t in terms if str(t) == "age"]
+             + sorted(t for t in terms if str(t) != "age"))
+
+    present = [c for c in CONTROL_LEVELS if c in set(table["Control"])]
+    if not present:
+        return None
+    shown = table[table["Term"].isin(terms)]
+    order = (shown.groupby("Metric")["EffectSize"]
+             .apply(lambda s: s.abs().max())
+             .sort_values(ascending=True).index.tolist())
+
+    fig, axes = plt.subplots(1, len(terms), figsize=(3.5 * len(terms) + 1.3, 4.4),
+                             squeeze=False, sharey=True)
+    for idx, term in enumerate(terms):
+        ax = axes[0][idx]
+        sub = shown[shown["Term"] == term]
+        for row_idx, metric in enumerate(order):
+            points = (sub[sub["Metric"] == metric]
+                      .set_index("Control").reindex(present).dropna(subset=["EffectSize"]))
+            if points.empty:
+                continue
+            if len(points) > 1:
+                ax.plot(points["EffectSize"], [row_idx] * len(points),
+                        color=MUTED, linewidth=1.2, alpha=0.7, zorder=1)
+            for control, point in points.iterrows():
+                colour = _CONTROL_COLOURS.get(control, INK)
+                significant = (pd.notna(point.get("PValueFDR"))
+                               and float(point["PValueFDR"]) < alpha)
+                ax.scatter(point["EffectSize"], row_idx, s=42, zorder=3,
+                           color=colour if significant else "white",
+                           edgecolors=colour, linewidths=1.5)
+        ax.axvline(0, color=INK, linewidth=0.9, linestyle=":")
+        ax.set_yticks(range(len(order)))
+        ax.set_yticklabels([_SWEEP_LABELS.get(m, m) for m in order], fontsize=8)
+        ax.set_title("Age" if str(term) == "age" else str(term), fontsize=9.5)
+        ax.set_xlabel("Effect size", fontsize=8.5)
+        ax.tick_params(labelsize=8)
+        _bare(ax)
+
+    handles = [plt.Line2D([], [], marker="o", linestyle="none",
+                          markerfacecolor=_CONTROL_COLOURS.get(c, INK),
+                          markeredgecolor=_CONTROL_COLOURS.get(c, INK),
+                          markersize=7, label=_CONTROL_LABELS.get(c, c))
+               for c in present]
+    fig.legend(handles=handles, loc="lower center", ncol=len(handles),
+               frameon=False, fontsize=8.5, bbox_to_anchor=(0.5, 0.145))
+    fig.suptitle("Age and genotype effects, before and after the controls",
+                 fontsize=11)
+    # Room for three footnote lines under the legend, which sits under the axes.
+    fig.tight_layout(rect=(0, 0.23, 1, 1))
+
+    isolated = "density" in present and "density+size" in present
+    note = ("Matched density to matched density + size is the node-subsampling "
+            "step on its own." if isolated else
+            "Only one controlled condition was run, so the density and size "
+            "controls cannot be told apart here.")
+    fig.text(0.01, 0.015,
+             "Filled markers survive FDR correction; open ones do not. An "
+             "effect that collapses toward zero under control was a statement\n"
+             "about how dense or how large the networks were, not about their "
+             f"organisation.\n{note} Every condition is measured on the "
+             "recordings all of them have, so a step is the control changing "
+             "and not the cohort.",
+             fontsize=7.5, color=MUTED, va="bottom", linespacing=1.5)
+    return _save(fig, out_path)
+
+
+def plot_genotype_effect_by_age(
+    table: pd.DataFrame, out_path: Path, *, alpha: float = 0.05,
+) -> Path | None:
+    """Each genotype contrast at each age, before and after the controls.
+
+    The pooled figure asks whether an effect survives control over the whole
+    timecourse; this asks *when*. One row per metric, one column per genotype
+    pair, age along the x axis, and one line per level of control. A raw line
+    that climbs with age and a controlled line that does not is a difference
+    that was tracking how dense and how large the networks became, not a
+    genotype difference that grows.
+
+    The statistic is Hedges' g from a Welch t-test at each age, which is not
+    the mixed model's standardised beta — the two are never drawn together for
+    that reason. Filled markers survive FDR correction at *alpha*.
+    """
+    if table is None or table.empty or "Scope" not in table.columns:
+        return None
+    per_age = table[table["Scope"] == "per-age"].dropna(subset=["Age"])
+    if per_age.empty:
+        return None
+
+    contrasts = sorted(pd.unique(per_age["Contrast"].astype(str)))
+    metrics = (per_age.groupby("Metric")["EffectSize"]
+               .apply(lambda s: s.abs().max())
+               .sort_values(ascending=False).index.tolist())
+    present = [c for c in CONTROL_LEVELS if c in set(per_age["Control"])]
+    if not contrasts or not metrics or not present:
+        return None
+
+    fig, axes = plt.subplots(
+        len(metrics), len(contrasts), squeeze=False, sharex=True, sharey=True,
+        figsize=(2.9 * len(contrasts) + 1.0, 1.75 * len(metrics) + 1.8))
+    for r, metric in enumerate(metrics):
+        for c, contrast in enumerate(contrasts):
+            ax = axes[r][c]
+            sub = per_age[(per_age["Metric"] == metric)
+                          & (per_age["Contrast"].astype(str) == contrast)]
+            for control in present:
+                line = sub[sub["Control"] == control].sort_values("Age")
+                if line.empty:
+                    continue
+                colour = _CONTROL_COLOURS.get(control, INK)
+                ax.plot(line["Age"], line["EffectSize"], color=colour,
+                        linewidth=1.8, zorder=2)
+                significant = (line["PValueFDR"].notna()
+                               & (line["PValueFDR"] < alpha))
+                ax.scatter(line["Age"], line["EffectSize"], s=30, zorder=3,
+                           color=[colour if ok else "white" for ok in significant],
+                           edgecolors=colour, linewidths=1.4)
+            ax.axhline(0, color=INK, linewidth=0.9, linestyle=":")
+            if r == 0:
+                ax.set_title(contrast, fontsize=9)
+            if c == 0:
+                ax.set_ylabel(_SWEEP_LABELS.get(metric, metric), fontsize=7.5)
+            if r == len(metrics) - 1:
+                ax.set_xlabel("Age (DIV)", fontsize=8.5)
+            ax.tick_params(labelsize=7.5)
+            _bare(ax)
+
+    handles = [plt.Line2D([], [], color=_CONTROL_COLOURS.get(c, INK), marker="o",
+                          markersize=6, linewidth=1.8,
+                          label=_CONTROL_LABELS.get(c, c)) for c in present]
+    fig.legend(handles=handles, loc="lower center", ncol=len(handles),
+               frameon=False, fontsize=8.5, bbox_to_anchor=(0.5, 0.045))
+    fig.suptitle("Genotype differences at each age, before and after the controls",
+                 fontsize=11)
+    fig.tight_layout(rect=(0, 0.085, 1, 0.985))
+    fig.text(0.01, 0.008,
+             "Hedges' g at each age; filled markers survive FDR correction. "
+             "Not the same statistic as the pooled figure, so read the shape "
+             "across ages rather than against that one.\nEvery condition is "
+             "measured on the recordings all of them have, so a step is the "
+             "control changing and not the cohort.",
+             fontsize=7.5, color=MUTED, va="bottom")
+    return _save(fig, out_path)
+
+
+def plot_metric_values(
+    values: pd.DataFrame, out_path: Path, *,
+    scheme: ColorScheme = DEFAULT_SCHEME,
+) -> Path | None:
+    """The metrics themselves per group and age, under each level of control.
+
+    Effect sizes say how far apart two groups are in units of their own spread;
+    they say nothing about what either group measured. This is the same
+    trajectory figure the comparisons draw, repeated once per level of control,
+    so a control that shifts every group together can be told from one that
+    pulls them apart. Mean ± SEM.
+
+    Rows share a y axis so a metric can be followed across conditions, but the
+    conditions are not the same measurement — step 4 measures each network at
+    its own density, the controlled columns are cost-integrated over the
+    density grid — so a shift between columns is a change of definition as well
+    as of control.
+    """
+    if values is None or values.empty:
+        return None
+    metrics = [m for m in SWEEP_METRICS if m in set(values["Metric"])]
+    controls = [c for c in CONTROL_LEVELS if c in set(values["Control"])]
+    if not metrics or not controls:
+        return None
+    groups = list(pd.unique(values["Group"].dropna()))
+    colours = _group_colors([str(g) for g in groups], scheme)
+
+    # Y axes are shared across the *controlled* columns only. Those measure the
+    # same quantity the same way and differ just in how much is controlled, so a
+    # common scale is what makes the subsampling step readable. The uncontrolled
+    # column is a different measurement — step 4 on the weighted network at its
+    # own density — and forcing it onto the same axis flattens it to a line
+    # (raw nMod is ~2 against ~10-35 controlled).
+    fig, axes = plt.subplots(
+        len(metrics), len(controls), squeeze=False, sharex=True,
+        figsize=(2.9 * len(controls) + 1.0, 1.75 * len(metrics) + 1.8))
+    for r, metric in enumerate(metrics):
+        for c, control in enumerate(controls):
+            ax = axes[r][c]
+            sub = values[(values["Metric"] == metric)
+                         & (values["Control"] == control)]
+            if sub.empty:
+                ax.text(0.5, 0.5, "no step-4 equivalent", transform=ax.transAxes,
+                        ha="center", va="center", fontsize=7.5, color=MUTED)
+                # Only this panel's labels: the x axis is shared, so clearing
+                # its ticks would strip them from every column.
+                ax.tick_params(labelbottom=False)
+                ax.set_yticks([])
+            for group in groups:
+                line = sub[sub["Group"] == group].sort_values("Age")
+                if line.empty:
+                    continue
+                colour = colours[str(group)]
+                ax.plot(line["Age"], line["Mean"], color=colour, linewidth=1.8,
+                        marker="o", markersize=4, label=str(group))
+                ax.fill_between(line["Age"], line["Mean"] - line["SEM"],
+                                line["Mean"] + line["SEM"], color=colour,
+                                alpha=0.18, linewidth=0)
+            if r == 0:
+                ax.set_title(_CONTROL_LABELS.get(control, control), fontsize=9)
+            if c == 0:
+                ax.set_ylabel(_SWEEP_LABELS.get(metric, metric), fontsize=7.5)
+            if r == len(metrics) - 1:
+                ax.set_xlabel("Age (DIV)", fontsize=8.5)
+            ax.tick_params(labelsize=7.5)
+            _bare(ax)
+
+    # Put the controlled columns of each row on one scale, after autoscaling.
+    controlled = [c for c, name in enumerate(controls) if name != "none"]
+    if len(controlled) > 1:
+        for r in range(len(metrics)):
+            limits = [axes[r][c].get_ylim() for c in controlled
+                      if axes[r][c].has_data()]
+            if len(limits) < 2:
+                continue
+            low, high = min(l for l, _ in limits), max(h for _, h in limits)
+            for c in controlled:
+                axes[r][c].set_ylim(low, high)
+            for c in controlled[1:]:
+                axes[r][c].tick_params(labelleft=False)
+
+    handles, labels_ = axes[0][0].get_legend_handles_labels()
+    if not handles:
+        for row in axes:
+            for ax in row:
+                handles, labels_ = ax.get_legend_handles_labels()
+                if handles:
+                    break
+            if handles:
+                break
+    if handles:
+        fig.legend(handles, labels_, loc="lower center", ncol=min(5, len(labels_)),
+                   frameon=False, fontsize=8.5, bbox_to_anchor=(0.5, 0.045))
+    fig.suptitle("The metrics themselves, under each level of control", fontsize=11)
+    fig.tight_layout(rect=(0, 0.085, 1, 0.985))
+    fig.text(0.01, 0.008,
+             "Mean ± SEM. The controlled columns of a row share a y axis, so "
+             "the subsampling step can be read directly; the uncontrolled "
+             "column is\na different measurement of the same quantity and is "
+             "scaled on its own. Every condition uses the recordings all of "
+             "them have.",
+             fontsize=7.5, color=MUTED, va="bottom")
     return _save(fig, out_path)

--- a/src/meanap/stats/run.py
+++ b/src/meanap/stats/run.py
@@ -34,8 +34,9 @@ from meanap.stats.decoding import (
     lda_projection,
 )
 from meanap.stats.density_sweep import (
-    COST_INT_SUFFIX, DEFAULT_DENSITIES, attach_labels, retention,
-    run_density_sweep,
+    COST_INT_SUFFIX, DEFAULT_DENSITIES, attach_labels, control_effects,
+    control_values, decompose_targets, retention, run_density_sweep,
+    selection_sensitivity,
 )
 from meanap.stats.figures import StatsResults, draw_stats_figure, stats_figures
 from meanap.stats.regression import regress
@@ -125,10 +126,31 @@ class StatsSettings:
     #: nodes are dropped — check the retention line in the log, because they
     #: are not a random sample.
     sweep_n_nodes: int | str | None = "auto"
-    #: Percentile of observed node counts ``"auto"`` targets. Low on purpose:
-    #: a higher target resolves topology better but drops more recordings, and
-    #: it drops them unevenly across groups.
-    sweep_node_percentile: float = 10.0
+    #: Percentile of observed node counts ``"auto"`` targets. A higher target
+    #: resolves topology better but drops more recordings, and drops them
+    #: unevenly across groups. Raised from p10 to p20 on 2026-09-02: p10 landed
+    #: at 23 nodes on the Yin run, and at that size a recording's
+    #: cost-integrated values rank only 0.75-0.83 against well-resolved ones -
+    #: fine for a group mean, too scrambled to feed decoding or regression,
+    #: which pass 0.90 agreement around 40 nodes. The retention that buys is
+    #: paid for in selection, but that cost is now visible rather than implicit:
+    #: ``_selection_check`` reports what a tighter cohort does to every gap.
+    sweep_node_percentile: float = 20.0
+    #: A second, larger target. When set, the sweep is run twice and the two
+    #: are decomposed into a selection and a resolution term (the A/B/C design
+    #: in :mod:`meanap.stats.density_sweep`). Doubles the sweep's cost, which
+    #: is why it is opt-in; the selection half alone is free and always runs.
+    sweep_n_nodes_high: int | None = None
+    #: Node count the free selection check restricts to, as a percentile of the
+    #: run's own counts. Higher than ``sweep_node_percentile`` on purpose: the
+    #: check asks what a more demanding target would have done to the cohort.
+    sweep_selection_percentile: float = 40.0
+    #: Also sweep with subsampling turned off, so the density control and the
+    #: size control can be told apart in ``control_effects.csv`` and on
+    #: ``5E7_control_effects``. Costs a second sweep; without it those outputs
+    #: carry only "no control" and "density+size" and cannot attribute a change
+    #: to subsampling specifically.
+    sweep_density_only: bool = False
     #: Random draws averaged over per recording when subsampling.
     sweep_subsamples: int = 20
 
@@ -323,6 +345,230 @@ def _run_density_sweep(ds: StatsDataset, folder: Path, settings,
         if kept["Fraction"].max() - kept["Fraction"].min() > 0.2:
             log("    ! retention differs by more than 20 points between groups — "
                 "the size confound has been traded for a selection one")
+
+    integrated = _labelled_integrated(sweep, ds, lag)
+    _selection_check(integrated, sweep, folder, settings, result, lag, log,
+                     computed)
+    _target_decomposition(integrated, ds, folder, settings, result, lag, log,
+                          computed, source_root)
+    _control_effects(sweep, ds, folder, settings, result, lag, log, computed,
+                     source_root)
+
+
+def _labelled_integrated(sweep, ds, lag) -> pd.DataFrame:
+    """``sweep.integrated`` with group labels attached and this lag selected.
+
+    The sweep stores the cost-integrated features unlabelled, since the object
+    is written to disk and read back by the figures; the group comparisons need
+    them joined, and joining once here keeps the two callers below consistent.
+    """
+    if sweep.integrated is None or sweep.integrated.empty:
+        return pd.DataFrame()
+    out = attach_labels(sweep.integrated, ds)
+    if lag is not None and "Lag" in out.columns:
+        out = out[out["Lag"] == lag]
+    return out
+
+
+def _selection_check(integrated, sweep, folder: Path, settings, result, lag,
+                     log, computed) -> None:
+    """What a more demanding node-count target would have done to the answers.
+
+    Free: the sweep already run, re-aggregated over the recordings that clear a
+    higher node count. That is condition C of the A/B/C design against the
+    condition A the run just produced, so it isolates *selection* — the cohort
+    changing — from the resolution the target would also have changed. A gap
+    that moves here is partly a statement about which recordings were big
+    enough to keep, and should not be quoted from one target alone.
+    """
+    if sweep.n_nodes is None or integrated.empty:
+        return
+    check = selection_sensitivity(
+        integrated, sweep.observed, group_col=sweep.group_col,
+        metrics=sweep.metrics, percentile=settings.sweep_selection_percentile)
+    computed.sweep_selection = check
+    if not check.ran:
+        if check.note:
+            log(f"    selection check not run: {check.note}")
+        return
+
+    _write_table(check.table, folder / "density_sweep_selection_check.csv", result)
+    result.summary.setdefault("density_sweep_selection", {})[str(lag)] = {
+        "node_threshold": check.threshold,
+        "n_all": check.n_all,
+        "n_restricted": check.n_restricted,
+        "n_flagged": len(check.flagged),
+        "flagged": [f"{m} ({a} vs {b})" for m, a, b in check.flagged],
+        "max_abs_delta": float(check.table["Delta"].abs().max()),
+    }
+    log(f"    selection check: {check.n_restricted} of {check.n_all} recordings "
+        f"clear {check.threshold} nodes")
+    if check.flagged:
+        worst = check.table.iloc[0]
+        log(f"    ! {len(check.flagged)} group difference(s) move on cohort alone, "
+            f"worst {worst.Metric} {worst.GapAll:+.2f} -> "
+            f"{worst.GapRestricted:+.2f} ({worst.GroupA} vs {worst.GroupB}) — "
+            "read these as selection, not topology")
+
+
+def _target_decomposition(integrated, ds: StatsDataset, folder: Path, settings,
+                          result, lag, log, computed, source_root: Path) -> None:
+    """The full A/B/C decomposition, when a second target was asked for.
+
+    Runs the sweep again at ``sweep_n_nodes_high`` and splits the difference
+    between the two targets into the cohort changing (selection) and the target
+    changing (resolution). The second sweep is the whole cost of this: condition
+    C is a row subset of the first one.
+    """
+    high = settings.sweep_n_nodes_high
+    if high is None or integrated.empty:
+        return
+    low_target = getattr(computed.sweep, "n_nodes", None)
+    if low_target is None:
+        log("    ! a second target needs the first one to subsample too; skipped")
+        return
+    if int(high) <= int(low_target):
+        log(f"    ! sweep_n_nodes_high ({high}) must exceed the first target "
+            f"({low_target}); skipped")
+        return
+
+    log(f"  density sweep again at {high} nodes, to separate selection from "
+        "resolution")
+    sweep_high = run_density_sweep(
+        source_root, densities=settings.sweep_densities,
+        modularity_reps=settings.sweep_modularity_reps,
+        n_nodes=int(high), n_subsamples=settings.sweep_subsamples,
+        seed=settings.seed, log=log)
+    if sweep_high.integrated is None or sweep_high.integrated.empty:
+        result.skipped.append(f"{folder.name}/target_decomposition: nothing swept")
+        return
+
+    high_integrated = _labelled_integrated(sweep_high, ds, lag)
+    table = decompose_targets(integrated, high_integrated,
+                              group_col=ds.group_col, metrics=sweep_high.metrics)
+    if table.empty:
+        result.skipped.append(
+            f"{folder.name}/target_decomposition: no metric could be decomposed")
+        return
+
+    table.insert(0, "TargetLow", int(low_target))
+    table.insert(1, "TargetHigh", int(high))
+    computed.sweep_decomposition = table
+    _write_table(table, folder / "density_sweep_target_decomposition.csv", result)
+
+    # One row per (metric, group pair), so a metric is only worth naming when
+    # every one of its pairs agrees; counting rows is the honest summary.
+    led = table["Dominant"] == "selection"
+    unanimous = sorted(
+        metric for metric, rows in table.groupby("Metric")
+        if (rows["Dominant"] == "selection").all())
+    result.summary.setdefault("density_sweep_targets", {})[str(lag)] = {
+        "target_low": int(low_target), "target_high": int(high),
+        "n_low": int(table["NA"].iloc[0]), "n_shared": int(table["NC"].iloc[0]),
+        "n_high": int(table["NB"].iloc[0]),
+        "mean_abs_selection": float(table["Selection"].abs().mean()),
+        "mean_abs_resolution": float(table["Resolution"].abs().mean()),
+        "n_comparisons": int(len(table)),
+        "n_selection_led": int(led.sum()),
+        "selection_led_throughout": unanimous,
+    }
+    log(f"    decomposed {len(table)} group differences: mean |selection| "
+        f"{table['Selection'].abs().mean():.3f} vs mean |resolution| "
+        f"{table['Resolution'].abs().mean():.3f}; "
+        f"{int(led.sum())}/{len(table)} led by selection")
+    if unanimous:
+        log("    selection-led for every group pair: " + ", ".join(unanimous)
+            + " — raising the target moved these mostly by changing the cohort")
+
+
+def _control_effects(sweep, ds: StatsDataset, folder: Path, settings, result,
+                     lag, log, computed, source_root: Path) -> None:
+    """Age and genotype effects for each metric under each level of control.
+
+    The same statistic the 5A heatmaps report, recomputed on the controlled
+    features, so "does this effect survive the control" can be read directly
+    rather than inferred from two separate figures. With
+    ``sweep_density_only`` set the sweep is run a second time with subsampling
+    off, which is what separates the density control from the size one — the
+    step between those two conditions is the subsampling effect alone.
+    """
+    if sweep.integrated is None or sweep.integrated.empty:
+        return
+
+    if sweep.n_nodes is None:
+        # The sweep controlled density only, so that is the condition it is.
+        density_only, density_and_size = sweep.integrated, None
+    else:
+        density_only, density_and_size = None, sweep.integrated
+        if settings.sweep_density_only:
+            log("  density sweep again with subsampling off, to separate the "
+                "density control from the size one")
+            plain = run_density_sweep(
+                source_root, densities=settings.sweep_densities,
+                modularity_reps=settings.sweep_modularity_reps,
+                n_nodes=None, seed=settings.seed, log=log)
+            if plain.integrated is not None and not plain.integrated.empty:
+                density_only = plain.integrated
+                _write_table(plain.integrated,
+                             folder / "density_sweep_integrated_density_only.csv",
+                             result)
+            else:
+                result.skipped.append(
+                    f"{folder.name}/control_effects: the unsubsampled sweep "
+                    "produced nothing")
+
+    try:
+        table = control_effects(ds, density_only=density_only,
+                                density_and_size=density_and_size,
+                                metrics=sweep.metrics)
+    except Exception as exc:  # a model that will not fit costs only this table
+        result.skipped.append(f"{folder.name}/control_effects: {exc}")
+        return
+    if table.empty:
+        return
+
+    computed.control_effects = table
+    _write_table(table, folder / "control_effects.csv", result)
+
+    # The metrics themselves, not just how far apart the groups are: an effect
+    # size in units of each condition's own spread cannot say what either group
+    # actually measured, and a control that moves every group together looks
+    # identical to one that moves none of them.
+    try:
+        measured = control_values(ds, density_only=density_only,
+                                  density_and_size=density_and_size,
+                                  metrics=sweep.metrics)
+    except Exception as exc:  # noqa: BLE001 - costs only this table
+        result.skipped.append(f"{folder.name}/control_values: {exc}")
+        measured = None
+    if measured is not None and not measured.empty:
+        computed.control_values = measured
+        _write_table(measured, folder / "control_metric_values.csv", result)
+
+    levels = [c for c in ("none", "density", "density+size")
+              if c in set(table["Control"])]
+    # How much of each effect the control removes, as the headline number.
+    shrunk = None
+    if "none" in levels and len(levels) > 1:
+        strongest = levels[-1]
+        wide = table.pivot_table(index=["Term", "Metric"], columns="Control",
+                                 values="EffectSize")
+        both = wide[["none", strongest]].dropna()
+        if not both.empty:
+            shrunk = float((both[strongest].abs() < both["none"].abs()).mean())
+
+    result.summary.setdefault("control_effects", {})[str(lag)] = {
+        "levels": levels,
+        "n_rows": int(len(table)),
+        "subsampling_isolated": bool(
+            "density" in levels and "density+size" in levels),
+        "fraction_shrunk_under_control": shrunk,
+    }
+    log("    effects under control: " + ", ".join(levels)
+        + (f"; {shrunk:.0%} of effects shrink" if shrunk is not None else ""))
+    if "density" not in levels and sweep.n_nodes is not None:
+        log("    (set sweep_density_only / --sweep-density-only to separate "
+            "the density control from the size one)")
 
 
 def _controlled_families(ds: StatsDataset, sweep, folder: Path, settings,


### PR DESCRIPTION
The density sweep already subsampled every network to a common node count, but nothing said what that cost. Recordings too small to reach the target are dropped, smallness is not spread evenly across groups, and so raising the target trades a size confound for a selection one.

Measured on the Yin timecourse (378 recordings), the selection term is **as large as or larger than** the resolution term, and it runs the *opposite* way from the N=22/50 pair the notes previously documented — so it has to be measured per dataset rather than assumed.

## Selection is now reported for free

A recording's swept result depends only on its matrix, the target and the seed — never on which cohort it sits in. So re-reading one sweep over the recordings clearing a higher node count is condition C of the A/B/C design at **no extra compute**.

`selection_sensitivity` does this whenever subsampling is on, writes `density_sweep_selection_check.csv`, and flags a gap that moves by ≥0.1 SD *and* either changes sign or moves by half its own size. Both conditions, since a large relative move on a gap of 0.02 is noise and a small one on a gap of 1.0 is not worth a warning. On the Yin run it fires for `Q`, `BCmean` and `PL`, and stays quiet for `CC`, `ElocMean` and `nMod`.

The full decomposition stays opt-in behind `--sweep-nodes 22,50`, since only condition B needs a second sweep.

## Effects under control

`control_effects` and `control_values` answer the question the 5A heatmaps leave open — does *this* effect survive the control — using the same statistic 5A reports, recomputed on the controlled features, at three levels:

| | |
|---|---|
| `none` | step 4's metrics, each network at its own density and size |
| `density` | cost-integrated over the density grid, size left alone |
| `density+size` | the same, on networks first cut to a common node count |

`--sweep-density-only` adds the middle condition, which is what isolates subsampling from the density control. `control_values` reports the metrics themselves per group and age, because an effect size in units of each condition's own spread cannot say what either group actually measured.

**Every condition is put on one cohort.** Without that, the step between two conditions mixes the control being applied with the cohort changing underneath it. Not hypothetical — on this data the unmatched tables read CC's pooled age effect as `none` +1.09, `density` −0.53, `density+size` −1.06, which looks like subsampling doubling the effect. Matched on the 306 recordings all three conditions have it is +1.24, −1.13, −1.06: the density control does essentially all the work. The unmatched reading attributes to node subsampling something that was the retention cut.

**Raw counterparts are the unnormalised metrics** — `CC_rawMean` and `PL_raw`, not the null-model-normalised `NetMet.CC`/`PL` saved under the same short names, which are a different quantity. `BCmean` has no step-4 recording-level counterpart at all and is labelled as such rather than left blank.

## Figures

The size half of the confound had no figures while the density half had three:

- `5E5_size_control` — node counts against the target, retention per group, titled in the warning colour when the spread crosses the same 20 points the runner warns on
- `5E6_selection_check` — the check above, one dumbbell per metric per group pair
- `5E7_control_effects` — pooled age and genotype effects under each control
- `5E8_genotype_effect_by_age` — the genotype contrasts per age rather than pooled
- `5E9_metric_values_by_control` — the metric values themselves, mean ± SEM

All redraw from CSVs alone, so they travel in a bundle (~0.8 MB for 35 tables) and appear in the viewer and HTML report with no format change.

## Also

- **Raises the `"auto"` target from p10 to p20.** p10 landed at 23 nodes here, where a recording's cost-integrated values rank only 0.75–0.83 against well-resolved ones — fine for a group mean, too scrambled to feed decoding or regression, which pass 0.90 around 40 nodes. Costs retention (wildtype 88% → 74%), which is now visible rather than implicit.
- **Fixes `5E4_topology_controlled`**, which was drawn during a run but vanished whenever results were read back: `load_results` never loaded the controlled family table, so the figure could not be rebuilt from a folder or a bundle. Pre-existing, unrelated to the rest of this change.

## Testing

`python/test_density_sweep.py` goes 68 → 90 checks (74 with the real-run section). New sections cover the gap tables, the selection check, the A/B/C decomposition — including that `Selection + Resolution == Total` and that C really is A read over B's recordings rather than a second measurement — the per-age scope, and the metric values. `test_bundle_render.py` passes 156/156.

Verified end to end on the Yin run: full stats with both sweeps, packed into a bundle, reopened, and all nine `5E` figures rendered from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBErMGuZkxnJGAZiP6d8yJ
