### PR TITLE
CAT-NAP: analyse several measures of activity in one run, and compare what they conclude

### DIFF
--- a/python/CATNAP_PORT_PLAN.md
+++ b/python/CATNAP_PORT_PLAN.md
@@ -425,6 +425,44 @@ Fixed in passing, both in the same loop:
 See `PIPELINE_PORT_STATUS.md` § "CAT-NAP resume" for the design choices and
 `python/test_catnap_resume.py` for the tests.
 
+### Phase 12 — Several measures of activity in one run ✅ (feature extension, no MATLAB counterpart)
+
+MATLAB's `Params.twopActivity` picks **one** of `peaks` / `denoised F` / `F` /
+`spks` and every number in the run is conditional on it — `peaks` builds an STTC
+event network, the other three a binned Pearson correlation network. The choice
+was invisible in the output, so "which measure was this?" could only be answered
+from a settings file that does not travel with a figure.
+
+`Params.twop_activities` now lists extra measures to analyse beside
+`twop_activity` in the same run (`src/meanap/catnap/activities.py`):
+
+- **one pass over the raw data.** Loading and denoising happen once per
+  recording however many measures are asked for; only the per-measure half —
+  adjacency, activity statistics, network metrics — repeats. That is what makes
+  this one run rather than N.
+- **layout.** The primary measure keeps the top-level folders, byte-for-byte as
+  a one-measure run wrote them. Each extra measure gets a *complete* run folder
+  under `ByActivityType/<slug>/` — its own `ExperimentMatFiles`,
+  `netmet_results.json`, figures and `params.json` naming that measure alone —
+  so the report, the bundle viewer and `meanap-stats` can be pointed straight at
+  it. The four tables at the top level pool every measure with an
+  `ActivityType` column.
+- **independence.** Cartography boundaries, batch metric ranges and the RNG are
+  per measure. Each measure draws from a generator seeded from the recording
+  name alone, so `peaks` run beside `denoised F` gives numbers identical to
+  `peaks` run on its own — checked in
+  `python/test_catnap_multi_activity.py` § C.
+- **step 5.** `meanap.stats.dataset` treats the measure as an axis like the lag:
+  each measure is analysed separately, then `meanap.stats.measures` compares
+  them — agreement (Spearman / Lin's CCC / Bland-Altman), the paired
+  within-recording shift (Wilcoxon + Hedges' g_av), whether each group and age
+  conclusion survives the change of measure, and decoding accuracy per measure.
+  Written to `5_StatsAndML/MeasureComparison/<lag>/` with figures `5F1`-`5F4`.
+
+The conclusion table is the point of the whole phase: a genotype effect that is
+significant under `peaks` and absent under `denoised F` is a finding about the
+analysis, and it should be visible before publication rather than after.
+
 ## Reuse wins
 - Denoising / peak detection (`catnap/denoising.py`) — done.
 - STTC + probabilistic thresholding (`pipeline/probabilistic_threshold.py`) —

--- a/python/diagnose_bundle_traces.py
+++ b/python/diagnose_bundle_traces.py
@@ -21,6 +21,18 @@ from meanap.pipeline.render import (  # noqa: E402
 NEEDS_DENOISING = ("peaks", "denoised F", "spks")
 
 
+def _measures(params) -> list[str]:
+    """Every measure of activity the run analysed, primary first."""
+    from meanap.catnap.activities import activity_types
+
+    return activity_types(params)
+
+
+def _denoising_measures(params) -> list[str]:
+    """The measures that make the run denoise — any one is enough for traces."""
+    return [a for a in _measures(params) if a in NEEDS_DENOISING]
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print(__doc__)
@@ -73,8 +85,9 @@ def main(argv: list[str]) -> int:
                   "they were never drawn.\n    They cannot be recovered from the "
                   "bundle; set it above 0 (CAT-NAP tab → Denoising settings → "
                   "Advanced) and re-run.")
-        elif params is not None and params.twop_activity not in NEEDS_DENOISING:
-            print(f"  → Activity type is {params.twop_activity!r}, which skips "
+        elif params is not None and not _denoising_measures(params):
+            named = " / ".join(repr(a) for a in _measures(params))
+            print(f"  → Activity type is {named}, which skips "
                   "denoising — and these figures plot the\n    denoised trace "
                   "against the detected events. Set it to 'peaks' and re-run.")
         else:

--- a/python/test_catnap_correlation_bins.py
+++ b/python/test_catnap_correlation_bins.py
@@ -230,6 +230,37 @@ check("the structural key keeps its historical spelling",
       all(k.endswith("mslag") for k in res.adjMs), str(list(res.adjMs)))
 
 
+# ── Self-correlations must not become edges ───────────────────────────────
+# MATLAB's suite2pToAdjm.m stores corr(...) verbatim, leaving a diagonal of 1
+# — the largest weight in the matrix — which inflates Dens (past 1.0), NS and
+# both sigEdges* metrics. The ETTC path has always returned a zero diagonal,
+# so without this the two measures were not comparable graphs.
+for activity in ("F", "spks", "denoised F"):
+    r = suite2p_to_adjm(peaks_data, activity, [1000])
+    a = r.adjMs["adjM1000mslag"]
+    check(f"{activity}: correlation adjacency has a zero diagonal",
+          a.shape[0] > 1 and np.allclose(np.diag(a), 0.0), str(np.diag(a)[:4]))
+
+corr_adj = suite2p_to_adjm(peaks_data, "spks", [1000]).adjMs["adjM1000mslag"]
+ettc_adj = peaks_res.adjMs["adjM1000mslag"]
+check("both measures agree about self-edges",
+      np.allclose(np.diag(corr_adj), np.diag(ettc_adj)),
+      f"corr={np.diag(corr_adj)[:3]} ettc={np.diag(ettc_adj)[:3]}")
+
+import meanap.pipeline.network_metrics as _nm  # noqa: E402
+n = corr_adj.shape[0]
+check("density stays a proportion",
+      0.0 <= _nm.density_und(corr_adj) <= 1.0,
+      f"{_nm.density_und(corr_adj):.4f}")
+with_loops = corr_adj.copy()
+np.fill_diagonal(with_loops, 1.0)
+check("...which it would not with self-loops present",
+      _nm.density_und(with_loops) > _nm.density_und(corr_adj),
+      f"{_nm.density_und(with_loops):.4f} vs {_nm.density_und(corr_adj):.4f}")
+check("off-diagonal correlations are untouched by the fix",
+      np.allclose(corr_adj[~np.eye(n, dtype=bool)],
+                  with_loops[~np.eye(n, dtype=bool)]), "")
+
 print()
 if FAILURES:
     print(f"{len(FAILURES)} FAILED:")

--- a/python/test_catnap_group_plots.py
+++ b/python/test_catnap_group_plots.py
@@ -405,8 +405,12 @@ def _runner_tail_checks() -> list[Check]:
         root = create_output_folders(tmp, "OutputTest", ["WT", "KO"])
         logs: list[str] = []
 
-        _save_catnap_results(recordings, results, stats, channels,
-                             root / "4_NetworkActivity", logs.append)
+        # Nested by measure of activity: a run analysing one measure is the
+        # one-key case of the multi-measure shape the pipeline now passes.
+        _save_catnap_results(params, recordings, {params.twop_activity: results},
+                             {params.twop_activity: stats},
+                             {params.twop_activity: channels},
+                             root, logs.append)
         _plot_group_comparisons(params, recordings, results, stats, channels,
                                 tables, states, root, logs.append)
 

--- a/python/test_catnap_multi_activity.py
+++ b/python/test_catnap_multi_activity.py
@@ -1,0 +1,485 @@
+"""CAT-NAP runs that analyse several measures of activity at once.
+
+Run from the repo root::
+
+    uv run python python/test_catnap_multi_activity.py
+
+``Params.twop_activities`` lets one run build the network from detected calcium
+events *and* from the deconvolved trace (and from raw fluorescence, and from
+suite2p's spike estimate) over the same recordings, so the choice of measure
+becomes an axis of the output instead of a decision buried in a settings file.
+That is only worth having if three things hold, which is what this checks:
+
+  - **layout** — the primary measure writes exactly what a one-measure run
+    always wrote, byte-for-byte in name and place, and each extra measure gets a
+    complete run folder of its own under ``ByActivityType/``; the pooled tables
+    carry every measure with an ``ActivityType`` column;
+  - **independence** — the measures do not contaminate each other: each gets
+    its own cartography boundaries, its own metric ranges, and a generator
+    seeded the same way it would be if it were the only measure in the run, so
+    ``peaks`` alone and ``peaks`` beside ``denoised F`` give identical numbers;
+  - **the comparison** — the statistics step analyses each measure separately
+    and then compares them, and its verdicts say what they mean: agreement,
+    paired shift, and whether the group conclusion survives a change of
+    measure.
+
+Sections A-C run on synthetic suite2p folders; section D runs the statistics
+step on a synthetic multi-measure table. No MATLAB and no example dataset.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from meanap.params import Params                                   # noqa: E402
+from meanap.pipeline.spreadsheet import RecordingInfo              # noqa: E402
+
+Check = tuple[str, bool, str]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n_pass = 0
+    for name, ok, detail in checks:
+        flag = "✓" if ok else "✗"
+        suffix = "" if ok else f"   [{detail}]"
+        print(f"  {flag} {name}{suffix}")
+        n_pass += bool(ok)
+    print(f"  → {n_pass}/{len(checks)} passed")
+    return n_pass, len(checks)
+
+
+# ── synthetic suite2p input ──────────────────────────────────────────────────
+
+N_ROIS = 14
+N_FRAMES = 1200
+FS = 30.0
+
+
+def _write_suite2p(plane0: Path, seed: int) -> None:
+    """A minimal suite2p plane0 folder with correlated, event-like traces.
+
+    Events rather than noise so ``peaks`` has something to detect and the two
+    measures have a chance of agreeing; correlated rather than independent so
+    the adjacency is not a matrix of zeros, which would make every metric
+    constant and every comparison below vacuous.
+    """
+    rng = np.random.default_rng(seed)
+    plane0.mkdir(parents=True, exist_ok=True)
+
+    # Two latent event trains; each ROI follows one of them plus its own noise.
+    latent = np.zeros((2, N_FRAMES))
+    for k in range(2):
+        onsets = rng.choice(N_FRAMES - 60, size=18, replace=False)
+        for t in onsets:
+            latent[k, t:t + 30] += np.exp(-np.arange(30) / 8.0)
+
+    F = np.zeros((N_ROIS, N_FRAMES))
+    for i in range(N_ROIS):
+        F[i] = (300.0 + 60.0 * latent[i % 2]
+                + rng.normal(0, 4.0, N_FRAMES)).astype(float)
+
+    np.save(plane0 / "F.npy", F)
+    np.save(plane0 / "Fneu.npy", np.full_like(F, 100.0))
+    np.save(plane0 / "spks.npy", np.clip(rng.normal(0, 1, F.shape), 0, None))
+    np.save(plane0 / "iscell.npy", np.column_stack(
+        [np.ones(N_ROIS), np.full(N_ROIS, 0.9)]))
+    stat = np.array([{"med": [int(rng.integers(0, 250)), int(rng.integers(0, 250))],
+                      "ypix": np.array([0]), "xpix": np.array([0])}
+                     for _ in range(N_ROIS)], dtype=object)
+    np.save(plane0 / "stat.npy", stat, allow_pickle=True)
+    np.save(plane0 / "ops.npy",
+            np.array({"fs": FS, "meanImg": rng.random((250, 250))}, dtype=object),
+            allow_pickle=True)
+
+
+def _params(raw: Path, activities: tuple[str, ...]) -> Params:
+    return Params(
+        suite2p_mode=True, raw_data=str(raw),
+        twop_activity="peaks", twop_activities=activities,
+        func_con_lag_val=[500],
+        prob_thresh_rep_num=8,          # the run's expensive half, kept tiny
+        min_number_of_nodes_to_cal_net_met=4,
+        num_2p_traces=0,                # no raw-data figures needed here
+        twop_network_background=False,
+        auto_set_cartography_boundaries=True,
+        random_seed=7,
+        recording_workers=1,
+    )
+
+
+def _run(root: Path, raw: Path, recordings, activities) -> list[str]:
+    from meanap.catnap.pipeline import run_catnap_pipeline
+    from meanap.pipeline.output_folders import create_output_folders
+
+    out = create_output_folders(root.parent, root.name,
+                                sorted({r.group for r in recordings}))
+    logs: list[str] = []
+    run_catnap_pipeline(_params(raw, activities), recordings, out, logs.append)
+    return logs
+
+
+def _dataset(n_recordings: int = 4):
+    """A raw-data folder plus the roster describing it."""
+    tmp = Path(tempfile.mkdtemp())
+    raw = tmp / "raw"
+    recordings = []
+    for i in range(n_recordings):
+        name = f"CULT{i:02d}_20240101_DIV{14 + 7 * (i % 2)}"
+        _write_suite2p(raw / name / "suite2p" / "plane0", seed=100 + i)
+        recordings.append(RecordingInfo(
+            filename=name, div=float(14 + 7 * (i % 2)),
+            group="WT" if i % 2 else "KO"))
+    return tmp, raw, recordings
+
+
+# ── Section A: layout ────────────────────────────────────────────────────────
+
+def _layout_checks() -> list[Check]:
+    from meanap.catnap.activities import (
+        activity_output_root, activity_params, activity_types, is_multi_activity,
+    )
+
+    checks: list[Check] = []
+
+    single = Params(suite2p_mode=True, twop_activity="spks")
+    checks.append(("a run with no extra measures analyses just its own",
+                   activity_types(single) == ["spks"], f"{activity_types(single)}"))
+    checks.append(("…and is not a multi-measure run",
+                   not is_multi_activity(single), ""))
+    checks.append(("…and keeps the top-level output folder",
+                   activity_output_root(Path("/out"), single, "spks") == Path("/out"),
+                   ""))
+
+    multi = Params(suite2p_mode=True, twop_activity="peaks",
+                   twop_activities=("denoised F", "peaks"))
+    checks.append(("the primary measure leads, however the extras are ordered",
+                   activity_types(multi) == ["peaks", "denoised F"],
+                   f"{activity_types(multi)}"))
+    checks.append(("the primary measure still owns the run folder",
+                   activity_output_root(Path("/out"), multi, "peaks") == Path("/out"),
+                   ""))
+    checks.append(("an extra measure gets a subtree named by its slug",
+                   activity_output_root(Path("/out"), multi, "denoised F")
+                   == Path("/out/ByActivityType/denoisedF"), ""))
+
+    per_measure = activity_params(multi, "denoised F")
+    checks.append(("a measure's own params name it and nothing else",
+                   per_measure.twop_activity == "denoised F"
+                   and not per_measure.twop_activities, ""))
+    checks.append(("…so its folders are named for what it measures",
+                   _folder(per_measure) == "500msbin", _folder(per_measure)))
+    checks.append(("…while the event measure's are still lags",
+                   _folder(activity_params(multi, "peaks")) == "500mslag", ""))
+    return checks
+
+
+def _folder(params) -> str:
+    from meanap.timescale import timescale_folder
+
+    return timescale_folder(500, params)
+
+
+# ── Section B: a real two-measure run ────────────────────────────────────────
+
+def _run_checks(tmp: Path, raw: Path, recordings) -> tuple[list[Check], Path]:
+    checks: list[Check] = []
+    root = tmp / "OutTwo"
+    logs = _run(root, raw, recordings, ("denoised F",))
+    text = "\n".join(logs)
+
+    checks.append(("the run says which measures it analysed",
+                   "Measures of activity: peaks, denoised F" in text,
+                   text[:200]))
+
+    net = root / "4_NetworkActivity"
+    sub = root / "ByActivityType" / "denoisedF"
+    checks.append(("the primary measure keeps the top-level results",
+                   (net / "netmet_results.json").exists(), ""))
+    checks.append(("the extra measure gets its own complete run folder",
+                   (sub / "4_NetworkActivity" / "netmet_results.json").exists()
+                   and (sub / "params.json").exists(), f"{sorted(p.name for p in sub.iterdir())}"))
+    if (sub / "params.json").exists():
+        with open(sub / "params.json") as fh:
+            saved = json.load(fh)
+        checks.append(("…whose params name that measure alone",
+                       saved.get("twop_activity") == "denoised F"
+                       and not saved.get("twop_activities"),
+                       f"{saved.get('twop_activity')}"))
+
+    rec_csv = net / "NetworkActivity_RecordingLevel.csv"
+    table = pd.read_csv(rec_csv) if rec_csv.exists() else pd.DataFrame()
+    checks.append(("the pooled table carries an ActivityType column",
+                   "ActivityType" in table.columns, f"{list(table.columns)[:6]}"))
+    if "ActivityType" in table.columns:
+        found = sorted(table["ActivityType"].unique())
+        checks.append(("…naming both measures",
+                       found == ["denoised F", "peaks"], f"{found}"))
+        checks.append(("…with a row per recording per measure",
+                       len(table) == 2 * len(recordings), f"{len(table)}"))
+        checks.append(("…and the same recordings under each",
+                       set(table[table["ActivityType"] == "peaks"]["FileName"])
+                       == set(table[table["ActivityType"] == "denoised F"]["FileName"]),
+                       ""))
+
+    per_measure = pd.read_csv(sub / "4_NetworkActivity"
+                              / "NetworkActivity_RecordingLevel.csv")
+    checks.append(("the subtree's own table holds only its measure",
+                   "ActivityType" not in per_measure.columns
+                   and len(per_measure) == len(recordings),
+                   f"{len(per_measure)}"))
+
+    act_csv = root / "2_NeuronalActivity" / "TwoPhotonActivity_RecordingLevel.csv"
+    act = pd.read_csv(act_csv) if act_csv.exists() else pd.DataFrame()
+    checks.append(("the activity stats are pooled the same way",
+                   "ActivityType" in act.columns and len(act) == 2 * len(recordings),
+                   f"{len(act)}"))
+
+    # Each measure's state file, in its own ExperimentMatFiles.
+    name = recordings[0].filename
+    checks.append(("each measure stores its own adjacency for re-runs",
+                   (root / "ExperimentMatFiles" / f"{name}_catnap.npz").exists()
+                   and (sub / "ExperimentMatFiles" / f"{name}_catnap.npz").exists(),
+                   ""))
+
+    # Figure folders: a lag for the event measure, a bin for the correlation one.
+    fig_root = net / "4A_IndividualNetworkAnalysis"
+    lag_dirs = {p.name for p in fig_root.rglob("*mslag") if p.is_dir()}
+    bin_dirs = {p.name for p in (sub / "4_NetworkActivity"
+                                 / "4A_IndividualNetworkAnalysis").rglob("*msbin")
+                if p.is_dir()}
+    checks.append(("the event measure's figures are filed under a lag",
+                   lag_dirs == {"500mslag"}, f"{lag_dirs}"))
+    checks.append(("…and the correlation measure's under a bin",
+                   bin_dirs == {"500msbin"}, f"{bin_dirs}"))
+    return checks, root
+
+
+# ── Section C: the measures do not contaminate each other ────────────────────
+
+def _independence_checks(tmp: Path, raw: Path, recordings, two_root: Path) -> list[Check]:
+    """Running ``peaks`` beside another measure must not change ``peaks``.
+
+    The property that makes a multi-measure run usable as a comparison: if the
+    numbers moved depending on which other measures were in the run, the
+    comparison would be measuring the run's configuration rather than the
+    measures. It holds because every measure draws from a generator seeded from
+    the recording name alone, never from a stream shared down the run.
+    """
+    checks: list[Check] = []
+    one_root = tmp / "OutOne"
+    _run(one_root, raw, recordings, ())
+
+    def load(root: Path) -> pd.DataFrame:
+        frame = pd.read_csv(root / "4_NetworkActivity"
+                            / "NetworkActivity_RecordingLevel.csv")
+        if "ActivityType" in frame.columns:
+            frame = frame[frame["ActivityType"] == "peaks"].drop(
+                columns=["ActivityType"])
+        return frame.sort_values("FileName").reset_index(drop=True)
+
+    alone, beside = load(one_root), load(two_root)
+    shared = [c for c in alone.columns if c in beside.columns]
+    checks.append(("the same columns come out either way",
+                   len(shared) == len(alone.columns) == len(beside.columns),
+                   f"{sorted(set(alone.columns) ^ set(beside.columns))}"))
+
+    numeric = [c for c in shared
+               if pd.api.types.is_numeric_dtype(alone[c])
+               and pd.api.types.is_numeric_dtype(beside[c])]
+    mismatched = [c for c in numeric
+                  if not np.allclose(alone[c].to_numpy(float),
+                                     beside[c].to_numpy(float),
+                                     rtol=1e-9, atol=1e-12, equal_nan=True)]
+    checks.append(("peaks gives identical numbers alone and in company",
+                   not mismatched, f"differs in {mismatched[:6]}"))
+
+    # Cartography boundaries are derived per measure from that measure's own
+    # pooled PC/Z, so the two subtrees must not be carrying the same ones.
+    def boundaries(root: Path, activity: str) -> tuple:
+        with open(root / "4_NetworkActivity" / "netmet_results.json") as fh:
+            data = json.load(fh)
+        first = next(iter(data.values()))
+        return tuple(next(iter(first.values())).get("cartographyBoundaries") or ())
+
+    peaks_bounds = boundaries(two_root, "peaks")
+    other_bounds = boundaries(two_root / "ByActivityType" / "denoisedF", "denoised F")
+    checks.append(("each measure got cartography boundaries of its own",
+                   bool(peaks_bounds) and peaks_bounds != other_bounds,
+                   f"{peaks_bounds} vs {other_bounds}"))
+    return checks
+
+
+# ── Section D: the statistics step's comparison ──────────────────────────────
+
+def _make_multi_measure_run(root: Path) -> Path:
+    """A run folder whose tables carry two measures of the same recordings.
+
+    Built by hand rather than by running the pipeline: this section is about
+    what the statistics step does with a measure axis, and a synthetic table
+    lets the answer be known in advance. ``Q`` is given a genotype effect under
+    ``peaks`` and none under ``denoised F``, which is exactly the situation the
+    concordance table exists to surface; ``Dens`` gets the same effect under
+    both, and should come out concordant.
+    """
+    rng = np.random.default_rng(3)
+    rows = []
+    for culture in range(28):
+        group = "WT" if culture % 2 else "KO"
+        for div in (14, 21, 28):
+            name = f"CULT{culture:03d}_20240101_DIV{div}"
+            base = 0.02 * div + rng.normal(0, 0.05)
+            q_effect = 0.35 if group == "KO" else 0.0
+            for activity in ("peaks", "denoised F"):
+                # A measure-specific offset and scale, so agreement is high in
+                # rank and poor in absolute value — the usual real case.
+                scale = 1.0 if activity == "peaks" else 2.5
+                rows.append({
+                    "FileName": name, "Grp": group, "DIV": float(div),
+                    "ActivityType": activity, "Lag": "500mslag",
+                    "Dens": scale * (base + 0.05 * (group == "KO"))
+                    + rng.normal(0, 0.01),
+                    "Q": (0.4 + (q_effect if activity == "peaks" else 0.0)
+                          + rng.normal(0, 0.06)),
+                    "aN": float(rng.integers(20, 60)),
+                    "Eglob": scale * base + rng.normal(0, 0.02),
+                })
+    net = root / "4_NetworkActivity"
+    net.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(net / "NetworkActivity_RecordingLevel.csv", index=False)
+    with open(net / "netmet_results.json", "w") as fh:
+        json.dump({}, fh)
+    with open(root / "params.json", "w") as fh:
+        json.dump({"custom_grp_order": ["WT", "KO"], "suite2p_mode": True}, fh)
+    return root
+
+
+def _stats_checks(tmp: Path) -> list[Check]:
+    from meanap.stats.dataset import load_dataset
+    from meanap.stats.figures import load_results, stats_figures
+    from meanap.stats.run import StatsSettings, run_stats
+
+    checks: list[Check] = []
+    root = _make_multi_measure_run(tmp / "StatsRun")
+
+    ds = load_dataset(root)
+    checks.append(("the dataset sees a measure axis",
+                   ds.activities == ["peaks", "denoised F"], f"{ds.activities}"))
+    checks.append(("…and subsetting by measure halves the rows",
+                   len(ds.for_activity("peaks").table) == len(ds.table) // 2,
+                   f"{len(ds.for_activity('peaks').table)} of {len(ds.table)}"))
+
+    settings = StatsSettings(
+        correlation=False, regression=False, n_repeats=1, n_permutations=0,
+        importance_repeats=1, per_age_decoding=False, shapley_by_age=False,
+        feature_families=False, models=("lda",))
+    logs: list[str] = []
+    result = run_stats(root, dest=root / "5_StatsAndML", settings=settings,
+                       log=logs.append)
+
+    dest = root / "5_StatsAndML"
+    checks.append(("each measure is analysed in a folder of its own",
+                   (dest / "peaks" / "500mslag" / "comparisons.csv").exists()
+                   and (dest / "denoisedF" / "500mslag" / "comparisons.csv").exists(),
+                   f"{sorted(p.name for p in dest.iterdir())}"))
+
+    folder = dest / "MeasureComparison" / "500mslag"
+    for name in ("measure_agreement", "measure_differences", "measure_effects",
+                 "measure_concordance", "measure_decoding"):
+        checks.append((f"{name}.csv written",
+                       (folder / f"{name}.csv").exists(), ""))
+
+    agree = pd.read_csv(folder / "measure_agreement.csv")
+    dens = agree[agree["Metric"] == "Dens"].iloc[0]
+    checks.append(("a metric that only changes scale still ranks alike",
+                   dens["Spearman"] > 0.9, f"rho={dens['Spearman']:.3f}"))
+    checks.append(("…but its agreement coefficient sees the scale change",
+                   dens["CCC"] < dens["Spearman"],
+                   f"CCC={dens['CCC']:.3f} vs rho={dens['Spearman']:.3f}"))
+    checks.append(("…and the Bland-Altman bias is reported in the metric's units",
+                   np.isfinite(dens["Bias"]) and dens["LoALower"] < dens["Bias"]
+                   < dens["LoAUpper"], f"{dens['Bias']}"))
+
+    diffs = pd.read_csv(folder / "measure_differences.csv")
+    dens_diff = diffs[diffs["Metric"] == "Dens"].iloc[0]
+    checks.append(("the paired shift in a rescaled metric is detected",
+                   dens_diff["PValueFDR"] < 0.05 and abs(dens_diff["HedgesG"]) > 0.5,
+                   f"p={dens_diff['PValueFDR']:.3g} g={dens_diff['HedgesG']:.2f}"))
+
+    conc = pd.read_csv(folder / "measure_concordance.csv")
+    q_rows = conc[(conc["Metric"] == "Q")
+                  & (conc["Term"].astype(str).str.contains("vs"))]
+    checks.append(("a genotype effect present under one measure only is flagged",
+                   len(q_rows) and q_rows.iloc[0]["Verdict"].startswith("disagree"),
+                   f"{q_rows['Verdict'].tolist() if len(q_rows) else 'no rows'}"))
+    dens_rows = conc[(conc["Metric"] == "Dens")
+                     & (conc["Term"].astype(str).str.contains("vs"))]
+    checks.append(("…while an effect found under both is called concordant",
+                   len(dens_rows)
+                   and dens_rows.iloc[0]["Verdict"] == "agree (both significant)",
+                   f"{dens_rows['Verdict'].tolist() if len(dens_rows) else 'no rows'}"))
+
+    text = "\n".join(logs)
+    checks.append(("the log says how many conclusions moved",
+                   "conclusions:" in text and "agree across" in text,
+                   text[-400:]))
+    checks.append(("the summary records the comparison",
+                   "measures" in result.summary
+                   and result.summary["measures"]["500mslag"]["n_pairs"] == 1,
+                   f"{list(result.summary)}"))
+
+    # The figures, through the same catalogue the viewer and the report use.
+    stored = load_results(folder, ds.for_lag("500mslag"), lag="500mslag")
+    keys = {f.key for f in stats_figures(stored)}
+    checks.append(("the comparison's figures are catalogued",
+                   {"measure_agreement", "measure_differences",
+                    "measure_concordance"} <= keys, f"{sorted(keys)}"))
+    drawn = {p.name for p in folder.glob("5F*.png")}
+    checks.append(("…and drawn",
+                   len(drawn) >= 3, f"{sorted(drawn)}"))
+    checks.append(("nothing was skipped",
+                   not result.skipped, f"{result.skipped[:3]}"))
+    return checks
+
+
+def main() -> int:
+    print("=" * 70)
+    print("CAT-NAP: several measures of activity in one run")
+    print("=" * 70)
+
+    tmp, raw, recordings = _dataset()
+    total_pass = total = 0
+    try:
+        sections: list[tuple[str, list[Check]]] = []
+        sections.append(("A — what goes where:", _layout_checks()))
+        run_checks, two_root = _run_checks(tmp, raw, recordings)
+        sections.append(("B — a two-measure run's output folder:", run_checks))
+        sections.append(("C — the measures stay independent:",
+                         _independence_checks(tmp, raw, recordings, two_root)))
+        sections.append(("D — the statistics step compares them:",
+                         _stats_checks(tmp)))
+        for title, checks in sections:
+            p, n = _report(title, checks)
+            total_pass += p
+            total += n
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print("\n" + "=" * 70)
+    print(f"Total: {total_pass}/{total} checks passed")
+    print("=" * 70)
+    return 0 if total_pass == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test_catnap_roi_mismatch.py
+++ b/python/test_catnap_roi_mismatch.py
@@ -173,7 +173,7 @@ def _early_and_isolated_checks() -> list[Check]:
             params.twop_activity = "peaks"     # the path that denoises
             out = catnap_pipeline._compute_recording(
                 params, RecordingInfo(filename="rec1", div=21.0, group="WT"),
-                plane0, log.append, np.random.default_rng(0),
+                plane0, log.append,
             )
         finally:
             denoising.process_suite2p_folder = real_denoise

--- a/python/test_remote_cache.py
+++ b/python/test_remote_cache.py
@@ -414,6 +414,71 @@ def _redaction_checks() -> list[Check]:
     return checks
 
 
+def _ops_shortcut_checks() -> list[Check]:
+    """``ops.npy`` is 96% of a suite2p folder and holds two small fields.
+
+    Once an earlier run has extracted them into the ``ops_fields.npz`` sidecar,
+    the loader never opens ``ops.npy`` again — so a re-run of the same dataset
+    with different parameters must not pay to download it a second time.
+    """
+    from meanap.catnap.derived import OPS_CACHE_NAME
+    from meanap.remote.source import RecordingSource
+
+    checks: list[Check] = []
+    MB = 1_000_000
+    folder = {
+        "rec1/suite2p/plane0/F.npy": 4 * MB,
+        "rec1/suite2p/plane0/stat.npy": 5 * MB,
+        "rec1/suite2p/plane0/iscell.npy": 1 * MB,
+        "rec1/suite2p/plane0/spks.npy": 4 * MB,
+        "rec1/suite2p/plane0/ops.npy": 463 * MB,
+        "rec1/suite2p/plane0/Fneu.npy": 4 * MB,   # never wanted
+    }
+
+    def build(tmp: str, derived: Path | None):
+        store = FakeStore(dict(folder))
+        cache = FileCache(root=Path(tmp) / "c", budget_bytes=2000 * MB)
+        return store, RecordingSource(store=store, cache=cache, log=lambda m: None,
+                                      derived_root=derived)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store, source = build(tmp, None)
+        source.plane0("rec1")
+        names = {Path(p).name for p in store.fetched}
+        checks.append(("with no sidecar, ops.npy is fetched as before",
+                       "ops.npy" in names, sorted(names)))
+        checks.append(("files the pipeline never opens stay skipped",
+                       "Fneu.npy" not in names, sorted(names)))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        derived = Path(tmp) / "derived"
+        (derived / "rec1" / "plane0").mkdir(parents=True)
+        (derived / "rec1" / "plane0" / OPS_CACHE_NAME).write_bytes(b"x")
+        store, source = build(tmp, derived)
+        source.plane0("rec1")
+        names = {Path(p).name for p in store.fetched}
+        checks.append(("with a sidecar, ops.npy is not fetched",
+                       "ops.npy" not in names, sorted(names)))
+        checks.append(("everything the loader still reads is fetched",
+                       {"F.npy", "stat.npy", "iscell.npy", "spks.npy"} <= names,
+                       sorted(names)))
+        moved = sum(store.sizes[p.strip("/")] for p in store.fetched)
+        checks.append(("the transfer drops by ~96%",
+                       moved < 0.05 * sum(folder.values()),
+                       f"{moved / 1e6:.0f} MB of {sum(folder.values()) / 1e6:.0f} MB"))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        derived = Path(tmp) / "derived"
+        (derived / "other" / "plane0").mkdir(parents=True)
+        (derived / "other" / "plane0" / OPS_CACHE_NAME).write_bytes(b"x")
+        store, source = build(tmp, derived)
+        source.plane0("rec1")
+        names = {Path(p).name for p in store.fetched}
+        checks.append(("another recording's sidecar does not count",
+                       "ops.npy" in names, sorted(names)))
+    return checks
+
+
 def main() -> int:
     print("=" * 70)
     print("Remote data: store protocol, cache, budgeting, redaction")
@@ -426,6 +491,8 @@ def main() -> int:
         ("D — concurrent fetch, eviction and pinning:", _concurrency_checks),
         ("E — disk budgeting:", _budget_checks),
         ("F — share links don't travel in bundles:", _redaction_checks),
+        ("G — a cached ops sidecar spares the biggest download:",
+         _ops_shortcut_checks),
     ]:
         p, n = _report(title, build())
         total_pass += p

--- a/src/meanap/catnap/activities.py
+++ b/src/meanap/catnap/activities.py
@@ -1,0 +1,166 @@
+"""Which calcium measure(s) a CAT-NAP run analyses, and what to call each one.
+
+``Params.twop_activity`` names one measure of neuronal activity — detected
+calcium events (``peaks``), the deconvolved/denoised trace (``denoised F``),
+raw fluorescence (``F``), or suite2p's own spike estimate (``spks``). Every
+adjacency matrix, activity statistic and network metric in a CAT-NAP run is
+computed *through* that choice, and the choice is not neutral: ``peaks`` gives
+an event-time STTC network, the other three give a binned correlation network,
+and the two do not produce the same numbers or necessarily the same conclusion.
+
+That made "which measure did you use?" an unanswerable-by-inspection question
+about every published CAT-NAP result. ``Params.twop_activities`` lets one run
+analyse several measures over the same recordings, so the question becomes an
+axis of the output rather than a decision buried in a settings file — see
+:mod:`meanap.stats.measures` for the analysis that reads it back.
+
+Everything here is deliberately tiny and dependency-free: it is imported by the
+pipeline, the GUI, the statistics step and the report, and none of them should
+have to agree on the spelling of ``denoisedF`` by copying it.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ACTIVITY_TYPES",
+    "BY_ACTIVITY_DIR",
+    "activity_output_root",
+    "activity_params",
+    "activity_subtrees",
+    "ACTIVITY_SLUGS",
+    "DEFAULT_ACTIVITY",
+    "activity_from_slug",
+    "activity_slug",
+    "activity_types",
+    "is_multi_activity",
+    "primary_activity",
+]
+
+#: Every measure ``suite2p_to_adjm`` understands, in the order the GUI lists
+#: them: the default first, then the two derived traces, then the raw one.
+ACTIVITY_TYPES: tuple[str, ...] = ("peaks", "denoised F", "F", "spks")
+
+DEFAULT_ACTIVITY = "peaks"
+
+#: Filesystem-safe name for each measure. ``denoised F`` is the only one that
+#: needs it, but the mapping is total so callers never have to special-case.
+#: These strings end up in folder names (``denoisedF_1000msbin/``) and in file
+#: names (``rec_denoisedF_catnap.npz``), so they are part of the output format
+#: and must not be re-spelled casually.
+ACTIVITY_SLUGS: dict[str, str] = {
+    "peaks": "peaks",
+    "denoised F": "denoisedF",
+    "F": "F",
+    "spks": "spks",
+}
+
+
+def activity_slug(activity: str) -> str:
+    """Filesystem-safe name for *activity* (``'denoised F'`` → ``'denoisedF'``)."""
+    name = str(activity)
+    if name in ACTIVITY_SLUGS:
+        return ACTIVITY_SLUGS[name]
+    # An unknown measure is still worth naming rather than crashing on: strip
+    # what a path cannot carry and keep going.
+    return "".join(c for c in name if c.isalnum() or c in "-_") or "activity"
+
+
+def activity_from_slug(slug: str) -> str | None:
+    """Reverse :func:`activity_slug` for the known measures, else ``None``.
+
+    Used when reading a run back off disk — a file name carries the slug, and
+    the tables and figures want the measure's real name.
+    """
+    for name, known in ACTIVITY_SLUGS.items():
+        if known == str(slug):
+            return name
+    return None
+
+
+def activity_types(params) -> list[str]:
+    """The measures this run analyses, primary first, de-duplicated.
+
+    ``Params.twop_activities`` empty (the default, and what every settings file
+    written before multi-measure runs existed carries) means "just
+    ``twop_activity``" — so a run configured the old way behaves exactly as it
+    did, down to the folder names.
+
+    ``twop_activity`` is always first in the list whether or not it also
+    appears in ``twop_activities``: it is the *primary* measure, the one whose
+    outputs keep the unprefixed names, and demoting it because the user ticked
+    the boxes in a different order would silently rename half a run's files.
+    """
+    primary = str(getattr(params, "twop_activity", DEFAULT_ACTIVITY)
+                  or DEFAULT_ACTIVITY)
+    out = [primary]
+    for name in (getattr(params, "twop_activities", None) or ()):
+        name = str(name)
+        if name and name not in out:
+            out.append(name)
+    return out
+
+
+def primary_activity(params) -> str:
+    """The measure whose outputs carry the run's unprefixed names."""
+    return activity_types(params)[0]
+
+
+def is_multi_activity(params) -> bool:
+    """Whether this run analyses more than one measure."""
+    return len(activity_types(params)) > 1
+
+
+# ── output layout ────────────────────────────────────────────────────────────
+
+#: Folder holding the extra measures' outputs, one complete run subtree each.
+#:
+#: The *primary* measure keeps the top-level tree it has always had, so a run
+#: that adds a second measure does not move a single file that a one-measure
+#: run would have written. Each subtree below is a full, self-contained output
+#: folder — its own ``ExperimentMatFiles``, ``2_NeuronalActivity``,
+#: ``4_NetworkActivity``, ``netmet_results.json`` and ``params.json`` naming
+#: that one measure — so the report, the bundle viewer and every tool that
+#: already knows how to read a run folder can be pointed straight at it.
+#:
+#: The pooled tables at the top level are the exception, and the reason the
+#: subtrees are not simply separate runs: ``NetworkActivity_RecordingLevel.csv``
+#: and its three siblings carry every measure's rows with an ``ActivityType``
+#: column, which is what lets step 5 compare the measures against each other
+#: rather than against nothing.
+BY_ACTIVITY_DIR = "ByActivityType"
+
+
+def activity_output_root(output_root, params, activity: str):
+    """Where *activity*'s figures, state files and JSON go within a run.
+
+    The primary measure of any run — and every measure of a single-measure run
+    — gets *output_root* itself.
+    """
+    from pathlib import Path
+
+    root = Path(output_root)
+    if not is_multi_activity(params) or activity == primary_activity(params):
+        return root
+    return root / BY_ACTIVITY_DIR / activity_slug(activity)
+
+
+def activity_params(params, activity: str):
+    """*params* as if the run had been configured for *activity* alone.
+
+    Everything downstream of the measure choice — the lag-vs-bin naming, the
+    adjacency builder, the activity statistics, the figure titles — already
+    reads ``twop_activity`` and knows nothing about multi-measure runs. Handing
+    each measure its own single-measure ``Params`` is what keeps it that way:
+    the per-measure half of the pipeline is the same code doing the same thing,
+    pointed at a different measure and a different output root.
+    """
+    import dataclasses
+
+    return dataclasses.replace(params, twop_activity=str(activity),
+                               twop_activities=())
+
+
+def activity_subtrees(output_root, params):
+    """``[(activity, params_for_it, output_root_for_it), …]``, primary first."""
+    return [(a, activity_params(params, a), activity_output_root(output_root, params, a))
+            for a in activity_types(params)]

--- a/src/meanap/catnap/adjacency.py
+++ b/src/meanap/catnap/adjacency.py
@@ -54,10 +54,37 @@ class Suite2pAdjmResult:
 
 
 def _corr_columns(x: np.ndarray) -> np.ndarray:
-    """MATLAB ``corr(X)`` — Pearson correlation between the columns (units) of X."""
+    """Pearson correlation between the columns (units) of X, without self-edges.
+
+    **Deliberate divergence from MATLAB.** ``suite2pToAdjm.m`` (lines 133-141)
+    stores ``double(corr(...))`` as the adjacency and nothing downstream clears
+    it, so every node carries a self-loop of weight 1 — the largest weight in
+    the matrix. The STTC/ETTC path has always returned a zero diagonal, so the
+    two connectivity measures were not producing comparable graphs.
+
+    What that corrupts, for anyone reading old correlation-mode results:
+
+    * ``Dens`` counts ``triu(adjM)`` *including* the diagonal against a
+      denominator that excludes it, so density is inflated by ``2/(n-1)`` and
+      can exceed 1 — which is how this was found.
+    * ``NS`` (``strengths_und``) gains exactly 1.0 per node.
+    * ``sigEdgesMean`` / ``sigEdgesTop10`` pool ``adjM[abs(adjM) > 0]``, so n
+      maximum-weight self-edges enter the distribution; the top-10% mean is
+      hit hardest.
+
+    ``ND`` and ``MEW`` are unaffected: ``find_node_deg_edge_weight`` subtracts
+    ``eye(n)`` before thresholding.
+
+    A run that needs the old behaviour bit-for-bit can compare against a
+    pre-fix bundle; nothing else in the pipeline depends on the diagonal.
+    """
     if x.shape[1] == 0:
         return np.zeros((0, 0))
-    return np.corrcoef(x, rowvar=False)
+    c = np.corrcoef(x, rowvar=False)
+    # corrcoef of a constant column is NaN throughout; that is a separate
+    # concern, handled downstream. Only the self-edges are cleared here.
+    np.fill_diagonal(c, 0.0)
+    return c
 
 
 def frames_per_bin(bin_ms: float, fs: float) -> int:

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -781,7 +781,8 @@ def _build_source(params: Params, log):
         f"prefetch depth {params.prefetch_depth})")
     log(f"  derived {params.derived_data_folder}")
     return RecordingSource(
-        store=store, cache=FileCache(root=cache_dir, budget_bytes=budget), log=log)
+        store=store, cache=FileCache(root=cache_dir, budget_bytes=budget), log=log,
+        derived_root=params.derived_data_folder or None)
 
 
 def _reload_for_plots(params, rec, state, log, source=None):

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -32,6 +32,10 @@ import numpy as np
 import pandas as pd
 
 from meanap.params import Params
+from meanap.catnap.activities import (
+    BY_ACTIVITY_DIR, activity_slug, activity_subtrees, activity_types,
+    is_multi_activity, primary_activity,
+)
 from meanap.catnap.adjacency import suite2p_to_adjm
 from meanap.catnap.group_plots import (
     SUBNET_GRAPH_METRICS, SUBNET_NODE_METRICS, twop_stats_frames,
@@ -87,9 +91,15 @@ class _MetricsTask:
     lag_independent: dict
     params: Params
     min_nodes: int
+    #: Which measure of activity this adjacency was built from. Carried so the
+    #: results a worker hands back can be routed to the right measure's tree —
+    #: ``params.twop_activity`` says the same thing, but a worker result is
+    #: matched on the pair, and reading it off the task is what makes that
+    #: explicit rather than implied.
+    activity: str = ""
 
 
-def _metrics_worker(task: _MetricsTask) -> tuple[str, dict]:
+def _metrics_worker(task: _MetricsTask) -> tuple[str, str, dict]:
     """Network metrics for every lag of one recording. Runs in a pool worker.
 
     Module-level and picklable-in/out because ``spawn`` re-imports this module
@@ -112,7 +122,7 @@ def _metrics_worker(task: _MetricsTask) -> tuple[str, dict]:
         # under `if e == 1` and saving them on the first lag field.
         metrics.update(task.lag_independent)
         out[f"{lag_ms}mslag"] = metrics
-    return task.filename, out
+    return task.activity, task.filename, out
 
 
 #: ``Params.startAnalysisStep`` at or above which a CAT-NAP run reads the prior
@@ -192,6 +202,84 @@ def _log_sampling_rates(states: dict, log) -> None:
         "not confounded with the groups being compared.")
 
 
+def _validated_measures(params: Params, log) -> Params:
+    """Drop measures of activity nothing can build a network from.
+
+    ``suite2p_to_adjm`` raises on an unknown measure, and it would do so partway
+    through the first recording — after the loading and the denoising, with the
+    run already committed. A typo in a settings file is worth catching here, in
+    one line, rather than as a traceback ten minutes in.
+
+    The primary measure is never dropped: if *that* is wrong the run has nothing
+    to do, and failing loudly at the first recording is the right outcome.
+    """
+    import dataclasses
+
+    from meanap.catnap.activities import ACTIVITY_TYPES
+
+    measures = activity_types(params)
+    unknown = [a for a in measures[1:] if a not in ACTIVITY_TYPES]
+    if not unknown:
+        return params
+    log(f"  Ignoring unknown measure(s) of activity: {', '.join(map(repr, unknown))} "
+        f"— expected one of {', '.join(ACTIVITY_TYPES)}")
+    kept = tuple(a for a in measures if a not in unknown)
+    return dataclasses.replace(params,
+                               twop_activities=kept if len(kept) > 1 else ())
+
+
+def _any_states(states: dict[str, dict]) -> dict:
+    """The first non-empty measure's states, for the facts they all agree on.
+
+    Frame rate, duration and cell count come out of the recording rather than
+    out of the measure, so anything reporting them can take whichever measure
+    happens to have loaded.
+    """
+    for by_rec in states.values():
+        if by_rec:
+            return by_rec
+    return {}
+
+
+def _prepare_activity_subtrees(params: Params, recordings, subtrees, log) -> None:
+    """Give each extra measure a complete, self-contained run folder.
+
+    The folder tree, so figures land where every other part of MEA-NAP expects
+    them, and a ``params.json`` describing *that measure alone* — which is what
+    lets the HTML report, the bundle viewer and ``meanap-stats`` be pointed
+    straight at ``ByActivityType/denoisedF/`` and read it as an ordinary run.
+    Without the params file they would read the parent run's, and label every
+    figure with the primary measure's name.
+    """
+    from meanap.params import save_params
+    from meanap.pipeline.output_folders import create_output_folders
+
+    groups = sorted({rec.group for rec in recordings})
+    primary = primary_activity(params)
+    for activity, (p_act, root_act) in subtrees.items():
+        if activity == primary:
+            continue  # the run folder itself, already created by the runner
+        try:
+            create_output_folders(root_act.parent, root_act.name, groups,
+                                  include_not_box_plots=params.include_not_box_plots)
+            save_params(p_act, root_act)
+        except Exception as e:
+            log(f"  Warning: could not prepare the {activity!r} output folder "
+                f"({root_act}): {e}")
+
+
+def _params_for(params: Params, activity: str) -> Params:
+    """*params* as a single-measure configuration for *activity*.
+
+    Cached per call site rather than per measure because it is cheap and the
+    alternative — threading an ``activity`` argument through every function
+    below — would put the same information in two places.
+    """
+    from meanap.catnap.activities import activity_params
+
+    return activity_params(params, activity)
+
+
 def _spike_counts(res, twop_activity: str) -> np.ndarray:
     """Per-node activity count used for the active-node inclusion test.
 
@@ -253,6 +341,18 @@ def run_catnap_pipeline(
     — the raw fluorescence matrices are hundreds of MB per recording and are
     re-read from disk in phase 3 for the trace figures.
 
+    **Several measures of activity.** With ``Params.twop_activities`` set, all
+    three phases carry a measure axis: every per-recording dict below is
+    ``{measure: {recording: …}}``, phase 2 places cartography boundaries once
+    per measure, and phase 3 draws each measure's figures into its own output
+    subtree (:mod:`meanap.catnap.activities`). Only phase 1's *loading* is
+    shared — the raw data is read and denoised once per recording however many
+    measures are asked for, which is what makes this one run rather than N.
+    Nothing else is: an event network and a binned correlation network of the
+    same recording are two different networks, and pooling anything across them
+    — boundaries, metric ranges, the RNG stream — would make each measure's
+    numbers depend on which others happened to be in the run.
+
     **Resuming.** Phase 1 writes each recording's adjacency + activity stats to
     ``ExperimentMatFiles/<rec>_catnap.npz`` (:mod:`meanap.catnap.store`). When
     ``params.start_analysis_step >= 4`` it reads that back from ``locator``
@@ -288,6 +388,21 @@ def run_catnap_pipeline(
     source.progress = progress
 
     min_nodes = params.min_number_of_nodes_to_cal_net_met
+    params = _validated_measures(params, log)
+    measures = activity_types(params)
+    # Each measure's outputs go in a complete run subtree of their own; the
+    # primary measure's *is* the run folder, so a one-measure run writes
+    # exactly what it always did. See meanap.catnap.activities.
+    subtrees = {a: (pa, root)
+                for a, pa, root in activity_subtrees(output_root, params)}
+    if is_multi_activity(params):
+        log("  Measures of activity: " + ", ".join(measures)
+            + f" (primary: {measures[0]})")
+        log(f"  Each extra measure writes a full run folder under "
+            f"{BY_ACTIVITY_DIR}/; the tables in this folder pool all of them "
+            "with an ActivityType column.")
+        _prepare_activity_subtrees(params, recordings, subtrees, log)
+
     net_dir = output_root / "4_NetworkActivity"
     net_dir.mkdir(parents=True, exist_ok=True)
     state_dir = output_root / ADJM_SUBDIR
@@ -295,11 +410,16 @@ def run_catnap_pipeline(
 
     resuming = params.start_analysis_step >= RESUME_STEP
 
-    all_results: dict[str, dict] = {}
-    all_stats: dict[str, dict] = {}
-    all_channels: dict[str, np.ndarray] = {}
-    states: dict[str, RecordingState] = {}
-    subnetwork_tables: dict[str, list] = {"summary": [], "node": [], "mix": []}
+    # Every one of these is now ``{measure: {recording: …}}``. Two measures of
+    # the same recording are two different networks, so nothing about them —
+    # not the cartography boundaries, not the batch metric ranges, not a single
+    # figure — may be pooled across the outer key.
+    all_results: dict[str, dict[str, dict]] = {a: {} for a in measures}
+    all_stats: dict[str, dict[str, dict]] = {a: {} for a in measures}
+    all_channels: dict[str, dict[str, np.ndarray]] = {a: {} for a in measures}
+    states: dict[str, dict[str, RecordingState]] = {a: {} for a in measures}
+    subnetwork_tables: dict[str, dict[str, list]] = {
+        a: {"summary": [], "node": [], "mix": []} for a in measures}
 
     progress.begin("catnap.compute", items=len(recordings))
 
@@ -337,12 +457,17 @@ def run_catnap_pipeline(
     )
     # Filled by the pool as workers finish, so in completion order — see the
     # re-ordering into ``all_results`` after the loop.
-    metric_results: dict[str, dict] = {}
+    metric_results: dict[tuple[str, str], dict] = {}
+    # One progress item per recording however many measures it is analysed
+    # under, so the bar still counts what the log's per-recording lines count.
+    outstanding: dict[str, int] = {}
 
-    def _metrics_done(result: tuple[str, dict]) -> None:
-        name, rec_results = result
-        metric_results[name] = rec_results
-        progress.item_done(name)
+    def _metrics_done(result: tuple[str, str, dict]) -> None:
+        activity, name, rec_results = result
+        metric_results[(activity, name)] = rec_results
+        outstanding[name] = outstanding.get(name, 0) - 1
+        if outstanding.get(name, 0) <= 0:
+            progress.item_done(name)
 
     with StreamingPool(n_metric_workers, on_result=_metrics_done,
                        cancel_check=should_cancel,
@@ -358,45 +483,60 @@ def run_catnap_pipeline(
             # activity stats are already in *this* folder, so load them rather than
             # redoing the STTC and the circular-shift thresholding, which is the
             # expensive half of the CAT-NAP path.
-            continued = already_done(
-                params, output_root,
-                state_dir / f"{rec.filename}{CATNAP_SUFFIX}", log)
+            # Every measure has to be there: a continued run that found only
+            # the primary measure's file would quietly drop the others, and the
+            # recording would be missing from exactly the comparison the extra
+            # measures were run for.
+            continued = all(
+                already_done(
+                    params, output_root,
+                    output_root / (_state_subdir(params, activity) or "")
+                    / ADJM_SUBDIR / f"{rec.filename}{CATNAP_SUFFIX}", log)
+                for activity in measures)
             if continued:
                 log(f"  [{rec.filename}] already computed — loading")
 
             loaded = (
-                _load_recording(locator, rec, plane0, log) if (resuming or continued)
-                else _compute_recording(params, rec, plane0, log,
-                                        make_rng(params.random_seed, "catnap",
-                                                 rec.filename))
+                _load_recording(locator, params, rec, plane0, log)
+                if (resuming or continued)
+                else _compute_recording(params, rec, plane0, log)
             )
-            if loaded is None:
+            if not loaded:
                 if not resuming:
                     source.unpin(rec.filename)
                     source.release(rec.filename)
                 continue
-            state, stats = loaded
 
             # Always re-read: cheap, and it means a resumed run picks up an edited
             # cell-type spreadsheet instead of freezing the first run's grouping.
             # A bundle carries a copy of the markers for recipients who have no
             # spreadsheet at all, so the live reading only wins when it found one.
-            groups, markers = _resolve_cell_types(params, rec, state.channels, log)
-            if groups is not None or state.groups is None:
-                state.groups = groups
-            if markers is not None or state.markers is None:
-                state.markers = markers
+            # Read once and shared: cell identity is a property of the field of
+            # view, not of how activity in it was measured.
+            first_state = next(iter(loaded.values()))[0]
+            groups, markers = _resolve_cell_types(
+                params, rec, first_state.channels, log)
 
-            all_stats[rec.filename] = stats
-            all_channels[rec.filename] = state.channels
-            states[rec.filename] = state
+            outstanding[rec.filename] = len(loaded)
+            for activity, (state, stats) in loaded.items():
+                if groups is not None or state.groups is None:
+                    state.groups = groups
+                if markers is not None or state.markers is None:
+                    state.markers = markers
 
-            try:
-                save_recording_state(
-                    state_dir / f"{rec.filename}{CATNAP_SUFFIX}", state, stats)
-            except Exception as e:
-                log(f"  [{rec.filename}] warning: could not save step-2 data for "
-                    f"re-runs: {e}")
+                all_stats[activity][rec.filename] = stats
+                all_channels[activity][rec.filename] = state.channels
+                states[activity][rec.filename] = state
+
+                sub_state_dir = (output_root / (_state_subdir(params, activity) or "")
+                                 / ADJM_SUBDIR)
+                try:
+                    sub_state_dir.mkdir(parents=True, exist_ok=True)
+                    save_recording_state(
+                        sub_state_dir / f"{rec.filename}{CATNAP_SUFFIX}", state, stats)
+                except Exception as e:
+                    log(f"  [{rec.filename}] warning: could not save step-2 data for "
+                        f"re-runs: {e}")
 
             # Everything derived from this recording is now on disk, so its raw
             # files are no longer needed — unless the trace figures still want them
@@ -409,20 +549,24 @@ def run_catnap_pipeline(
             # Hand the expensive half off. ``submit`` blocks once the pool is
             # saturated, which is what stops the stream fetching further ahead
             # than the metrics can keep up with.
-            kind = timescale_kind(params)
-            lags = [lag for lag, _ in sorted_adjm_items(state.adjMs)]
-            log(f"  [{rec.filename}] network metrics "
-                f"({kind}{'' if len(lags) == 1 else 's'} "
-                f"{', '.join(str(lag) for lag in lags)} ms)…")
-            pool.submit(_metrics_worker, _MetricsTask(
-                filename=rec.filename,
-                adjMs=state.adjMs,
-                spike_counts=state.spike_counts,
-                duration_s=state.duration_s,
-                lag_independent=state.lag_independent,
-                params=params,
-                min_nodes=min_nodes,
-            ))
+            for activity, (state, _stats) in loaded.items():
+                p_act = subtrees[activity][0]
+                kind = timescale_kind(p_act)
+                lags = [lag for lag, _ in sorted_adjm_items(state.adjMs)]
+                note = f" [{activity}]" if len(loaded) > 1 else ""
+                log(f"  [{rec.filename}]{note} network metrics "
+                    f"({kind}{'' if len(lags) == 1 else 's'} "
+                    f"{', '.join(str(lag) for lag in lags)} ms)…")
+                pool.submit(_metrics_worker, _MetricsTask(
+                    filename=rec.filename,
+                    adjMs=state.adjMs,
+                    spike_counts=state.spike_counts,
+                    duration_s=state.duration_s,
+                    lag_independent=state.lag_independent,
+                    params=p_act,
+                    min_nodes=min_nodes,
+                    activity=activity,
+                ))
 
         pool.drain()
 
@@ -435,85 +579,133 @@ def run_catnap_pipeline(
     # so everything downstream — the cartography barrier that pools PC/Z across
     # recordings, the batch metric bounds, the CSVs — sees exactly the sequence
     # it saw when this loop was serial.
-    for rec in recordings:
-        if rec.filename in metric_results:
-            all_results[rec.filename] = metric_results[rec.filename]
+    for activity in measures:
+        for rec in recordings:
+            if (activity, rec.filename) in metric_results:
+                all_results[activity][rec.filename] = \
+                    metric_results[(activity, rec.filename)]
 
-    _log_sampling_rates(states, log)
+    # Acquisition rate is a property of the recording, so it is the same under
+    # every measure — reported once, from whichever measure has the states.
+    _log_sampling_rates(_any_states(states), log)
 
     # ── Phase 2: reduce — data-driven node-cartography boundaries ─────────────
     # Pool PC/Z over the whole batch and re-place the six role boundaries, then
     # re-classify every node (port of MEApipeline.m's autoSetCartographyBoundaries
     # barrier). Without this the roles come from the fixed Params defaults and
     # almost every node lands in role 1.
-    if params.auto_set_cartography_boundaries and all_results:
-        check_cancel(should_cancel)
-        # ``out_dir=None`` suppresses the pooled PC/Z landscape scatter — a
-        # figure, and one the bundle's metrics can redraw.
-        _apply_cartography_boundaries(
-            params, all_results, log,
-            out_dir=None if params.express_mode else net_dir)
-
-    # Pooled node-metric ranges, so the ``_scaled`` network plots of different
-    # recordings share an axis.
-    batch_bounds = {m: _batch_metric_bounds(all_results, m)
-                    for m in ("ND", "NS", "BC", "PC", "Eloc")}
+    #
+    # Per measure, never pooled across them: an STTC event network and a binned
+    # correlation network have PC/Z distributions that do not live on the same
+    # scale, so one shared set of boundaries would put the two measures' roles
+    # in different places and then invite the reader to compare them.
+    batch_bounds: dict[str, dict] = {}
+    for activity in measures:
+        p_act, root_act = subtrees[activity]
+        results_act = all_results[activity]
+        if params.auto_set_cartography_boundaries and results_act:
+            check_cancel(should_cancel)
+            # ``out_dir=None`` suppresses the pooled PC/Z landscape scatter — a
+            # figure, and one the bundle's metrics can redraw.
+            _apply_cartography_boundaries(
+                p_act, results_act, log,
+                out_dir=None if params.express_mode
+                else root_act / "4_NetworkActivity")
+        # Pooled node-metric ranges, so the ``_scaled`` network plots of
+        # different recordings share an axis.
+        batch_bounds[activity] = {m: _batch_metric_bounds(results_act, m)
+                                  for m in ("ND", "NS", "BC", "PC", "Eloc")}
 
     # ── Phase 3: plot ─────────────────────────────────────────────────────────
     progress.phase_done()
     progress.begin("catnap.plot", items=len(recordings))
     for rec in recordings:
-        state = states.get(rec.filename)
-        if state is None:
+        # Whichever measures this recording has, not necessarily the primary:
+        # resuming a two-measure run against a one-measure prior analysis can
+        # leave a recording with only the *other* measure, and dropping it from
+        # the figures because the primary is missing would lose work that was
+        # done.
+        present = [a for a in measures if rec.filename in states[a]]
+        if not present:
             continue
         check_cancel(should_cancel)
         # The backdrop came from phase 1; this only re-opens the folder when
-        # per-cell trace figures were asked for.
-        data, background = _reload_for_plots(params, rec, state, log, source)
-        # Persisted, not just drawn: figure 12 is the one plot that needs pixels
-        # rather than metrics, so a bundle has to carry the projection or it
-        # could never be reconstructed.
-        try:
-            save_background(
-                state_dir / f"{rec.filename}{BACKGROUND_SUFFIX}", background)
-        except Exception as e:
-            log(f"  [{rec.filename}] warning: could not save mean projection: {e}")
+        # per-cell trace figures were asked for — once per recording, not once
+        # per measure, because the traces it draws are the raw and denoised
+        # fluorescence and neither depends on the measure.
+        data, _ = _reload_for_plots(
+            params, rec, states[present[0]][rec.filename], log, source)
+        _plot_traces(params, rec, output_root, log, data)
 
-        _plot_recording(params, rec, state, all_results[rec.filename],
-                        batch_bounds, output_root, log, data, background)
+        for activity in present:
+            state = states[activity][rec.filename]
+            if rec.filename not in all_results[activity]:
+                continue
+            p_act, root_act = subtrees[activity]
+            # Persisted, not just drawn: figure 12 is the one plot that needs
+            # pixels rather than metrics, so a bundle has to carry the
+            # projection or it could never be reconstructed. Written into every
+            # measure's subtree so each one opens as a complete run folder.
+            try:
+                save_background(
+                    root_act / ADJM_SUBDIR / f"{rec.filename}{BACKGROUND_SUFFIX}",
+                    state.background)
+            except Exception as e:
+                log(f"  [{rec.filename}] warning: could not save mean projection: {e}")
 
-        if params.twop_subnetwork_analysis:
-            _run_subnetwork_analysis(
-                params, rec, state, all_results[rec.filename],
-                min_nodes, output_root, subnetwork_tables, log,
-                make_rng(params.random_seed, "catnap_subnetwork", rec.filename),
-                background,
-            )
+            _plot_recording(p_act, rec, state, all_results[activity][rec.filename],
+                            batch_bounds[activity], root_act, log, state.background)
+
+            if params.twop_subnetwork_analysis:
+                _run_subnetwork_analysis(
+                    p_act, rec, state, all_results[activity][rec.filename],
+                    min_nodes, root_act, subnetwork_tables[activity], log,
+                    make_rng(params.random_seed, "catnap_subnetwork", rec.filename),
+                    state.background,
+                )
         progress.item_done(rec.filename)
 
     progress.phase_done()
     progress.begin("batch", items=1)
-    _save_catnap_results(recordings, all_results, all_stats, all_channels, net_dir, log,
-                         sampling_rates={name: float(st.fs)
-                                         for name, st in states.items() if st.fs})
-    _save_subnetwork_results(subnetwork_tables, net_dir, log)
-    _plot_group_comparisons(
-        params, recordings, all_results, all_stats, all_channels,
-        subnetwork_tables, states, output_root, log,
-    )
+    rates = {name: float(st.fs)
+             for name, st in _any_states(states).items() if st.fs}
+    _save_catnap_results(params, recordings, all_results, all_stats, all_channels,
+                         output_root, log, sampling_rates=rates)
+    _save_subnetwork_results(params, subnetwork_tables, output_root, log)
+    for activity in measures:
+        p_act, root_act = subtrees[activity]
+        _plot_group_comparisons(
+            p_act, recordings, all_results[activity], all_stats[activity],
+            all_channels[activity], subnetwork_tables[activity],
+            states[activity], root_act, log,
+        )
     progress.phase_done()
     log("  CAT-NAP pipeline complete.")
 
 
 def _compute_recording(
-    params: Params, rec: RecordingInfo, plane0: Path, log, rng,
-) -> tuple[RecordingState, dict] | None:
-    """Build one recording's adjacency + activity stats from its suite2p folder.
+    params: Params, rec: RecordingInfo, plane0: Path, log,
+) -> dict[str, tuple[RecordingState, dict]] | None:
+    """Build one recording's adjacency + activity stats, for every measure.
 
     This is the expensive half of the CAT-NAP path — denoising, then STTC with
     ``prob_thresh_rep_num`` circular-shift surrogates per lag — and the half a
     step-4 resume skips. Returns ``None`` (having logged why) when the
-    recording has no suite2p output to read.
+    recording has no suite2p output to read; otherwise ``{measure: (state,
+    stats)}`` with one entry per measure the run analyses.
+
+    The loading and the denoising happen **once** no matter how many measures
+    are asked for. That is the whole reason a multi-measure run is one run
+    rather than several: the fluorescence matrices are hundreds of MB and the
+    peak detection is not cheap, and every measure is derived from the same
+    pass over them. What is genuinely per-measure — the adjacency, the activity
+    statistics, the active-node counts — is what the loop below repeats.
+
+    Each measure gets a generator seeded identically, not a shared one drawn
+    down in sequence. A stream shared across measures would make ``peaks``
+    produce different numbers depending on which other measures were run beside
+    it, and the first thing anyone does with a multi-measure run is compare it
+    against a single-measure one.
     """
     from meanap.catnap.denoising import process_suite2p_folder
 
@@ -539,7 +731,8 @@ def _compute_recording(
     log(f"  [{rec.filename}] {data.fs:.4g} Hz, {data.n_frames} frames "
         f"({data.duration_s:.0f} s)")
 
-    if params.twop_activity in _NEEDS_DENOISING and (
+    measures = activity_types(params)
+    if any(a in _NEEDS_DENOISING for a in measures) and (
         data.F_denoised is None or params.twop_redo_denoising
     ):
         log(f"  [{rec.filename}] denoising ({data.F.shape[0]} ROIs)…")
@@ -555,36 +748,44 @@ def _compute_recording(
         )
         data = load_suite2p(plane0, derived, rec.filename)
 
-    log(f"  [{rec.filename}] building adjacency matrices…")
-    res = suite2p_to_adjm(
-        data, params.twop_activity, params.func_con_lag_val,
-        remove_nodes_with_no_peaks=params.remove_nodes_with_no_peaks,
-        prob_thresh_tail=params.prob_thresh_tail,
-        prob_thresh_rep_num=params.prob_thresh_rep_num,
-        rng=rng,
-    )
-    _log_bin_rounding(res, log, rec.filename)
-    duration_s = res.F.shape[0] / res.fs
+    out: dict[str, tuple[RecordingState, dict]] = {}
+    for activity in measures:
+        p_act = _params_for(params, activity)
+        label = f"  [{rec.filename}]" + (f" [{activity}]" if len(measures) > 1 else "")
+        log(f"{label} building adjacency matrices…")
+        res = suite2p_to_adjm(
+            data, activity, params.func_con_lag_val,
+            remove_nodes_with_no_peaks=params.remove_nodes_with_no_peaks,
+            prob_thresh_tail=params.prob_thresh_tail,
+            prob_thresh_rep_num=params.prob_thresh_rep_num,
+            rng=make_rng(params.random_seed, "catnap", rec.filename),
+        )
+        _log_bin_rounding(res, log, rec.filename)
+        duration_s = res.F.shape[0] / res.fs
 
-    state = RecordingState(
-        adjMs=res.adjMs, coords=res.coords, channels=res.channels,
-        spike_counts=_spike_counts(res, params.twop_activity),
-        duration_s=duration_s, fs=res.fs, plane0=plane0,
-        coord_norm=res.coord_norm,
-    )
-    state.lag_independent = _lag_independent_metrics(res, params, duration_s, log,
-                                                     rec.filename, rng)
-    # Capture the field-of-view backdrop now, while the (large) suite2p data is
-    # already loaded. Phase 3 used to re-open the whole folder just for this;
-    # doing it here means the raw data is read once per recording, which is what
-    # lets a batch stream through bounded local storage.
-    if params.twop_network_background:
-        state.background = quantize_background(
-            _mean_image_background(data.mean_img, res.coord_norm))
-        if state.background is None:
-            log(f"  [{rec.filename}] note: no mean projection in ops — "
-                "network plots drawn without a backdrop")
-    return state, _activity_stats_for(res, params, duration_s)
+        state = RecordingState(
+            adjMs=res.adjMs, coords=res.coords, channels=res.channels,
+            spike_counts=_spike_counts(res, activity),
+            duration_s=duration_s, fs=res.fs, plane0=plane0,
+            coord_norm=res.coord_norm,
+        )
+        state.lag_independent = _lag_independent_metrics(
+            res, p_act, duration_s, log, rec.filename,
+            make_rng(params.random_seed, "catnap", rec.filename))
+        # Capture the field-of-view backdrop now, while the (large) suite2p data
+        # is already loaded. Phase 3 used to re-open the whole folder just for
+        # this; doing it here means the raw data is read once per recording,
+        # which is what lets a batch stream through bounded local storage. The
+        # normalisation is per measure because ``remove_nodes_with_no_peaks``
+        # can drop nodes and move the centroid range with them.
+        if params.twop_network_background:
+            state.background = quantize_background(
+                _mean_image_background(data.mean_img, res.coord_norm))
+            if state.background is None and activity == measures[0]:
+                log(f"  [{rec.filename}] note: no mean projection in ops — "
+                    "network plots drawn without a backdrop")
+        out[activity] = (state, _activity_stats_for(res, p_act, duration_s))
+    return out
 
 
 def _activity_matrix_for(res, twop_activity: str) -> np.ndarray | None:
@@ -658,33 +859,54 @@ def _event_times_from_matrix(activity: np.ndarray, fs: float) -> list[np.ndarray
 
 
 def _load_recording(
-    locator: InputLocator, rec: RecordingInfo, plane0: Path, log,
-) -> tuple[RecordingState, dict] | None:
+    locator: InputLocator, params: Params, rec: RecordingInfo, plane0: Path, log,
+) -> dict[str, tuple[RecordingState, dict]] | None:
     """Read one recording's step-2 products back from a previous run.
 
     Mirrors MEApipeline.m's ``priorAnalysis == 1 && startAnalysisStep == 4``
     branch, which loads ``adjMs`` out of the prior ``ExperimentMatFiles`` rather
     than calling ``suite2pToAdjm`` again. Returns ``None`` (having logged why)
-    when the file is absent or unreadable, so one bad recording costs the batch
-    that recording and not the run.
+    when *no* measure could be read, so one bad recording costs the batch that
+    recording and not the run.
+
+    A measure whose file is missing is dropped with a warning and the others
+    still load: resuming a two-measure run against a one-measure prior analysis
+    is a reasonable thing to do by accident, and losing the measure that *is*
+    there would be the worse answer.
     """
-    path = locator.catnap_file(rec.filename)
-    if path is None:
-        log(f"  [{rec.filename}] SKIP: no saved step-2 data "
-            f"({rec.filename}{CATNAP_SUFFIX}) to resume from")
+    out: dict[str, tuple[RecordingState, dict]] = {}
+    for activity in activity_types(params):
+        subdir = _state_subdir(params, activity)
+        path = locator.catnap_file(rec.filename, subdir=subdir)
+        note = f" [{activity}]" if is_multi_activity(params) else ""
+        if path is None:
+            log(f"  [{rec.filename}]{note} SKIP: no saved step-2 data "
+                f"({rec.filename}{CATNAP_SUFFIX}) to resume from")
+            continue
+        try:
+            state, stats = load_recording_state(path, plane0)
+        except Exception as e:
+            log(f"  [{rec.filename}]{note} SKIP: could not read {path}: {e}")
+            continue
+        # Phase 1 didn't run, so the backdrop it would have captured is loaded
+        # from whatever the previous run persisted (present in a bundle, absent
+        # if that run had backgrounds switched off).
+        state.background = load_background(
+            path.with_name(f"{rec.filename}{BACKGROUND_SUFFIX}"))
+        log(f"  [{rec.filename}]{note} reusing adjacency matrices from {path}")
+        out[activity] = (state, stats)
+    return out or None
+
+
+def _state_subdir(params: Params, activity: str) -> Path | None:
+    """Where *activity*'s ``ExperimentMatFiles`` sit, relative to a run root.
+
+    ``None`` for the primary measure, which keeps the top-level folder — see
+    :data:`meanap.catnap.activities.BY_ACTIVITY_DIR`.
+    """
+    if not is_multi_activity(params) or activity == primary_activity(params):
         return None
-    try:
-        state, stats = load_recording_state(path, plane0)
-    except Exception as e:
-        log(f"  [{rec.filename}] SKIP: could not read {path}: {e}")
-        return None
-    # Phase 1 didn't run, so the backdrop it would have captured is loaded from
-    # whatever the previous run persisted (present in a bundle, absent if that
-    # run had backgrounds switched off).
-    state.background = load_background(
-        path.with_name(f"{rec.filename}{BACKGROUND_SUFFIX}"))
-    log(f"  [{rec.filename}] reusing adjacency matrices from {path}")
-    return state, stats
+    return Path(BY_ACTIVITY_DIR) / activity_slug(activity)
 
 
 def _mean_image_background(mean_img, coord_norm) -> tuple | None:
@@ -821,8 +1043,10 @@ def _no_trace_reason(params, data) -> str | None:
     if data is None:
         return "its suite2p folder could not be re-read (see the warning above)"
     if data.F_denoised is None or data.peak_start_frames is None:
-        if params.twop_activity not in _NEEDS_DENOISING:
-            return (f"activity type {params.twop_activity!r} does not denoise, "
+        measures = activity_types(params)
+        if not any(a in _NEEDS_DENOISING for a in measures):
+            named = " or ".join(repr(a) for a in measures)
+            return (f"activity type {named} does not denoise, "
                     "and these figures plot the denoised trace against the "
                     "detected events — use 'peaks' to get them")
         return ("no denoised traces were found for it — denoising did not run "
@@ -832,9 +1056,47 @@ def _no_trace_reason(params, data) -> str | None:
     return None
 
 
+def _plot_traces(params, rec, output_root, log, data=None) -> None:
+    """The per-cell peak-detection trace figures for one recording.
+
+    Split out from the network figures because they are the one family that is
+    the same under every measure of activity: they plot the raw and denoised
+    fluorescence against the detected events, none of which depends on which
+    measure the adjacency was built from. A multi-measure run draws them once,
+    into the primary measure's tree.
+
+    They are also the one family a bundle cannot rebuild — they need the full
+    fluorescence matrices, which are hundreds of MB and deliberately not
+    carried — which is why express mode still draws them.
+    """
+    from meanap.catnap.plotting import plot_2p_traces
+
+    if not params.num_2p_traces:
+        return
+    # Say why when there is nothing to draw. These are the one family a bundle
+    # cannot rebuild, so a run that quietly skips them leaves the reader looking
+    # at an empty section in the viewer with nothing in the log to explain it —
+    # and no way to get them back but another run.
+    reason = _no_trace_reason(params, data)
+    if reason:
+        log(f"  [{rec.filename}] no peak-detection trace figures: {reason}")
+        return
+    try:
+        trace_dir = (output_root / "2_NeuronalActivity"
+                     / "2A_IndividualNeuronalAnalysis"
+                     / rec.group / rec.filename)
+        log(f"  [{rec.filename}] plotting 2P traces…")
+        drawn = plot_2p_traces(data, trace_dir, rec.filename,
+                               num_traces=params.num_2p_traces)
+        if not drawn:
+            log(f"  [{rec.filename}] warning: 2P trace plots produced no figures")
+    except Exception as e:
+        log(f"  [{rec.filename}] warning: 2P trace plots failed: {e}")
+
+
 def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, log,
-                    data=None, background=None) -> None:
-    """Per-unit trace figures + the full step-4A figure set for one recording.
+                    background=None) -> None:
+    """The full step-4A network figure set for one recording and one measure.
 
     The network figures are the *shared* ``_plot_recording_lag`` — connectivity
     stats, the five spatial network plots (plus their batch-scaled and combined
@@ -847,35 +1109,12 @@ def _plot_recording(params, rec, state, rec_results, batch_bounds, output_root, 
     circular cartography plot show the batch-derived boundaries and the roles
     that the CSVs report.
 
-    In express mode only the trace figures are drawn. They are the one family
-    here that cannot be rebuilt from the run's own outputs — they need the full
-    fluorescence matrices, which are hundreds of MB and deliberately not carried
-    — whereas every network figure is a pure function of data the bundle holds.
+    Nothing is drawn in express mode: every figure here is a pure function of
+    metrics the bundle already carries, so the viewer can rebuild them on
+    demand. The trace figures, which it cannot, are drawn by
+    :func:`_plot_traces` regardless.
     """
-    from meanap.catnap.plotting import plot_2p_traces
     from meanap.pipeline.step4 import _plot_recording_lag
-
-    if params.num_2p_traces:
-        # Say why when there is nothing to draw. These are the one family a
-        # bundle cannot rebuild, so a run that quietly skips them leaves the
-        # reader looking at an empty section in the viewer with nothing in the
-        # log to explain it — and no way to get them back but another run.
-        reason = _no_trace_reason(params, data)
-        if reason:
-            log(f"  [{rec.filename}] no peak-detection trace figures: {reason}")
-        else:
-            try:
-                trace_dir = (output_root / "2_NeuronalActivity"
-                             / "2A_IndividualNeuronalAnalysis"
-                             / rec.group / rec.filename)
-                log(f"  [{rec.filename}] plotting 2P traces…")
-                drawn = plot_2p_traces(data, trace_dir, rec.filename,
-                                       num_traces=params.num_2p_traces)
-                if not drawn:
-                    log(f"  [{rec.filename}] warning: 2P trace plots produced "
-                        "no figures")
-            except Exception as e:
-                log(f"  [{rec.filename}] warning: 2P trace plots failed: {e}")
 
     if params.express_mode:
         return
@@ -1156,105 +1395,204 @@ def _plot_group_comparisons(
             log(f"  Warning: cell-type subnetwork group comparison plots failed: {e}")
 
 
-def _save_subnetwork_results(tables: dict[str, list], net_dir: Path, log) -> None:
-    """Write the three batch-level cell-type subnetwork CSVs."""
-    outputs = {
-        "summary": "Subnetwork_RecordingLevel.csv",
-        "node": "Subnetwork_NodeLevel.csv",
-        "mix": "Subnetwork_EdgeMix.csv",
-    }
-    for key, filename in outputs.items():
-        if not tables[key]:
+#: The three batch-level cell-type subnetwork CSVs.
+_SUBNETWORK_FILES = {
+    "summary": "Subnetwork_RecordingLevel.csv",
+    "node": "Subnetwork_NodeLevel.csv",
+    "mix": "Subnetwork_EdgeMix.csv",
+}
+
+
+def _save_subnetwork_results(params: Params, tables: dict[str, dict[str, list]],
+                             output_root: Path, log) -> None:
+    """Write the cell-type subnetwork CSVs, per measure and pooled.
+
+    Each measure's subtree gets its own copy holding only its rows, so the
+    subtree reads as a complete run; the top level gets every measure's rows in
+    one file with an ``ActivityType`` column, which is the form the statistics
+    step compares measures from.
+    """
+    measures = activity_types(params)
+    multi = is_multi_activity(params)
+    for key, filename in _SUBNETWORK_FILES.items():
+        pooled: list[dict] = []
+        for activity in measures:
+            rows = tables.get(activity, {}).get(key) or []
+            if not rows:
+                continue
+            tagged = [dict(row, ActivityType=activity) for row in rows] if multi else rows
+            pooled.extend(tagged)
+            if not multi:
+                continue
+            sub_dir = (output_root / (_state_subdir(params, activity) or "")
+                       / "4_NetworkActivity")
+            try:
+                sub_dir.mkdir(parents=True, exist_ok=True)
+                pd.DataFrame(rows).to_csv(sub_dir / filename, index=False)
+            except Exception as e:
+                log(f"  Warning: could not save {activity} {filename}: {e}")
+        if not pooled:
             continue
         try:
-            pd.DataFrame(tables[key]).to_csv(net_dir / filename, index=False)
+            pd.DataFrame(pooled).to_csv(
+                output_root / "4_NetworkActivity" / filename, index=False)
         except Exception as e:
             log(f"  Warning: could not save {filename}: {e}")
 
 
 def _save_catnap_results(
+    params: Params,
     recordings: list[RecordingInfo],
-    all_results: dict[str, dict],
-    all_stats: dict[str, dict],
-    all_channels: dict[str, np.ndarray],
-    net_dir: Path,
+    all_results: dict[str, dict[str, dict]],
+    all_stats: dict[str, dict[str, dict]],
+    all_channels: dict[str, dict[str, np.ndarray]],
+    output_root: Path,
     log: Callable[[str], None],
     sampling_rates: dict[str, float] | None = None,
 ) -> None:
-    """Write netmet_results.json + NetworkActivity CSVs (compact port of the
-    save block in ``step4._run_step4_network_metrics``).
+    """Write netmet_results.json + the NetworkActivity / TwoPhotonActivity CSVs
+    (compact port of the save block in ``step4._run_step4_network_metrics``).
 
     ``sampling_rates`` adds a ``samplingRateHz`` column to the recording-level
     tables. It is the only place the rate reaches disk in a readable form —
     params.json cannot carry it, because it is per recording rather than per
     run — and it is what the HTML report and the bundle viewer read back.
+
+    Each measure's ``netmet_results.json`` goes in that measure's own subtree,
+    unchanged in shape, so the viewer and the exporter can read a subtree
+    exactly as they read any run. The four CSVs are written twice over: once per
+    subtree with that measure's rows alone, and once at the top level with every
+    measure's rows carrying an ``ActivityType`` column. The pooled copy is what
+    :mod:`meanap.stats.measures` compares, and it is why a multi-measure run is
+    one run rather than several that happen to share a parent folder.
     """
     rates = sampling_rates or {}
+    measures = activity_types(params)
+    multi = is_multi_activity(params)
+
+    def tag(rows: list[dict], activity: str) -> list[dict]:
+        """Rows with the measure named, positioned before the metrics."""
+        if not multi:
+            return rows
+        return [dict(ActivityType=activity, **row) for row in rows]
+
+    def write(frame: "pd.DataFrame | list[dict]", root: Path, rel: str) -> None:
+        frame = pd.DataFrame(frame) if not isinstance(frame, pd.DataFrame) else frame
+        if frame.empty:
+            return
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_csv(path, index=False)
+
+    pooled: dict[str, list[dict]] = {
+        "net_rec": [], "net_node": [], "act_rec": [], "act_node": []}
+
     try:
-        json_results = {
-            rec_name: {
-                lag: {k: v for k, v in metrics.items() if k != "adjMsub"}
-                for lag, metrics in rec_results.items()
+        for activity in measures:
+            root_act = output_root / (_state_subdir(params, activity) or "")
+            results_act = all_results.get(activity) or {}
+            stats_act = all_stats.get(activity) or {}
+            channels_act = all_channels.get(activity) or {}
+
+            json_results = {
+                rec_name: {
+                    lag: {k: v for k, v in metrics.items() if k != "adjMsub"}
+                    for lag, metrics in rec_results.items()
+                }
+                for rec_name, rec_results in results_act.items()
             }
-            for rec_name, rec_results in all_results.items()
-        }
-        with open(net_dir / "netmet_results.json", "w") as fh:
-            json.dump(_convert_numpy(json_results), fh, indent=2)
+            net_dir = root_act / "4_NetworkActivity"
+            net_dir.mkdir(parents=True, exist_ok=True)
+            with open(net_dir / "netmet_results.json", "w") as fh:
+                json.dump(_convert_numpy(json_results), fh, indent=2)
 
-        rec_rows, node_rows = [], []
-        for rec in recordings:
-            if rec.filename not in all_results:
-                continue
-            for lag, metrics in all_results[rec.filename].items():
-                base = {"FileName": rec.filename, "Grp": rec.group, "DIV": rec.div, "Lag": lag}
-                if rec.filename in rates:
-                    base["samplingRateHz"] = rates[rec.filename]
-                rec_row = dict(base)
-                node_metrics = {}
-                for k, v in metrics.items():
-                    if k == "adjMsub" or k in _NMF_NON_NODE_KEYS:
-                        continue
-                    is_array = isinstance(v, (list, np.ndarray))
-                    if not is_array or np.size(v) <= 1:
-                        rec_row[k] = v[0] if is_array and np.size(v) == 1 else v
-                    else:
-                        node_metrics[k] = v
-                rec_rows.append(rec_row)
-                if node_metrics:
-                    num_nodes = len(next(iter(node_metrics.values())))
-                    for ch in range(num_nodes):
-                        node_row = dict(base, Channel=ch + 1)
-                        for k, arr in node_metrics.items():
-                            if len(arr) == num_nodes:
-                                node_row[k] = arr[ch]
-                        node_rows.append(node_row)
+            rec_rows, node_rows = _network_rows(recordings, results_act, rates)
+            act_rows = _activity_rows(recordings, stats_act, rates)
+            _, node_stats = twop_stats_frames(recordings, stats_act, channels_act)
+            act_node_rows = node_stats.to_dict("records") if not node_stats.empty else []
 
-        if rec_rows:
-            pd.DataFrame(rec_rows).to_csv(net_dir / "NetworkActivity_RecordingLevel.csv", index=False)
-        if node_rows:
-            pd.DataFrame(node_rows).to_csv(net_dir / "NetworkActivity_NodeLevel.csv", index=False)
+            pooled["net_rec"].extend(tag(rec_rows, activity))
+            pooled["net_node"].extend(tag(node_rows, activity))
+            pooled["act_rec"].extend(tag(act_rows, activity))
+            pooled["act_node"].extend(tag(act_node_rows, activity))
 
-        # Two-photon activity stats (step-2 equivalent). The recording-level CSV
-        # takes every scalar field; the node-level one carries the per-unit
-        # arrays (event rate, ISI, amplitude, duration, area), which otherwise
-        # only existed in memory — and are what the group comparison figures
-        # plot.
-        twop_dir = net_dir.parent / "2_NeuronalActivity"
-        # samplingRateHz sits next to DIV rather than among the metrics: it
-        # describes how the recording was acquired, not something measured in
-        # it, and every rate below is derived from it.
-        stats_rows = [dict({"FileName": r.filename, "Grp": r.group, "DIV": r.div},
-                           **({"samplingRateHz": rates[r.filename]}
-                              if r.filename in rates else {}),
-                           **{k: v for k, v in all_stats[r.filename].items()
-                              if np.size(v) <= 1})
-                      for r in recordings if r.filename in all_stats]
-        if stats_rows:
-            pd.DataFrame(stats_rows).to_csv(
-                twop_dir / "TwoPhotonActivity_RecordingLevel.csv", index=False)
+            if multi:
+                write(rec_rows, root_act,
+                      "4_NetworkActivity/NetworkActivity_RecordingLevel.csv")
+                write(node_rows, root_act,
+                      "4_NetworkActivity/NetworkActivity_NodeLevel.csv")
+                write(act_rows, root_act,
+                      "2_NeuronalActivity/TwoPhotonActivity_RecordingLevel.csv")
+                write(act_node_rows, root_act,
+                      "2_NeuronalActivity/TwoPhotonActivity_NodeLevel.csv")
 
-        _, node_stats = twop_stats_frames(recordings, all_stats, all_channels)
-        if not node_stats.empty:
-            node_stats.to_csv(twop_dir / "TwoPhotonActivity_NodeLevel.csv", index=False)
+        write(pooled["net_rec"], output_root,
+              "4_NetworkActivity/NetworkActivity_RecordingLevel.csv")
+        write(pooled["net_node"], output_root,
+              "4_NetworkActivity/NetworkActivity_NodeLevel.csv")
+        write(pooled["act_rec"], output_root,
+              "2_NeuronalActivity/TwoPhotonActivity_RecordingLevel.csv")
+        write(pooled["act_node"], output_root,
+              "2_NeuronalActivity/TwoPhotonActivity_NodeLevel.csv")
     except Exception as e:
         log(f"  Warning: could not save CAT-NAP results: {e}")
+
+
+def _network_rows(
+    recordings: list[RecordingInfo], all_results: dict[str, dict],
+    rates: dict[str, float],
+) -> tuple[list[dict], list[dict]]:
+    """One measure's network metrics as recording-level and node-level rows.
+
+    A metric with one value per recording goes in the first table and one with
+    a value per node in the second; ``adjMsub`` and the NMF matrices are neither
+    and are skipped.
+    """
+    rec_rows: list[dict] = []
+    node_rows: list[dict] = []
+    for rec in recordings:
+        if rec.filename not in all_results:
+            continue
+        for lag, metrics in all_results[rec.filename].items():
+            base = {"FileName": rec.filename, "Grp": rec.group, "DIV": rec.div,
+                    "Lag": lag}
+            if rec.filename in rates:
+                base["samplingRateHz"] = rates[rec.filename]
+            rec_row = dict(base)
+            node_metrics = {}
+            for k, v in metrics.items():
+                if k == "adjMsub" or k in _NMF_NON_NODE_KEYS:
+                    continue
+                is_array = isinstance(v, (list, np.ndarray))
+                if not is_array or np.size(v) <= 1:
+                    rec_row[k] = v[0] if is_array and np.size(v) == 1 else v
+                else:
+                    node_metrics[k] = v
+            rec_rows.append(rec_row)
+            if node_metrics:
+                num_nodes = len(next(iter(node_metrics.values())))
+                for ch in range(num_nodes):
+                    node_row = dict(base, Channel=ch + 1)
+                    for k, arr in node_metrics.items():
+                        if len(arr) == num_nodes:
+                            node_row[k] = arr[ch]
+                    node_rows.append(node_row)
+    return rec_rows, node_rows
+
+
+def _activity_rows(
+    recordings: list[RecordingInfo], all_stats: dict[str, dict],
+    rates: dict[str, float],
+) -> list[dict]:
+    """One measure's two-photon activity stats, one row per recording.
+
+    ``samplingRateHz`` sits next to DIV rather than among the metrics: it
+    describes how the recording was acquired, not something measured in it, and
+    every rate below is derived from it.
+    """
+    return [dict({"FileName": r.filename, "Grp": r.group, "DIV": r.div},
+                 **({"samplingRateHz": rates[r.filename]}
+                    if r.filename in rates else {}),
+                 **{k: v for k, v in all_stats[r.filename].items()
+                    if np.size(v) <= 1})
+            for r in recordings if r.filename in all_stats]

--- a/src/meanap/gui/panels/catnap.py
+++ b/src/meanap/gui/panels/catnap.py
@@ -24,7 +24,21 @@ from meanap.gui.advanced import AdvancedSection
 from meanap.gui.widgets import pin_width, scrollable
 from meanap.params import Params, is_remote_url
 
-ACTIVITY_TYPES = ["peaks", "denoised F", "F", "spks"]
+from meanap.catnap.activities import ACTIVITY_TYPES as _ACTIVITY_TYPES
+
+ACTIVITY_TYPES = list(_ACTIVITY_TYPES)
+
+#: One line each, shown as the checkbox tooltips. What separates the four
+#: measures is not obvious from their names, and the choice changes both the
+#: network that gets built and — sometimes — the conclusion drawn from it.
+ACTIVITY_HELP = {
+    "peaks": "Detected calcium events. The network is an STTC coincidence "
+             "network and the timescale parameter is a lag.",
+    "denoised F": "The deconvolved fluorescence trace. The network is a "
+                  "Pearson correlation between binned traces, at zero lag.",
+    "F": "Raw fluorescence, uncorrected. Correlation network, as above.",
+    "spks": "suite2p's own spike estimate. Correlation network, as above.",
+}
 
 # Subnetwork grouping modes, in combo-box order. The stored value of
 # ``Params.twop_subnetwork_groups`` is None / "E/I" / a dict of expressions;
@@ -422,6 +436,10 @@ class CatNapPanel(QWidget):
         self._activity_combo = QComboBox()
         self._activity_combo.addItems(ACTIVITY_TYPES)
         self._activity_combo.currentTextChanged.connect(self._refresh_plot)
+        self._activity_combo.currentTextChanged.connect(self._update_extra_measures)
+        self._activity_combo.setToolTip(
+            "The measure the run is built from. Its results keep the top-level "
+            "output folders.")
 
         self._n_cells_preview = QSpinBox()
         self._n_cells_preview.setRange(1, 20)
@@ -431,6 +449,7 @@ class CatNapPanel(QWidget):
         self._remove_no_peaks = QCheckBox()
 
         ctrl_form.addRow("Activity type", self._activity_combo)
+        ctrl_form.addRow("Also analyse", self._build_extra_measures())
         ctrl_form.addRow("Cells to preview", self._n_cells_preview)
         ctrl_form.addRow("Exclude cells with no peaks", self._remove_no_peaks)
 
@@ -738,6 +757,41 @@ class CatNapPanel(QWidget):
             rec = self._recordings[row]
             self._recording_list.item(row).setText(f"✓  {rec.name}")
 
+    def _build_extra_measures(self) -> QWidget:
+        """Tick boxes for measures to analyse *beside* the one above.
+
+        Each ticked measure adds a full pass over the same recordings — its own
+        adjacency, metrics and figures — and, in the statistics step, a
+        comparison against the others: how far the values move with the
+        measure, and whether the group and age conclusions survive the change.
+        The raw data is loaded and denoised once no matter how many are ticked,
+        so the extra cost is the network metrics rather than another whole run.
+        """
+        w = QWidget()
+        row = QHBoxLayout(w)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(10)
+        self._extra_measures: dict[str, QCheckBox] = {}
+        for name in ACTIVITY_TYPES:
+            box = QCheckBox(name)
+            box.setToolTip(ACTIVITY_HELP.get(name, ""))
+            self._extra_measures[name] = box
+            row.addWidget(box)
+        row.addStretch()
+        self._update_extra_measures()
+        return w
+
+    def _update_extra_measures(self) -> None:
+        """Grey out the primary measure — it is already being analysed."""
+        primary = self._activity_combo.currentText()
+        for name, box in self._extra_measures.items():
+            is_primary = name == primary
+            if is_primary and box.isChecked():
+                box.setChecked(False)
+            box.setEnabled(not is_primary)
+            box.setToolTip("Already the measure this run is built from."
+                           if is_primary else ACTIVITY_HELP.get(name, ""))
+
     def _refresh_plot(self) -> None:
         if self._current_data is None:
             return
@@ -933,9 +987,15 @@ class CatNapPanel(QWidget):
     def load(self, params: Params) -> None:
         self._folder_edit.setText(params.raw_data)
         self._suite2p_mode.setChecked(params.suite2p_mode)
-        idx = self._activity_combo.findText(params.twop_activity)
+        from meanap.catnap.activities import activity_types
+
+        measures = activity_types(params)
+        idx = self._activity_combo.findText(measures[0])
         if idx >= 0:
             self._activity_combo.setCurrentIndex(idx)
+        for name, box in self._extra_measures.items():
+            box.setChecked(name in measures[1:])
+        self._update_extra_measures()
         self._redo_denoising.setChecked(params.twop_redo_denoising)
         self._remove_no_peaks.setChecked(params.remove_nodes_with_no_peaks)
         self._denoise_threshold.setValue(params.twop_denoising_threshold)
@@ -973,6 +1033,13 @@ class CatNapPanel(QWidget):
         params.raw_data = self._folder_edit.text()
         params.suite2p_mode = self._suite2p_mode.isChecked()
         params.twop_activity = self._activity_combo.currentText()
+        # Empty rather than a one-element tuple when nothing extra is ticked:
+        # that is what marks a run as single-measure, and it is what keeps its
+        # output folders named the way they always were.
+        extra = tuple(name for name in ACTIVITY_TYPES
+                      if name != params.twop_activity
+                      and self._extra_measures[name].isChecked())
+        params.twop_activities = (params.twop_activity, *extra) if extra else ()
         params.twop_redo_denoising = self._redo_denoising.isChecked()
         params.remove_nodes_with_no_peaks = self._remove_no_peaks.isChecked()
         params.twop_denoising_threshold = self._denoise_threshold.value()

--- a/src/meanap/gui/panels/stats.py
+++ b/src/meanap/gui/panels/stats.py
@@ -210,6 +210,21 @@ class StatsPanel(QWidget):
         self.sweep_cb.toggled.connect(self._on_sweep_toggled)
         outer.addWidget(self.sweep_cb)
 
+        self.measures_cb = QCheckBox(
+            "Compare measures of activity  (does the measure change the answer?)")
+        self.measures_cb.setChecked(True)
+        self.measures_cb.setToolTip(
+            "For a CAT-NAP run that analysed several measures of activity "
+            "(calcium events, deconvolved trace, raw fluorescence, suite2p "
+            "spikes): how far each metric moves when the measure changes, "
+            "whether the recordings still rank the same way, and — the part "
+            "that matters — whether the group and age effects survive the "
+            "change.\n\n"
+            "Free: it reads the per-measure results the analyses above already "
+            "produced. A run with one measure has nothing to compare and skips "
+            "it.")
+        outer.addWidget(self.measures_cb)
+
         self.sweep_note = QLabel()
         self.sweep_note.setWordWrap(True)
         self.sweep_note.setStyleSheet(
@@ -427,6 +442,7 @@ class StatsPanel(QWidget):
             shapley_by_age=self.shapley_cb.isChecked(),
             feature_families=self.families_cb.isChecked(),
             density_sweep=self.sweep_cb.isChecked() and self.sweep_cb.isEnabled(),
+            measure_comparison=self.measures_cb.isChecked(),
             sweep_n_nodes=self.sweep_size.currentData(),
             decoding_target=self.decode_target.currentData(),
             regression_target=self.regress_target.currentData(),

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -239,6 +239,16 @@ class Params:
     # writing back is impossible. See catnap/derived.py.
     derived_data_folder: str = ""
     twop_activity: str = "peaks"
+    # Extra measures of activity to analyse alongside ``twop_activity`` in the
+    # same run. Empty (the default, and what every settings file written before
+    # this existed carries) means the run analyses ``twop_activity`` alone and
+    # is named exactly as it always was. Listing more makes the measure an axis
+    # of the output — an ``ActivityType`` column in every CAT-NAP table, an
+    # activity-prefixed folder per figure set, and the cross-measure comparison
+    # in step 5 (:mod:`meanap.stats.measures`), which is the point: the choice
+    # of measure changes both the numbers and, sometimes, the conclusion, and
+    # that was previously invisible. See :mod:`meanap.catnap.activities`.
+    twop_activities: tuple[str, ...] = ()
     twop_redo_denoising: bool = False
     remove_nodes_with_no_peaks: bool = False
     num_2p_traces: int = 3

--- a/src/meanap/pipeline/bundle.py
+++ b/src/meanap/pipeline/bundle.py
@@ -256,6 +256,18 @@ _PAYLOAD_FAMILIES = (
 )
 
 
+def _strip_activity_prefix(posix: str) -> str:
+    """``ByActivityType/denoisedF/4_NetworkActivity/x`` → ``4_NetworkActivity/x``."""
+    from meanap.catnap.activities import BY_ACTIVITY_DIR
+
+    prefix = f"{BY_ACTIVITY_DIR}/"
+    if not posix.startswith(prefix):
+        return posix
+    rest = posix[len(prefix):]
+    _measure, sep, tail = rest.partition("/")
+    return tail if sep else posix
+
+
 def _keep_as_images(root: Path) -> tuple[str, ...]:
     """Figure dirs to pack verbatim because their payload isn't there.
 
@@ -269,7 +281,13 @@ def _keep_as_images(root: Path) -> tuple[str, ...]:
 
 
 def _is_reconstructable_member(rel: Path, keep: tuple[str, ...] = ()) -> bool:
-    posix = rel.as_posix()
+    # A multi-measure CAT-NAP run puts each extra measure's complete run folder
+    # under ByActivityType/<measure>/, so the same figure families sit one level
+    # deeper. Stripping that prefix before matching drops them from the bundle
+    # exactly as the primary measure's are dropped — they are reconstructable
+    # from the same data, which travels in that subtree beside them. Without
+    # this an extra measure's pictures would be the largest thing in the bundle.
+    posix = _strip_activity_prefix(rel.as_posix())
     dirs = tuple(d for d in _RECONSTRUCTABLE_DIRS if d not in keep)
     if any(posix.startswith(d) for d in dirs):
         return True

--- a/src/meanap/pipeline/render.py
+++ b/src/meanap/pipeline/render.py
@@ -1732,6 +1732,11 @@ def available_stats_lags(ctx: RenderContext) -> list[str]:
     return available_lags(_stats_root(ctx))
 
 
+#: Re-exported so this module's own lag handling and the statistics step agree
+#: about which folder holds the cross-measure comparison.
+MEASURES_PREFIX = "MeasureComparison"
+
+
 def stats_results(ctx: RenderContext, lag: str):
     """The stored statistics results for one lag, loaded once per context.
 
@@ -1754,12 +1759,32 @@ def stats_results(ctx: RenderContext, lag: str):
         cache[lag] = None
         return None
     dataset = load_dataset(ctx.root)
+    # A run that analysed several measures of activity nests its folders one
+    # level deeper (``peaks/1000mslag``), and the dataset behind such a folder
+    # is that measure's rows alone — the same subsetting the step itself did.
+    # ``MeasureComparison`` is the exception: it belongs to no single measure,
+    # so it keeps every row for the lag.
+    measure, _, stem = str(lag).rpartition("/")
+    if measure and measure != MEASURES_PREFIX:
+        dataset = _stats_activity_subset(dataset, measure)
     # "all" is the folder a run with no lag axis writes to; there is nothing to
     # subset by in that case.
     cache[lag] = load_results(
-        folder, dataset if lag == "all" else dataset.for_lag(_stats_lag_value(dataset, lag)),
-        lag=lag)
+        folder,
+        dataset if stem == "all" else dataset.for_lag(_stats_lag_value(dataset, stem)),
+        lag=stem)
     return cache[lag]
+
+
+def _stats_activity_subset(dataset, slug: str):
+    """The rows of one measure of activity, addressed by its folder slug."""
+    from meanap.catnap.activities import activity_from_slug
+
+    name = activity_from_slug(slug)
+    for value in dataset.activities:
+        if str(value) == name or str(value) == slug:
+            return dataset.for_activity(value)
+    return dataset
 
 
 def _stats_lag_value(dataset, lag: str):

--- a/src/meanap/pipeline/report.py
+++ b/src/meanap/pipeline/report.py
@@ -31,6 +31,8 @@ FOLDER_DESCRIPTIONS: dict[str, str] = {
     "4B_GroupComparisons": "Network metrics pooled across the whole batch and compared between experimental groups and ages, one sub-folder per connectivity timescale (STTC lag, or correlation bin on a CAT-NAP correlation run).",
     "5_StatsAndML": "Step 5 — statistics and machine learning. Comparisons between experimental groups and ages, the correlation structure of the metrics, decoding of genotype or age from them, and how much of a target each metric explains. One sub-folder per connectivity timescale. Unlike steps 1-4 this is not part of a pipeline run: it is run over a finished run, from the Stats & ML tab or the meanap-stats command.",
     "ExperimentMatFiles": "Per-recording adjacency matrices (STTC, raw + significance-thresholded) saved as .npz, one file per recording.",
+    "ByActivityType": "CAT-NAP only, and only when the run analysed more than one measure of activity. One complete run folder per extra measure — its own ExperimentMatFiles, per-recording figures, group comparisons and netmet_results.json — named by the measure. The primary measure keeps the top-level folders; the tables at the top level pool every measure with an ``ActivityType`` column, which is what the statistics step compares them from.",
+    "MeasureComparison": "Step 5, CAT-NAP only. How the choice of activity measure changes the result: whether the measures rank recordings alike, how far each metric's value moves, and — the part that matters — whether the group and age conclusions survive the change. One sub-folder per connectivity timescale.",
     # Comparison sub-folders (shared by the ephys and CAT-NAP paths).
     "1_NodeByGroup": "Node-level metrics compared between experimental groups — one subplot per group, x-axis = age. Every node of every recording contributes a point.",
     "2_NodeByAge": "The same node-level metrics, transposed: one subplot per age, x-axis = experimental group.",
@@ -423,6 +425,13 @@ _DATA_FILE_DESCRIPTIONS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"^Subnetwork_NodeLevel\.csv$"), "CAT-NAP. One row per recording x lag x node x cell type: whole-network node metrics labelled by type, plus each node's within-group strength fraction. Long format — a cell positive for two markers appears once per group."),
     (re.compile(r"^Subnetwork_EdgeMix\.csv$"), "CAT-NAP. One row per recording x lag x cell-type pair: edge density and mean weight within and between types."),
     (re.compile(r"^step_durations\.json$"), "Wall-clock seconds spent in each pipeline step, for performance comparison."),
+    # Step 5, cross-measure comparison. Only written by a CAT-NAP run that
+    # analysed more than one measure of activity.
+    (re.compile(r"^measure_agreement\.csv$"), "Step 5. One row per (metric, pair of activity measures): Spearman and Pearson correlation between the values the two measures give, Lin's concordance coefficient, and the Bland-Altman bias and limits of agreement in the metric's own units. High correlation with low concordance means the measures rank recordings alike but on different scales."),
+    (re.compile(r"^measure_differences\.csv$"), "Step 5. One row per (metric, pair of activity measures): the paired Wilcoxon signed-rank test of the within-recording difference, its FDR-corrected p-value, the median difference and percent change, and a paired standardised effect size (Hedges' g_av, standardised by the pooled SD of the two measures)."),
+    (re.compile(r"^measure_effects\.csv$"), "Step 5. The run's own mixed-model group and age effects, stacked with an ``ActivityType`` column — the same numbers each measure's ``comparisons.csv`` reports, side by side."),
+    (re.compile(r"^measure_concordance\.csv$"), "Step 5. One row per (metric, model term, pair of measures): both effect sizes, both FDR-corrected p-values, and a verdict — whether both measures found the effect, one did, or neither. The table to check before quoting a result without naming the measure it came from."),
+    (re.compile(r"^measure_decoding\.csv$"), "Step 5. Best decoding score per activity measure, against chance — which measure carries the most information about the target."),
     # Step 5. Every figure in this folder is a pure function of these tables,
     # which is why a bundle carries them and drops the pictures.
     (re.compile(r"^comparisons\.csv$"), "Step 5. One row per (metric, test, term): the estimate, the test statistic, the raw p-value and its Benjamini-Hochberg partner (corrected within the family named in the row), and an effect size whose name the row states. Covers the mixed models, the per-age group contrasts and the paired age contrasts."),
@@ -646,10 +655,19 @@ def _report_timescale(output_root: Path) -> str:
             data = json.load(f)
     except (OSError, ValueError):
         return "STTC lag"
-    if (data.get("suite2p_mode")
-            and data.get("twop_activity") in CORRELATION_ACTIVITIES):
-        return "correlation bin"
-    return "STTC lag"
+    if not data.get("suite2p_mode"):
+        return "STTC lag"
+    measures = [str(a) for a in (data.get("twop_activities") or ())]
+    if not measures:
+        measures = [str(data.get("twop_activity") or "peaks")]
+    kinds = {("correlation bin" if m in CORRELATION_ACTIVITIES else "STTC lag")
+             for m in measures}
+    if len(kinds) > 1:
+        # A run analysing calcium events beside a continuous trace produces
+        # both, filed under different measures — naming only one would
+        # mislabel half the folder.
+        return "STTC lag or correlation bin, depending on the measure of activity"
+    return kinds.pop()
 
 
 def generate_report(output_root: Path | str, out_path: Path | str | None = None) -> Path:

--- a/src/meanap/pipeline/resume.py
+++ b/src/meanap/pipeline/resume.py
@@ -100,15 +100,22 @@ class InputLocator:
         candidates += [root / ADJM_SUBDIR / name for root in self.prior_roots]
         return _first_existing(candidates)
 
-    def catnap_file(self, recording_name: str) -> Path | None:
+    def catnap_file(self, recording_name: str, *,
+                    subdir: Path | str | None = None) -> Path | None:
         """Path to a recording's CAT-NAP step-2 file, or ``None`` if absent.
 
         ``spike_dir`` is not consulted: it holds externally *spike-detected*
         MEA data, which has nothing to say about a suite2p recording.
+
+        *subdir* addresses one measure's subtree in a multi-measure run
+        (``ByActivityType/denoisedF``); the primary measure passes ``None`` and
+        reads the top-level folder, which is where a single-measure run — and
+        every run written before measures could be combined — puts it.
         """
         name = f"{recording_name}{CATNAP_SUFFIX}"
-        candidates = [self.output_root / ADJM_SUBDIR / name]
-        candidates += [root / ADJM_SUBDIR / name for root in self.prior_roots]
+        rel = (Path(subdir) / ADJM_SUBDIR) if subdir else ADJM_SUBDIR
+        candidates = [self.output_root / rel / name]
+        candidates += [root / rel / name for root in self.prior_roots]
         return _first_existing(candidates)
 
     # ── reporting ────────────────────────────────────────────────────────────

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -401,6 +401,8 @@ def _check_remote_source(params: Params, recordings, log, progress=None) -> None
 
     store = open_store(params)
     names = [r.filename for r in recordings]
+    from meanap.params import default_derived_dir
+
     report = run_preflight(
         store, names,
         mode="catnap" if params.suite2p_mode else "ephys",
@@ -408,6 +410,9 @@ def _check_remote_source(params: Params, recordings, log, progress=None) -> None
         cache_dir=default_cache_dir(params),
         cache_budget_gb=params.cache_budget_gb,
         prefetch_depth=params.prefetch_depth,
+        # Resolved the same way the source will resolve it, so the estimate and
+        # the transfer agree about what an earlier run already left behind.
+        derived_root=default_derived_dir(params, store.copies) or None,
     )
     log("\n=== Pre-flight ===")
     for line in report.render().splitlines():

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -16,7 +16,9 @@ import numpy as np
 import pandas as pd
 from scipy.spatial.distance import pdist, squareform
 
-from meanap.timescale import timescale_folder, timescale_kind
+from meanap.timescale import (
+    timescale_folder, timescale_kind, timescale_folder_display,
+)
 from meanap.params import Params
 from meanap.pipeline import network_metrics as nm
 from meanap.pipeline.cancellation import CancelCheck, check_cancel
@@ -735,11 +737,13 @@ def _apply_cartography_boundaries(
             params.connector_hub_part_coef,
         )
         if bounds is None:
-            log(f"  Cartography: too few PC/Z values at {source_lag}; "
+            log("  Cartography: too few PC/Z values at "
+                f"{timescale_folder_display(source_lag, params)}; "
                 "keeping fixed boundaries.")
             continue
         hub_b, peri, non_hub_conn, pro_hub, conn_hub = bounds
-        log(f"  Cartography boundaries from {source_lag} pooled PC/Z: "
+        log("  Cartography boundaries from "
+            f"{timescale_folder_display(source_lag, params)} pooled PC/Z: "
             f"Zhub={hub_b:.3f} peri={peri:.3f} nonHubConn={non_hub_conn:.3f} "
             f"proHub={pro_hub:.3f} connHub={conn_hub:.3f}")
 

--- a/src/meanap/remote/preflight.py
+++ b/src/meanap/remote/preflight.py
@@ -58,6 +58,9 @@ class RecordingCheck:
     missing: list[str] = field(default_factory=list)
     fetch_bytes: int = 0
     skipped_bytes: int = 0
+    #: Bytes present remotely, wanted by the loader, but already extracted
+    #: into a derived sidecar by an earlier run — so not transferred again.
+    cached_bytes: int = 0
     needs_denoising: bool = False
     #: A folder that is present and looks like this recording under another
     #: name. Renamed folders are the commonest reason a batch silently shrinks.
@@ -95,6 +98,10 @@ class PreflightReport:
     @property
     def skipped_bytes(self) -> int:
         return sum(r.skipped_bytes for r in self.usable)
+
+    @property
+    def cached_bytes(self) -> int:
+        return sum(r.cached_bytes for r in self.usable)
 
     @property
     def name_map(self) -> dict:
@@ -159,6 +166,9 @@ class PreflightReport:
                             if self.skipped_bytes else ""))
             lines.append(f"  Est. transfer {mins:6.0f} min at "
                          f"{ASSUMED_MB_PER_S:.0f} MB/s")
+        if self.cached_bytes:
+            lines.append(f"  Not fetched   {self.cached_bytes / gb:6.2f} GB"
+                         "   (ops.npy — already extracted by an earlier run)")
         if self.budget_bytes:
             fits = "OK" if self.peak_bytes <= self.budget_bytes else "TOO SMALL"
             lines.append(f"  Peak storage  {self.peak_bytes / gb:6.2f} GB"
@@ -243,7 +253,18 @@ def _roi_mismatch(entries: dict) -> str | None:
             "(re-save the recording in the suite2p GUI)")
 
 
-def _check_catnap(store: RemoteStore, name: str) -> RecordingCheck:
+def _ops_already_extracted(derived_root: Path | str | None, name: str) -> bool:
+    """Has an earlier run written this recording's ``ops_fields.npz``?"""
+    if not derived_root:
+        return False
+    from meanap.catnap.derived import OPS_CACHE_NAME, derived_dir
+
+    d = derived_dir(derived_root, name)
+    return d is not None and (d / OPS_CACHE_NAME).exists()
+
+
+def _check_catnap(store: RemoteStore, name: str,
+                  derived_root: Path | str | None = None) -> RecordingCheck:
     plane0 = f"{name}/suite2p/plane0"
     entries = {e.name: e for e in store.list(plane0)}
     if not entries:
@@ -257,11 +278,20 @@ def _check_catnap(store: RemoteStore, name: str) -> RecordingCheck:
     empty = [f for f in CATNAP_REQUIRED
              if f in entries and entries[f].size == 0]
     wanted = set(CATNAP_REQUIRED) | set(CATNAP_OPTIONAL)
+    # ``ops.npy`` is the bulk of a suite2p folder and the loader stops opening
+    # it once an earlier run has cached the two fields it wants. Counting it
+    # as a download here would quote a first-run figure for a re-run — the
+    # number someone reads when deciding whether to start at all.
+    cached = 0
+    if _ops_already_extracted(derived_root, name):
+        wanted.discard("ops.npy")
+        cached = entries["ops.npy"].size or 0 if "ops.npy" in entries else 0
     fetch = sum(e.size or 0 for n, e in entries.items() if n in wanted)
-    skipped = sum(e.size or 0 for n, e in entries.items() if n not in wanted)
+    skipped = sum(e.size or 0 for n, e in entries.items()
+                  if n not in wanted and n != "ops.npy")
     return RecordingCheck(
         name=name, found=True, missing=missing,
-        fetch_bytes=fetch, skipped_bytes=skipped,
+        fetch_bytes=fetch, skipped_bytes=skipped, cached_bytes=cached,
         needs_denoising="Fdenoised.npy" not in entries,
         unusable=_empty_required(empty) or _roi_mismatch(entries),
     )
@@ -309,6 +339,7 @@ def run_preflight(
     cache_dir: Path | str | None = None,
     cache_budget_gb: float | None = None,
     prefetch_depth: int = 1,
+    derived_root: Path | str | None = None,
 ) -> PreflightReport:
     """Inspect a source and report whether the named recordings can be analysed.
 
@@ -319,9 +350,10 @@ def run_preflight(
     report = PreflightReport(mode=mode, source=str(store),
                              spreadsheet=spreadsheet)
 
-    check = _check_catnap if mode == "catnap" else _check_ephys
     for name in recording_names:
-        report.recordings.append(check(store, name))
+        report.recordings.append(
+            _check_catnap(store, name, derived_root) if mode == "catnap"
+            else _check_ephys(store, name))
 
     named = set(recording_names)
     present = [e.name for e in store.list() if e.is_dir]

--- a/src/meanap/remote/source.py
+++ b/src/meanap/remote/source.py
@@ -57,6 +57,9 @@ class RecordingSource:
     #: bytes have arrived. Reported from here rather than from the cache because
     #: only this knows the transfer is one run's worth of work.
     progress: object | None = None
+    #: Where CAT-NAP's derived files live, so a fetch can tell what an earlier
+    #: run already extracted. See :meth:`_wanted_for`.
+    derived_root: str | Path | None = None
     #: cache-relative path → how many not-yet-released recordings still need it.
     _holders: dict = field(default_factory=dict, repr=False)
     #: Bytes fetched so far this run, across every file. Not guarded: prefetch
@@ -101,6 +104,29 @@ class RecordingSource:
         finally:
             self._fetched = base + seen
 
+    def _wanted_for(self, recording: str) -> frozenset:
+        """Which of :data:`WANTED` this recording still has to be fetched for.
+
+        ``ops.npy`` is the whole set bar a rounding error — 463 MB of a 480 MB
+        folder in this dataset — and the pipeline wants two small fields out of
+        it, the frame rate and the mean projection. :func:`load_suite2p` reads
+        those from the ``ops_fields.npz`` sidecar whenever one exists and never
+        opens ``ops.npy`` at all, so once an earlier run has written the sidecar
+        there is nothing left for the download to supply. Re-running a batch
+        with different parameters then costs a twentieth of the first pass.
+
+        The sidecar carries no parameters — it is a verbatim copy of two
+        suite2p fields — so it stays valid across runs, and
+        :func:`~meanap.catnap.loader._load_ops_fields` still discards one older
+        than the ``ops.npy`` it came from.
+        """
+        from meanap.catnap.derived import OPS_CACHE_NAME, derived_dir
+
+        cached = derived_dir(self.derived_root, recording)
+        if cached is not None and (cached / OPS_CACHE_NAME).exists():
+            return WANTED - {"ops.npy"}
+        return WANTED
+
     def plane0(self, recording: str) -> Path:
         """A local ``suite2p/plane0`` for *recording*, fetching it if remote.
 
@@ -122,12 +148,17 @@ class RecordingSource:
         if not entries:
             raise FileNotFoundError(f"no suite2p output at {rel}")
 
-        wanted = [e for e in entries if e.name in WANTED]
+        keep = self._wanted_for(recording)
+        wanted = [e for e in entries if e.name in keep]
         skipped = sum(e.size or 0 for e in entries if e.name not in WANTED)
+        cached_ops = sum(e.size or 0 for e in entries
+                         if e.name in WANTED and e.name not in keep)
         total = sum(e.size or 0 for e in wanted)
         self.log(f"  [{recording}] fetching {total / 1e6:.0f} MB"
                  + (f" (skipping {skipped / 1e6:.0f} MB the pipeline never opens)"
-                    if skipped else ""))
+                    if skipped else "")
+                 + (f" (skipping {cached_ops / 1e6:.0f} MB of ops.npy — already "
+                    "extracted by an earlier run)" if cached_ops else ""))
         for entry in wanted:
             self._fetch(entry.path, detail=recording)
         return self.cache.path_for(self.store, rel)

--- a/src/meanap/stats/comparisons.py
+++ b/src/meanap/stats/comparisons.py
@@ -65,6 +65,17 @@ class ComparisonResults:
         return self.table[self.table[col] < alpha].sort_values(col)
 
 
+#: ``EffectSizeName`` values that name a *signed, comparable* effect size.
+#: The comparison table also carries unsigned ones — a chi-square for the
+#: omnibus group test, a degrees-of-freedom count for the interaction — which
+#: are real results but say nothing about direction or magnitude on a shared
+#: scale. Anything reading ``EffectSize`` as a direction has to filter on this,
+#: or it will read "1.0" off an interaction row and plot it as an effect.
+SIGNED_EFFECT_SIZES = frozenset({
+    "standardised beta", "SD change across age range", "Hedges g", "Cohen dz",
+})
+
+
 # ── effect sizes and correction ──────────────────────────────────────────────
 
 def hedges_g(a: np.ndarray, b: np.ndarray) -> float:

--- a/src/meanap/stats/dataset.py
+++ b/src/meanap/stats/dataset.py
@@ -48,7 +48,7 @@ __all__ = [
 #: are stringified tuples/arrays rather than scalars, so they are excluded here
 #: as well as by the numeric-dtype check — being explicit documents *why*.
 META_COLUMNS = frozenset({
-    "FileName", "Grp", "DIV", "Lag", "Channel", "Culture",
+    "FileName", "Grp", "DIV", "Lag", "Channel", "Culture", "ActivityType",
     "eGrp", "AgeDiv", "recordingName",
     "cartographyBoundaries", "activeChannelIndex",
 })
@@ -154,6 +154,12 @@ class StatsDataset:
     age_col: str = "DIV"
     culture_col: str = "Culture"
     name_col: str = "FileName"
+    #: Which measure of activity a row was computed from — CAT-NAP only, and
+    #: only when a run analysed more than one (see
+    #: :mod:`meanap.catnap.activities`). Absent from the table for every ephys
+    #: run and every single-measure calcium run, which is why nothing here may
+    #: assume the column exists.
+    activity_col: str = "ActivityType"
     level: str = "recording"
     source: Path | None = None
 
@@ -174,6 +180,34 @@ class StatsDataset:
             return []
         return list(pd.unique(self.table["Lag"].dropna()))
 
+    @property
+    def activities(self) -> list:
+        """Measures of activity present, or ``[]`` when the run used only one.
+
+        Empty rather than one-element for a single-measure run: the caller's
+        question is "is there a measure axis to analyse along", and a run with
+        one measure has nothing to compare, exactly as a run with no ``Lag``
+        column has no lag axis.
+        """
+        if self.activity_col not in self.table.columns:
+            return []
+        found = list(pd.unique(self.table[self.activity_col].dropna()))
+        return found if len(found) > 1 else []
+
+    @property
+    def activity(self):
+        """The single measure of activity these rows were computed from.
+
+        ``None`` when the table has no measure column (every ephys run) or
+        carries more than one — the two cases where "this dataset's measure" is
+        not a question with an answer. Distinct from :attr:`activities`, which
+        reports the axis rather than a position on it.
+        """
+        if self.activity_col not in self.table.columns:
+            return None
+        found = list(pd.unique(self.table[self.activity_col].dropna()))
+        return found[0] if len(found) == 1 else None
+
     def label(self, metric: str) -> str:
         return self.labels.get(metric, metric)
 
@@ -190,6 +224,7 @@ class StatsDataset:
             "groups": [str(g) for g in self.groups],
             "ages": [float(a) for a in self.ages],
             "lags": [str(x) for x in self.lags],
+            "activities": [str(x) for x in self.activities],
             "n_metrics": len(self.metrics),
             "level": self.level,
         }
@@ -208,6 +243,20 @@ class StatsDataset:
         sub = self.table[self.table["Lag"] == lag].reset_index(drop=True)
         return self._with_table(sub)
 
+    def for_activity(self, activity) -> "StatsDataset":
+        """The rows measured one way, as a dataset in its own right.
+
+        The measure axis is handled exactly like the lag axis and for the same
+        reason: two measures of one recording are two different measurements,
+        and a comparison or a decoder that pooled them would be treating one
+        culture as two independent samples. Everything that compares *across*
+        measures goes through :mod:`meanap.stats.measures` instead.
+        """
+        if self.activity_col not in self.table.columns:
+            return self
+        sub = self.table[self.table[self.activity_col] == activity]
+        return self._with_table(sub.reset_index(drop=True))
+
     def with_metrics(self, metrics: list[str]) -> "StatsDataset":
         keep = [m for m in metrics if m in self.table.columns]
         cols = [c for c in self.table.columns if c in META_COLUMNS] + keep
@@ -215,7 +264,7 @@ class StatsDataset:
             table=self.table[cols].copy(), metrics=keep, labels=self.labels,
             group_col=self.group_col, age_col=self.age_col,
             culture_col=self.culture_col, name_col=self.name_col,
-            level=self.level, source=self.source,
+            activity_col=self.activity_col, level=self.level, source=self.source,
         )
 
     def _with_table(self, table: pd.DataFrame) -> "StatsDataset":
@@ -223,7 +272,7 @@ class StatsDataset:
             table=table, metrics=usable_metrics(table, self.metrics),
             labels=self.labels, group_col=self.group_col, age_col=self.age_col,
             culture_col=self.culture_col, name_col=self.name_col,
-            level=self.level, source=self.source,
+            activity_col=self.activity_col, level=self.level, source=self.source,
         )
 
     # ── the feature matrix ───────────────────────────────────────────────────
@@ -352,8 +401,15 @@ def load_dataset(
             # Grp/DIV are carried by both tables and are identical; keeping one
             # copy avoids the _x/_y suffixes a plain merge would introduce.
             drop = [c for c in ("Grp", "DIV", "Lag") if c in act.columns]
+            # A multi-measure CAT-NAP run has one activity row per recording
+            # *per measure*, so the measure is part of the key. Joining on the
+            # name alone would give a recording the wrong measure's event rates
+            # — or, at the recording level, fail the m:1 check outright.
+            keys = list(join_on)
+            if "ActivityType" in act.columns and "ActivityType" in net.columns:
+                keys.append("ActivityType")
             table = net.merge(
-                act.drop(columns=drop), on=join_on, how="left", validate="m:1"
+                act.drop(columns=drop), on=keys, how="left", validate="m:1"
                 if level == "recording" else "m:m")
 
         table["Culture"] = derive_culture_ids(

--- a/src/meanap/stats/figures.py
+++ b/src/meanap/stats/figures.py
@@ -48,6 +48,7 @@ FIGURE_GROUPS: tuple[tuple[str, str, str], ...] = (
     ("decoding", "Decoding", "5C"),
     ("regression", "Variance attribution", "5D"),
     ("density", "Topology at matched density", "5E"),
+    ("measures", "Measure of activity", "5F"),
 )
 
 
@@ -104,6 +105,12 @@ class StatsResults:
     #: The metrics themselves, per group and age, under each level of control.
     control_values: object = None
     regression: RegressionResults | None = None
+    #: Cross-measure comparison for a CAT-NAP run that analysed several
+    #: measures of activity (:class:`meanap.stats.measures.MeasureComparison`).
+    #: Unlike every other field here this describes the *lag* rather than one
+    #: measure of it, so it is filled on a results object of its own rather
+    #: than on any single measure's.
+    measures: object = None
     #: How many metrics the trajectory figure draws. Carried on the results
     #: rather than passed to every call, because the figure catalogue has to
     #: know whether that figure exists at all before anyone asks to draw it.
@@ -121,6 +128,37 @@ class StatsResults:
 
 #: ``key -> (label, caption)`` for every figure with a fixed name.
 _PROSE: dict[str, tuple[str, str]] = {
+    "measure_agreement": (
+        "Agreement between measures of activity",
+        "Spearman correlation between the values each measure of activity gives "
+        "for the same metric, over the recordings both could measure. High means "
+        "the two measures rank the recordings alike, so a comparison built on "
+        "one would rank them the same way on the other; near zero means the "
+        "metric is measuring a different thing under each.",
+    ),
+    "measure_differences": (
+        "How far the values move with the measure",
+        "The paired shift in each metric when the same recordings are measured "
+        "the other way, in pooled standard deviations, tested within recording. "
+        "Filled dots survive FDR correction. A large shift is expected — an "
+        "event network and a correlation network are on different scales — and "
+        "is only a problem when the conclusion moves with it.",
+    ),
+    "measure_concordance": (
+        "Would the conclusion have been the same?",
+        "Each metric's group and age effect measured one way against the same "
+        "effect measured the other. Points on the dashed identity line are "
+        "conclusions that do not depend on how activity was measured; points "
+        "off it, and especially in an off-diagonal quadrant, are conclusions "
+        "that do. Colour is whether both measures called the effect "
+        "significant, one did, or neither; the disagreements are named.",
+    ),
+    "measure_decoding": (
+        "Decoding performance by measure of activity",
+        "The best decoder trained on each measure's own features, against "
+        "chance. Answers which measure carries the most information about the "
+        "target — the practical counterpart of the concordance figure.",
+    ),
     "trajectories": (
         "Trajectories of the top metrics",
         "Mean ± SEM against age for the metrics with the strongest age or "
@@ -342,6 +380,10 @@ _FILENAMES: dict[str, str] = {
     "control_effects": "5E7_control_effects",
     "genotype_effect_by_age": "5E8_genotype_effect_by_age",
     "metric_values": "5E9_metric_values_by_control",
+    "measure_agreement": "5F1_measure_agreement",
+    "measure_differences": "5F2_measure_differences",
+    "measure_concordance": "5F3_measure_concordance",
+    "measure_decoding": "5F4_measure_decoding",
 }
 
 #: Filename stems for the effect heatmaps: the pooled mixed model first, then
@@ -376,6 +418,10 @@ _GROUPS: dict[str, str] = {
     "control_effects": "density",
     "genotype_effect_by_age": "density",
     "metric_values": "density",
+    "measure_agreement": "measures",
+    "measure_differences": "measures",
+    "measure_concordance": "measures",
+    "measure_decoding": "measures",
 }
 
 _EFFECTS_POOLED = (
@@ -484,6 +530,16 @@ def stats_figures(results: StatsResults) -> list[StatsFigure]:
     if (results.families is not None and results.families_controlled is not None
             and not results.families_controlled.table.empty):
         out.append(_fixed("topology_controlled"))
+
+    measures = results.measures
+    if measures is not None and getattr(measures, "ran", False):
+        out.append(_fixed("measure_agreement"))
+        if not measures.differences.empty:
+            out.append(_fixed("measure_differences"))
+        if not measures.concordance.empty:
+            out.append(_fixed("measure_concordance"))
+        if not measures.decoding.empty:
+            out.append(_fixed("measure_decoding"))
 
     reg = results.regression
     if reg is not None and not reg.scores.empty:
@@ -598,6 +654,14 @@ def draw_stats_figure(
         return plots.plot_family_contributions(results.families, out_path)
     if key == "family_alone_vs_unique":
         return plots.plot_family_alone_vs_unique(results.families, out_path)
+    if key == "measure_agreement":
+        return plots.plot_measure_agreement(results.measures, out_path)
+    if key == "measure_differences":
+        return plots.plot_measure_differences(results.measures, out_path)
+    if key == "measure_concordance":
+        return plots.plot_measure_concordance(results.measures, out_path)
+    if key == "measure_decoding":
+        return plots.plot_measure_decoding(results.measures, out_path, scheme=scheme)
     if key == "regression_performance":
         return plots.plot_regression_scores(results.regression, out_path)
     if key == "variance_decomposition":
@@ -691,6 +755,7 @@ def load_results(folder: Path | str, dataset: StatsDataset, *, lag=None,
         from meanap.stats.decoding import lda_projection
 
         results.lda = lda_projection(dataset) or None
+    results.measures = _load_measures(folder)
     results.by_age = _read(folder, "decoding_by_age.csv")
     results.shapley = _load_shapley(folder)
     results.families = _load_families(folder)
@@ -708,6 +773,42 @@ def load_results(folder: Path | str, dataset: StatsDataset, *, lag=None,
     if reg_scores is not None:
         results.regression = _load_regression(folder, reg_scores, dataset, lag)
     return results
+
+
+def _load_measures(folder: Path):
+    """The cross-measure comparison, read back from its five CSVs.
+
+    Rebuilt rather than recomputed because every number in it came from models
+    that are gone by the time a viewer opens the folder — refitting them would
+    be slow and, with a different random seed, would not necessarily agree with
+    the figure beside it.
+    """
+    from meanap.stats.measures import MeasureComparison
+
+    agreement = _read(folder, "measure_agreement.csv")
+    if agreement is None:
+        return None
+    activities: list[str] = []
+    for column in ("MeasureA", "MeasureB"):
+        for value in agreement.get(column, pd.Series(dtype=str)).dropna():
+            if str(value) not in activities:
+                activities.append(str(value))
+    pairs = sorted({(str(a), str(b)) for a, b in
+                    zip(agreement["MeasureA"], agreement["MeasureB"])})
+    return MeasureComparison(
+        lag=agreement["Lag"].iloc[0] if "Lag" in agreement.columns else None,
+        activities=activities, pairs=pairs, agreement=agreement,
+        differences=_frame(folder, "measure_differences.csv"),
+        effects=_frame(folder, "measure_effects.csv"),
+        concordance=_frame(folder, "measure_concordance.csv"),
+        decoding=_frame(folder, "measure_decoding.csv"),
+    )
+
+
+def _frame(folder: Path, name: str) -> pd.DataFrame:
+    """:func:`_read`, but an absent table is an empty frame rather than ``None``."""
+    frame = _read(folder, name)
+    return frame if frame is not None else pd.DataFrame()
 
 
 def _load_shapley(folder: Path):
@@ -893,15 +994,42 @@ def _load_regression(folder: Path, scores: pd.DataFrame, ds: StatsDataset,
 
 
 def available_lags(stats_root: Path | str) -> list[str]:
-    """Lag folder names inside a ``5_StatsAndML`` directory, in the run's order."""
+    """Analysis folders inside a ``5_StatsAndML`` directory, in the run's order.
+
+    Normally one per lag (``1000mslag``, or ``all`` for a run with no lag axis).
+    A CAT-NAP run that analysed several measures of activity nests them one
+    level deeper — ``peaks/1000mslag``, and ``MeasureComparison/1000mslag`` for
+    the comparison across measures — so the names returned are relative paths
+    rather than plain folder names, and a caller joining one onto the root gets
+    the right folder either way.
+    """
     root = Path(stats_root)
     if not root.is_dir():
         return []
-    names = [p.name for p in root.iterdir()
-             if p.is_dir() and any(p.glob("*.csv"))]
+    names: list[str] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        if any(entry.glob("*.csv")):
+            names.append(entry.name)
+            continue
+        # A measure's folder holds no tables of its own, only one folder per
+        # lag beneath it.
+        names.extend(f"{entry.name}/{child.name}" for child in sorted(entry.iterdir())
+                     if child.is_dir() and any(child.glob("*.csv")))
     return sorted(names, key=_lag_sort_key)
 
 
 def _lag_sort_key(name: str):
-    digits = "".join(ch for ch in name if ch.isdigit())
-    return (0, int(digits)) if digits else (1, 0)
+    # Measure name first (so one measure's lags stay together), then the lag,
+    # and the cross-measure comparison last — it is read after the measures it
+    # compares, not between them.
+    prefix, _, stem = str(name).rpartition("/")
+    last = (1, "") if prefix == MEASURES_PREFIX else (0, prefix)
+    digits = "".join(ch for ch in stem if ch.isdigit())
+    return (*last, 0, int(digits)) if digits else (*last, 1, 0)
+
+
+#: Folder name :mod:`meanap.stats.run` gives the cross-measure comparison. Kept
+#: here as well so a reader of a results folder need not import the runner.
+MEASURES_PREFIX = "MeasureComparison"

--- a/src/meanap/stats/measures.py
+++ b/src/meanap/stats/measures.py
@@ -1,0 +1,557 @@
+"""Does the measure of activity you chose change the answer you got?
+
+A CAT-NAP recording has no single "activity". Detected calcium events, the
+deconvolved trace, raw fluorescence and suite2p's spike estimate are four
+different readings of the same field of view, and the pipeline builds a
+different network from each: events give an STTC coincidence network, the three
+continuous traces give a binned Pearson correlation network. Every number
+downstream — event rate, density, modularity, small-worldness, and the genotype
+effect measured on any of them — is conditional on that choice, and until a run
+could analyse several measures at once (``Params.twop_activities``, see
+:mod:`meanap.catnap.activities`) the choice was invisible in the output.
+
+This module reads a multi-measure run back and asks three questions of it, in
+increasing order of what is at stake:
+
+1. **Do the values agree?** Per metric, per pair of measures: how strongly do
+   the recordings rank the same way, how far apart are the values, and is one
+   measure systematically higher (:func:`agreement_table`). A metric that
+   correlates at rho = 0.95 across measures is measuring one thing; one at
+   rho = 0.1 is measuring two.
+
+2. **Do the values differ?** The same recordings measured two ways are paired
+   observations, so the difference is tested within recording — a Wilcoxon
+   signed-rank test and a paired standardised effect size
+   (:func:`difference_table`). This is the question "would my reported mean
+   have been different", and for most metrics the answer is yes and large,
+   which is *expected* and not by itself a problem.
+
+3. **Does the conclusion differ?** The question that actually matters. The
+   run's own group and age comparisons are re-read within each measure and put
+   side by side (:func:`effect_table`, :func:`concordance_table`): same sign?
+   both significant? And the decoders trained per measure are compared on
+   accuracy (:func:`decoding_table`), which says which measure carries more of
+   the signal being looked for. A genotype effect that is significant under
+   ``peaks`` and absent under ``denoised F`` is a finding about the analysis,
+   not about the biology, and it should be visible before publication rather
+   than after.
+
+Nothing here recomputes a model. The per-measure comparisons and decoders are
+already fitted by :mod:`meanap.stats.run`, once per measure, because each
+measure is analysed as a dataset in its own right; this module is handed those
+results and lines them up. That keeps the cost of the whole comparison down to
+a few correlations, and — more importantly — guarantees the effect it reports
+for a measure is the identical number that measure's own ``5A`` table reports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import combinations
+
+import numpy as np
+import pandas as pd
+
+from meanap.stats.comparisons import SIGNED_EFFECT_SIZES, fdr_correct
+from meanap.stats.dataset import StatsDataset
+
+__all__ = [
+    "MeasureComparison",
+    "agreement_table",
+    "compare_measures",
+    "concordance_table",
+    "decoding_table",
+    "difference_table",
+    "effect_table",
+]
+
+#: Terms from the run's own comparison table that a conclusion can hinge on.
+#: The omnibus group test and the age slope are the two headline effects every
+#: MEA-NAP run reports; the pairwise genotype contrasts come along because a
+#: two-group study reads those and not the omnibus.
+_CONCLUSION_FAMILY = "mixed-model"
+
+#: Below this, a metric's two measures are not ranking the recordings alike and
+#: anything either of them says about a group difference is a statement about
+#: that measure rather than about the network. Chosen as the conventional floor
+#: for "good" agreement rather than derived from anything; the number is
+#: reported beside every rho so a reader can apply their own.
+AGREEMENT_FLOOR = 0.5
+
+
+@dataclass
+class MeasureComparison:
+    """Everything the measure comparison produced for one lag."""
+
+    lag: object = None
+    #: Measures compared, in the order the run analysed them (primary first).
+    activities: list[str] = field(default_factory=list)
+    #: Unordered pairs, as ``(A, B)`` with A earlier in *activities* than B.
+    pairs: list[tuple[str, str]] = field(default_factory=list)
+    agreement: pd.DataFrame = field(default_factory=pd.DataFrame)
+    differences: pd.DataFrame = field(default_factory=pd.DataFrame)
+    effects: pd.DataFrame = field(default_factory=pd.DataFrame)
+    concordance: pd.DataFrame = field(default_factory=pd.DataFrame)
+    decoding: pd.DataFrame = field(default_factory=pd.DataFrame)
+    #: Headline counts, for the log line and ``summary.json``.
+    summary: dict = field(default_factory=dict)
+    #: Metric display names, so figures drawn from this need no dataset.
+    labels: dict = field(default_factory=dict)
+
+    @property
+    def ran(self) -> bool:
+        return bool(self.pairs) and not self.agreement.empty
+
+
+# ── the paired frame every table is built from ───────────────────────────────
+
+def _paired(ds: StatsDataset, metric: str) -> pd.DataFrame:
+    """``metric`` per recording per measure, one column per measure.
+
+    Recordings are the pairing unit: the same field of view measured two ways
+    is one observation seen twice, not two observations. Rows where either
+    measure is missing or non-finite are dropped, so every statistic below is
+    computed on exactly the recordings both measures could describe — a metric
+    that is undefined for a recording under one measure must not contribute a
+    half-pair to the comparison.
+    """
+    cols = [ds.name_col, ds.activity_col, metric]
+    frame = ds.table[cols].copy()
+    frame[metric] = pd.to_numeric(frame[metric], errors="coerce")
+    frame = frame.replace([np.inf, -np.inf], np.nan)
+    wide = frame.pivot_table(index=ds.name_col, columns=ds.activity_col,
+                             values=metric, aggfunc="first")
+    return wide
+
+
+def _pair_values(wide: pd.DataFrame, a: str, b: str):
+    """The finite, matched values of two measures — ``(x, y)`` or two empties."""
+    if a not in wide.columns or b not in wide.columns:
+        return np.empty(0), np.empty(0)
+    both = wide[[a, b]].dropna()
+    return both[a].to_numpy(float), both[b].to_numpy(float)
+
+
+def _pairs_of(activities: list[str]) -> list[tuple[str, str]]:
+    return list(combinations(activities, 2))
+
+
+# ── 1. do the values agree? ──────────────────────────────────────────────────
+
+def _concordance_correlation(x: np.ndarray, y: np.ndarray) -> float:
+    """Lin's concordance correlation coefficient.
+
+    Preferred over a plain Pearson r as the single agreement number because r
+    is blind to exactly the failure worth catching here: two measures can
+    correlate at 0.99 while one is three times the other, and r would call that
+    perfect agreement. CCC multiplies r by a bias term that only reaches 1 when
+    the values also lie on the identity line.
+    """
+    if len(x) < 3:
+        return float("nan")
+    vx, vy = x.var(ddof=0), y.var(ddof=0)
+    if vx <= 0 or vy <= 0:
+        return float("nan")
+    cov = float(np.cov(x, y, ddof=0)[0, 1])
+    denom = vx + vy + (x.mean() - y.mean()) ** 2
+    return float(2 * cov / denom) if denom > 0 else float("nan")
+
+
+def agreement_table(ds: StatsDataset, metrics: list[str],
+                    pairs: list[tuple[str, str]]) -> pd.DataFrame:
+    """How closely two measures agree about each metric, over matched recordings.
+
+    Reports both a *ranking* statistic (Spearman rho: do the recordings come out
+    in the same order?) and an *agreement* one (CCC, and the Bland-Altman bias
+    and limits: are the values actually the same?). They answer different
+    questions and a metric can pass one and fail the other — which is the
+    common case, since a correlation network and an event network are on
+    different scales by construction.
+    """
+    from scipy import stats as sps
+
+    rows: list[dict] = []
+    for metric in metrics:
+        wide = _paired(ds, metric)
+        for a, b in pairs:
+            x, y = _pair_values(wide, a, b)
+            row = {"Lag": None, "Metric": metric, "MetricLabel": ds.label(metric),
+                   "MeasureA": a, "MeasureB": b, "N": int(len(x))}
+            if len(x) < 3 or np.allclose(x, x[0]) or np.allclose(y, y[0]):
+                # Two or fewer paired recordings, or a metric that is constant
+                # under one measure: every statistic below would be either
+                # undefined or a coin flip dressed up as a correlation.
+                rows.append({**row, "Spearman": np.nan, "Pearson": np.nan,
+                             "CCC": np.nan, "MeanA": float(np.mean(x)) if len(x) else np.nan,
+                             "MeanB": float(np.mean(y)) if len(y) else np.nan,
+                             "Bias": np.nan, "LoALower": np.nan, "LoAUpper": np.nan,
+                             "Note": "too few matched recordings, or constant"})
+                continue
+            diff = y - x
+            sd_diff = float(np.std(diff, ddof=1))
+            rows.append({
+                **row,
+                "Spearman": float(sps.spearmanr(x, y).statistic),
+                "Pearson": float(sps.pearsonr(x, y).statistic),
+                "CCC": _concordance_correlation(x, y),
+                "MeanA": float(np.mean(x)), "MeanB": float(np.mean(y)),
+                "SDA": float(np.std(x, ddof=1)), "SDB": float(np.std(y, ddof=1)),
+                # Bland-Altman: the mean difference and the interval 95% of
+                # differences fall in. Quoted in the metric's own units, since
+                # "how far apart" is not a question a correlation answers.
+                "Bias": float(np.mean(diff)),
+                "LoALower": float(np.mean(diff) - 1.96 * sd_diff),
+                "LoAUpper": float(np.mean(diff) + 1.96 * sd_diff),
+                "Note": "",
+            })
+    return pd.DataFrame(rows)
+
+
+# ── 2. do the values differ? ─────────────────────────────────────────────────
+
+def _paired_hedges_g(x: np.ndarray, y: np.ndarray) -> float:
+    """Standardised mean difference for paired data, Cumming's ``g_av``.
+
+    Standardised by the *pooled* SD of the two conditions rather than the SD of
+    the differences. The difference-SD version (``g_z``) inflates without limit
+    as the two measures correlate, which they do here by construction — the
+    same recordings measured twice — so it would report an enormous effect for
+    a shift that is small on the metric's own scale. ``g_av`` stays comparable
+    to the between-group effect sizes the rest of the step reports.
+    """
+    n = len(x)
+    if n < 2:
+        return float("nan")
+    sd = np.sqrt((np.var(x, ddof=1) + np.var(y, ddof=1)) / 2.0)
+    if not np.isfinite(sd) or sd <= 0:
+        return float("nan")
+    d = float(np.mean(y - x) / sd)
+    # Hedges' small-sample correction, on the paired degrees of freedom.
+    j = 1.0 - 3.0 / (4.0 * (n - 1) - 1) if n > 2 else 1.0
+    return d * j
+
+
+def difference_table(ds: StatsDataset, metrics: list[str],
+                     pairs: list[tuple[str, str]]) -> pd.DataFrame:
+    """Within-recording differences between measures, tested and sized.
+
+    FDR-corrected across metrics *within* each pair of measures: the family of
+    tests a reader scans is "which of my metrics moved when I changed measure",
+    and correcting across pairs as well would penalise a three-measure run for
+    asking the same question three times.
+    """
+    from scipy import stats as sps
+
+    rows: list[dict] = []
+    for metric in metrics:
+        wide = _paired(ds, metric)
+        for a, b in pairs:
+            x, y = _pair_values(wide, a, b)
+            diff = y - x
+            row = {"Lag": None, "Metric": metric, "MetricLabel": ds.label(metric),
+                   "MeasureA": a, "MeasureB": b, "N": int(len(x))}
+            if len(x) < 5 or np.allclose(diff, 0):
+                rows.append({**row, "Statistic": np.nan, "PValue": np.nan,
+                             "HedgesG": np.nan, "MedianDiff": float(np.median(diff))
+                             if len(diff) else np.nan, "PercentChange": np.nan,
+                             "Note": "too few matched recordings, or identical"})
+                continue
+            try:
+                test = sps.wilcoxon(x, y)
+                stat, pval = float(test.statistic), float(test.pvalue)
+            except ValueError as exc:  # all-zero differences, or too few
+                stat, pval = np.nan, np.nan
+                row["Note"] = str(exc)
+            median_a = float(np.median(x))
+            rows.append({
+                **row,
+                "Statistic": stat, "PValue": pval,
+                "HedgesG": _paired_hedges_g(x, y),
+                "MedianDiff": float(np.median(diff)),
+                # Relative change is the readable one for rates and counts and
+                # meaningless for a metric that crosses zero, so it is left
+                # blank there rather than reported as a huge number.
+                "PercentChange": (float(np.median(diff) / median_a * 100.0)
+                                  if abs(median_a) > 1e-12 else np.nan),
+                "Note": row.get("Note", ""),
+            })
+    table = pd.DataFrame(rows)
+    if table.empty:
+        return table
+    table["PValueFDR"] = np.nan
+    for _, idx in table.groupby(["MeasureA", "MeasureB"], dropna=False).groups.items():
+        table.loc[idx, "PValueFDR"] = fdr_correct(table.loc[idx, "PValue"])
+    return table
+
+
+# ── 3. does the conclusion differ? ───────────────────────────────────────────
+
+def effect_table(comparisons: dict, metrics: list[str] | None = None) -> pd.DataFrame:
+    """Each measure's own group and age effects, stacked into one table.
+
+    *comparisons* is ``{measure: ComparisonResults}`` — the results
+    :mod:`meanap.stats.run` already fitted for each measure separately. Only the
+    pooled mixed-model family is kept: the per-age cross-sections multiply the
+    rows by the number of ages without changing the question being asked here.
+    """
+    frames = []
+    for activity, results in comparisons.items():
+        table = getattr(results, "table", None)
+        if table is None or table.empty:
+            continue
+        sub = table[table["Family"] == _CONCLUSION_FAMILY].copy()
+        if metrics is not None:
+            sub = sub[sub["Metric"].isin(metrics)]
+        if sub.empty:
+            continue
+        sub.insert(0, "ActivityType", activity)
+        frames.append(sub)
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def concordance_table(effects: pd.DataFrame, pairs: list[tuple[str, str]],
+                      *, alpha: float = 0.05) -> pd.DataFrame:
+    """Whether two measures reach the same conclusion about each metric.
+
+    One row per (metric, term, pair of measures) carrying both effect sizes,
+    both p-values, and a plain-language ``Verdict``:
+
+    ``agree (both significant)``
+        The same effect, in the same direction, found under both measures.
+        The only verdict that lets a result be quoted without naming the
+        measure it came from.
+    ``agree (neither significant)``
+        Nothing found either way — concordant, but only as an absence.
+    ``disagree (only <measure>)``
+        Significant under one measure and not the other. Whichever measure was
+        reported, the other one would have told a different story.
+    ``disagree (opposite signs)``
+        Significant under both, pointing opposite ways. The worst case, and the
+        one worth checking the raw traces over.
+
+    Significance is read off the FDR-corrected p-value, because that is what the
+    ``5A`` tables and figures report; a verdict that disagreed with the figure
+    beside it would be worse than no verdict.
+    """
+    if effects.empty:
+        return pd.DataFrame()
+
+    pcol = "PValueFDR" if "PValueFDR" in effects.columns else "PValue"
+    rows: list[dict] = []
+    keys = ["Metric", "Term"]
+    for (metric, term), block in effects.groupby(keys, dropna=False):
+        by_measure = block.set_index("ActivityType")
+        label = str(block["MetricLabel"].iloc[0]) if "MetricLabel" in block else metric
+        for a, b in pairs:
+            if a not in by_measure.index or b not in by_measure.index:
+                continue
+            ra, rb = by_measure.loc[a], by_measure.loc[b]
+            # A metric can appear twice under one measure only if the run's own
+            # table did, which it does not; guard anyway so a duplicated row
+            # cannot turn a Series into a DataFrame and crash the whole step.
+            if isinstance(ra, pd.DataFrame):
+                ra = ra.iloc[0]
+            if isinstance(rb, pd.DataFrame):
+                rb = rb.iloc[0]
+            ea, eb = _effect_of(ra), _effect_of(rb)
+            pa, pb = float(ra.get(pcol, np.nan)), float(rb.get(pcol, np.nan))
+            sig_a, sig_b = pa < alpha, pb < alpha
+            # Some terms are unsigned by construction — the omnibus group test
+            # reports a chi-square, which has no direction. Two measures that
+            # both find such an effect agree about it; calling that "opposite
+            # signs" because neither had a sign to compare would invent a
+            # disagreement out of the test's own arithmetic.
+            directional = bool(np.isfinite(ea) and np.isfinite(eb))
+            same_sign = bool(np.sign(ea) == np.sign(eb)) if directional else None
+            if sig_a and sig_b:
+                verdict = ("disagree (opposite signs)" if same_sign is False
+                           else "agree (both significant)")
+            elif sig_a or sig_b:
+                verdict = f"disagree (only {a if sig_a else b})"
+            else:
+                verdict = "agree (neither significant)"
+            rows.append({
+                "Lag": ra.get("Lag"), "Metric": metric, "MetricLabel": label,
+                "Term": term, "MeasureA": a, "MeasureB": b,
+                "EffectA": ea, "EffectB": eb, "PValueA": pa, "PValueB": pb,
+                "SignificantA": bool(sig_a), "SignificantB": bool(sig_b),
+                "Directional": directional, "SameSign": same_sign,
+                "Verdict": verdict,
+                "EffectSizeName": ra.get("EffectSizeName", ""),
+            })
+    return pd.DataFrame(rows)
+
+
+def _effect_of(row) -> float:
+    """A row's signed effect size, or ``nan`` when the term has none.
+
+    Not every row in the comparison table carries a direction. The omnibus group
+    test reports a chi-square and the age x group interaction reports a
+    degrees-of-freedom count; both are real results, and reading either as an
+    effect size would put a metric on the concordance scatter at a position that
+    means nothing. ``nan`` is the honest answer, and the verdict logic then
+    judges those terms on significance alone.
+    """
+    if str(row.get("EffectSizeName", "")) not in SIGNED_EFFECT_SIZES:
+        return float("nan")
+    for key in ("EffectSize", "Estimate"):
+        value = row.get(key, np.nan)
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(value):
+            return value
+    return float("nan")
+
+
+def decoding_table(decoding: dict) -> pd.DataFrame:
+    """Best decoding score per measure — which measure carries the signal.
+
+    *decoding* is ``{measure: DecodingResults}``. The best model rather than the
+    mean over models: the question is how much the features of this measure can
+    be made to say about the target, and averaging in a model that happened to
+    suit one measure's feature geometry answers a different one. The winning
+    model's name is reported alongside so a reader can see when the measures
+    were not won by the same one.
+    """
+    rows: list[dict] = []
+    for activity, results in decoding.items():
+        summary = getattr(results, "summary", None)
+        table = summary() if callable(summary) else None
+        if table is None or table.empty:
+            continue
+        best = table.sort_values("BalancedAccuracy", ascending=False).iloc[0]
+        rows.append({
+            "ActivityType": activity,
+            "Target": getattr(results, "target", ""),
+            "Model": best.get("Model", ""),
+            "BalancedAccuracy": float(best.get("BalancedAccuracy", np.nan)),
+            "SD": float(best.get("SD", np.nan)),
+            "Chance": float(getattr(results, "chance", np.nan)),
+            "PValue": float(best.get("PValue", np.nan)),
+            "NRecordings": int(getattr(results, "n_samples", 0)),
+            "NFeatures": len(getattr(results, "features", []) or []),
+        })
+    return pd.DataFrame(rows)
+
+
+# ── putting it together ──────────────────────────────────────────────────────
+
+def compare_measures(
+    ds: StatsDataset,
+    *,
+    comparisons: dict | None = None,
+    decoding: dict | None = None,
+    metrics: list[str] | None = None,
+    lag=None,
+    alpha: float = 0.05,
+) -> MeasureComparison:
+    """Compare every measure of activity in *ds* against every other.
+
+    *ds* holds one lag's rows for all measures. *comparisons* and *decoding*
+    are the per-measure results the run already fitted, keyed by measure; both
+    are optional, and without them the two value-level tables are still
+    produced — which is the whole analysis for a run whose comparisons were
+    switched off.
+
+    Returns an empty :class:`MeasureComparison` (``ran`` False) when the run
+    used one measure. That is not a failure: it is what every ephys run and
+    every ordinary CAT-NAP run looks like, and the caller skips the outputs.
+    """
+    activities = ds.activities
+    result = MeasureComparison(lag=lag, activities=list(activities))
+    if len(activities) < 2:
+        return result
+
+    names = [m for m in (metrics or ds.metrics) if m in ds.table.columns]
+    pairs = _pairs_of(list(activities))
+    result.pairs = pairs
+    result.labels = {m: ds.label(m) for m in names}
+
+    result.agreement = agreement_table(ds, names, pairs)
+    result.differences = difference_table(ds, names, pairs)
+    for frame in (result.agreement, result.differences):
+        if not frame.empty:
+            frame["Lag"] = lag
+
+    result.effects = effect_table(comparisons or {}, names)
+    result.concordance = concordance_table(result.effects, pairs, alpha=alpha)
+    result.decoding = decoding_table(decoding or {})
+    result.summary = _summarise(result, alpha=alpha)
+    return result
+
+
+def _summarise(result: MeasureComparison, *, alpha: float) -> dict:
+    """The handful of numbers worth putting in a log line and ``summary.json``."""
+    out: dict = {
+        "activities": list(result.activities),
+        "n_pairs": len(result.pairs),
+    }
+    agree = result.agreement
+    if not agree.empty:
+        rho = pd.to_numeric(agree["Spearman"], errors="coerce")
+        out["n_metrics"] = int(agree["Metric"].nunique())
+        out["median_spearman"] = float(rho.median()) if rho.notna().any() else None
+        out["n_poorly_agreeing"] = int((rho.abs() < AGREEMENT_FLOOR).sum())
+        weak = agree.loc[rho.abs() < AGREEMENT_FLOOR, "Metric"]
+        out["poorly_agreeing_metrics"] = sorted(set(weak.astype(str)))[:20]
+    diffs = result.differences
+    if not diffs.empty and "PValueFDR" in diffs:
+        out["n_metrics_shifted"] = int((diffs["PValueFDR"] < alpha).sum())
+        out["n_comparisons"] = int(len(diffs))
+    conc = result.concordance
+    if not conc.empty:
+        counts = conc["Verdict"].value_counts()
+        out["verdicts"] = {str(k): int(v) for k, v in counts.items()}
+        disagreeing = conc[conc["Verdict"].str.startswith("disagree")]
+        out["n_conclusions_disagreeing"] = int(len(disagreeing))
+        out["conclusions_disagreeing"] = sorted(
+            {f"{r.Metric} ({r.Term})" for r in disagreeing.itertuples()})[:20]
+    dec = result.decoding
+    if not dec.empty:
+        best = dec.sort_values("BalancedAccuracy", ascending=False).iloc[0]
+        out["best_decoding_measure"] = str(best["ActivityType"])
+        out["best_decoding_accuracy"] = float(best["BalancedAccuracy"])
+    return out
+
+
+def summary_lines(result: MeasureComparison) -> list[str]:
+    """The comparison in prose, for the run log.
+
+    Written as sentences rather than a table because this is the part of the
+    step a reader most needs to *notice*: a run whose conclusions move with the
+    measure should say so where it cannot be scrolled past.
+    """
+    s = result.summary
+    if not result.ran:
+        return []
+    lines = [f"  measures compared: {', '.join(result.activities)}"]
+    if s.get("median_spearman") is not None:
+        lines.append(
+            f"  metric agreement across measures: median Spearman rho = "
+            f"{s['median_spearman']:.2f} over {s.get('n_metrics', 0)} metrics; "
+            f"{s.get('n_poorly_agreeing', 0)} comparison(s) below "
+            f"rho = {AGREEMENT_FLOOR}")
+    if "n_metrics_shifted" in s:
+        lines.append(
+            f"  values shifted with the measure in {s['n_metrics_shifted']} of "
+            f"{s.get('n_comparisons', 0)} metric x measure-pair comparisons "
+            "(paired Wilcoxon, FDR-corrected)")
+    if "n_conclusions_disagreeing" in s:
+        n = s["n_conclusions_disagreeing"]
+        total = sum(s.get("verdicts", {}).values())
+        lines.append(
+            f"  group/age conclusions: {total - n} of {total} agree across "
+            f"measures, {n} do not")
+        for name in s.get("conclusions_disagreeing", [])[:5]:
+            lines.append(f"    disagrees: {name}")
+        if n > 5:
+            lines.append(f"    …and {n - 5} more (see measure_concordance.csv)")
+    if "best_decoding_measure" in s:
+        lines.append(
+            f"  best decoding: {s['best_decoding_measure']} at "
+            f"{s['best_decoding_accuracy']:.2f} balanced accuracy")
+    return lines

--- a/src/meanap/stats/plots.py
+++ b/src/meanap/stats/plots.py
@@ -47,6 +47,10 @@ __all__ = [
     "plot_family_alone_vs_unique",
     "plot_family_contributions",
     "plot_lda_projection",
+    "plot_measure_agreement",
+    "plot_measure_concordance",
+    "plot_measure_decoding",
+    "plot_measure_differences",
     "plot_metric_trajectories",
     "plot_observed_vs_predicted",
     "plot_pca_variance",
@@ -126,9 +130,10 @@ def plot_effect_heatmap(
     makes a huge effect in a small group look identical to a trivial effect in
     a large one.
     """
+    from meanap.stats.comparisons import SIGNED_EFFECT_SIZES
+
     sub = table[table["Family"] == family]
-    sub = sub[sub["EffectSizeName"].isin(
-        {"standardised beta", "SD change across age range", "Hedges g", "Cohen dz"})]
+    sub = sub[sub["EffectSizeName"].isin(SIGNED_EFFECT_SIZES)]
     if sub.empty:
         return None
 
@@ -1632,4 +1637,250 @@ def plot_metric_values(
              "scaled on its own. Every condition uses the recordings all of "
              "them have.",
              fontsize=7.5, color=MUTED, va="bottom")
+    return _save(fig, out_path)
+
+
+# ── measure of activity ──────────────────────────────────────────────────────
+#
+# Four figures answering one question in increasing order of consequence: do
+# the measures rank recordings alike, do they give the same values, do they
+# give the same conclusion, and which of them carries the most signal. See
+# meanap.stats.measures for what each table means.
+
+def _pair_label(a: str, b: str) -> str:
+    return f"{a} vs {b}"
+
+
+def plot_measure_agreement(result, out_path: Path) -> Path | None:
+    """Metrics × measure pairs, coloured by how alike the two measures rank them.
+
+    Spearman rho rather than the agreement coefficient beside it in the table:
+    the ranking is the part that has to hold for a group comparison to survive
+    a change of measure, and two measures on different scales — which an event
+    network and a correlation network always are — would show as poor agreement
+    on any statistic that also asks for the same *values*.
+
+    Signed, and drawn on the diverging map for that reason: a metric that
+    anti-correlates across measures is a much louder finding than one that
+    merely fails to correlate, and a sequential map would hide the difference
+    at the bottom of the scale.
+    """
+    table = getattr(result, "agreement", None)
+    if table is None or table.empty:
+        return None
+    sub = table.copy()
+    sub["Pair"] = [_pair_label(a, b) for a, b in zip(sub["MeasureA"], sub["MeasureB"])]
+    wide = sub.pivot_table(index="MetricLabel", columns="Pair", values="Spearman")
+    wide = wide.dropna(how="all").dropna(axis=1, how="all")
+    if wide.empty:
+        return None
+    # Worst agreement at the top: those are the rows a reader has to act on.
+    wide = wide.reindex(wide.abs().min(axis=1).sort_values().index)
+
+    n_rows, n_cols = wide.shape
+    fig, ax = plt.subplots(figsize=(max(4.0, 1.9 * n_cols + 2.4),
+                                    max(3.0, 0.28 * n_rows + 1.4)))
+    mesh = ax.imshow(wide.to_numpy(), cmap=DIVERGING, vmin=-1, vmax=1, aspect="auto")
+
+    norm = matplotlib.colors.Normalize(vmin=-1, vmax=1)
+    cmap = matplotlib.colormaps[DIVERGING]
+    for i in range(n_rows):
+        for j in range(n_cols):
+            value = wide.iat[i, j]
+            if not np.isfinite(value):
+                continue
+            r, g, b, _ = cmap(norm(value))
+            ink = "white" if (0.299 * r + 0.587 * g + 0.114 * b) < 0.55 else INK
+            ax.text(j, i, f"{value:.2f}", ha="center", va="center",
+                    fontsize=7, color=ink)
+
+    ax.set_xticks(range(n_cols))
+    ax.set_xticklabels(wide.columns, rotation=20, ha="right", fontsize=8)
+    ax.set_yticks(range(n_rows))
+    ax.set_yticklabels(wide.index, fontsize=7)
+    ax.set_title("Do the measures rank recordings the same way?\n"
+                 "Spearman rho between measures, over matched recordings",
+                 fontsize=10)
+    bar = fig.colorbar(mesh, ax=ax, fraction=0.035, pad=0.02)
+    bar.set_label("Spearman rho", fontsize=8)
+    bar.ax.tick_params(labelsize=7)
+    return _save(fig, out_path)
+
+
+def plot_measure_differences(result, out_path: Path, *, alpha: float = 0.05,
+                             limit: int = 30) -> Path | None:
+    """Paired standardised difference per metric, largest shift first.
+
+    A dot per metric per measure pair, at ``g_av`` — the shift in the metric
+    when the same recordings are measured the other way, in pooled standard
+    deviations. Filled dots survived FDR correction; open dots did not.
+
+    The zero line is the claim being tested: a metric sitting on it is one whose
+    reported mean would not have changed had the other measure been used.
+    """
+    table = getattr(result, "differences", None)
+    if table is None or table.empty:
+        return None
+    sub = table.dropna(subset=["HedgesG"]).copy()
+    if sub.empty:
+        return None
+    sub["Pair"] = [_pair_label(a, b) for a, b in zip(sub["MeasureA"], sub["MeasureB"])]
+
+    # Rank metrics by their largest shift under any pair, then keep the top
+    # few: fifty rows of dots is a figure nobody reads, and the full table is
+    # on disk beside it.
+    order = (sub.groupby("MetricLabel")["HedgesG"].apply(lambda v: v.abs().max())
+             .sort_values(ascending=False))
+    keep = list(order.index[:limit])
+    sub = sub[sub["MetricLabel"].isin(keep)]
+    positions = {name: i for i, name in enumerate(reversed(keep))}
+
+    pairs = list(pd.unique(sub["Pair"]))
+    colours = dict(zip(pairs, plt.get_cmap("tab10").colors))
+    offsets = np.linspace(-0.22, 0.22, len(pairs)) if len(pairs) > 1 else [0.0]
+
+    fig, ax = plt.subplots(figsize=(6.4, max(3.0, 0.26 * len(keep) + 1.4)))
+    ax.axvline(0.0, color=MUTED, lw=1.0, zorder=0)
+    pcol = "PValueFDR" if "PValueFDR" in sub.columns else "PValue"
+    for pair, offset in zip(pairs, offsets):
+        block = sub[sub["Pair"] == pair]
+        y = [positions[name] + offset for name in block["MetricLabel"]]
+        sig = pd.to_numeric(block[pcol], errors="coerce") < alpha
+        colour = colours[pair]
+        ax.scatter(block["HedgesG"][sig], np.asarray(y)[sig.to_numpy()],
+                   s=26, color=colour, label=pair, zorder=3)
+        ax.scatter(block["HedgesG"][~sig], np.asarray(y)[~sig.to_numpy()],
+                   s=26, facecolors="none", edgecolors=colour, zorder=3)
+
+    ax.set_yticks(list(positions.values()))
+    ax.set_yticklabels(list(positions.keys()), fontsize=7)
+    ax.set_xlabel("paired difference between measures (Hedges' g$_{av}$)", fontsize=9)
+    ax.set_title("How far do the values move when the measure changes?\n"
+                 f"filled = significant after FDR correction (p < {alpha})",
+                 fontsize=10)
+    if len(pairs) > 1:
+        ax.legend(fontsize=7, frameon=False, loc="best")
+    _bare(ax)
+    return _save(fig, out_path)
+
+
+#: Colour per concordance verdict. Green for the two agreements, warm for the
+#: two disagreements, so the figure reads before the legend does.
+_VERDICT_COLORS = {
+    "agree (both significant)": "#2f7d46",
+    "agree (neither significant)": "#9dbfa6",
+    "disagree (opposite signs)": "#a12a2a",
+}
+_VERDICT_DEFAULT = "#e08b2c"   # "disagree (only <measure>)", one per measure
+
+
+def plot_measure_concordance(result, out_path: Path) -> Path | None:
+    """Each metric's group/age effect under one measure against the other.
+
+    The figure the whole comparison exists for. A point on the identity line is
+    a conclusion that does not depend on how activity was measured; a point far
+    off it, and especially one in an off-diagonal quadrant, is a conclusion that
+    does. Colour carries the verdict — whether both measures called it
+    significant, one did, or neither.
+
+    Drawn per measure pair as its own panel so the axes can be read as "the
+    effect I would have reported using this measure".
+    """
+    table = getattr(result, "concordance", None)
+    if table is None or table.empty:
+        return None
+    sub = table.dropna(subset=["EffectA", "EffectB"]).copy()
+    if sub.empty:
+        return None
+
+    pairs = sorted({(a, b) for a, b in zip(sub["MeasureA"], sub["MeasureB"])})
+    n = len(pairs)
+    fig, axes = plt.subplots(1, n, figsize=(4.2 * n, 4.2), squeeze=False)
+    for ax, (a, b) in zip(axes[0], pairs):
+        block = sub[(sub["MeasureA"] == a) & (sub["MeasureB"] == b)]
+        limit = float(np.nanmax(np.abs(
+            np.concatenate([block["EffectA"], block["EffectB"]])))) or 1.0
+        limit *= 1.15
+        ax.plot([-limit, limit], [-limit, limit], color=MUTED, lw=1.0, ls="--",
+                zorder=0)
+        ax.axhline(0, color=MUTED, lw=0.6, zorder=0)
+        ax.axvline(0, color=MUTED, lw=0.6, zorder=0)
+        for verdict, part in block.groupby("Verdict"):
+            colour = _VERDICT_COLORS.get(str(verdict), _VERDICT_DEFAULT)
+            ax.scatter(part["EffectA"], part["EffectB"], s=30, color=colour,
+                       edgecolors="white", linewidths=0.4, label=str(verdict),
+                       zorder=3)
+        # Name only the points that disagree: labelling all fifty would bury
+        # the four that matter.
+        off = block[block["Verdict"].str.startswith("disagree")]
+        for row in off.itertuples():
+            ax.annotate(str(row.Metric), (row.EffectA, row.EffectB),
+                        textcoords="offset points", xytext=(4, 3), fontsize=6,
+                        color=INK)
+        ax.set_xlim(-limit, limit)
+        ax.set_ylim(-limit, limit)
+        ax.set_xlabel(f"effect under {a}", fontsize=9)
+        ax.set_ylabel(f"effect under {b}", fontsize=9)
+        ax.set_aspect("equal", adjustable="box")
+        _bare(ax)
+
+    handles, labels = axes[0][-1].get_legend_handles_labels()
+    if handles:
+        fig.legend(handles, labels, fontsize=7, frameon=False,
+                   loc="lower center", ncol=min(4, len(labels)),
+                   bbox_to_anchor=(0.5, -0.06))
+    fig.suptitle("Would the conclusion have been the same?\n"
+                 "group and age effects, measured each way", fontsize=10)
+    fig.tight_layout()
+    return _save(fig, out_path)
+
+
+def plot_measure_decoding(result, out_path: Path, *, scheme=None) -> Path | None:
+    """Best decoding score per measure, against chance.
+
+    Which measure carries the most information about the target — the practical
+    counterpart of the concordance figure, and the one to read when the answer
+    to "which measure should I use" has to be a single name.
+    """
+    table = getattr(result, "decoding", None)
+    if table is None or table.empty:
+        return None
+    sub = table.dropna(subset=["BalancedAccuracy"]).sort_values(
+        "BalancedAccuracy", ascending=True)
+    if sub.empty:
+        return None
+    scheme = scheme or DEFAULT_SCHEME
+
+    colours = scheme.groups(len(sub))
+    fig, ax = plt.subplots(figsize=(5.6, max(2.4, 0.5 * len(sub) + 1.4)))
+    y = np.arange(len(sub))
+    errs = pd.to_numeric(sub["SD"], errors="coerce").fillna(0.0).to_numpy()
+    ax.barh(y, sub["BalancedAccuracy"], xerr=errs, color=colours, height=0.6,
+            error_kw={"ecolor": MUTED, "elinewidth": 1.0, "capsize": 3})
+    chance = pd.to_numeric(sub["Chance"], errors="coerce").dropna()
+    if len(chance):
+        ax.axvline(float(chance.iloc[0]), color=INK, ls="--", lw=1.0,
+                   label="chance")
+        ax.legend(fontsize=7, frameon=False, loc="lower right")
+
+    for i, row in enumerate(sub.itertuples()):
+        mark = _stars(getattr(row, "PValue", np.nan))
+        # Past the error bar, not past the bar: a wide interval would otherwise
+        # run straight through the model's name.
+        ax.text(float(row.BalancedAccuracy) + float(errs[i]) + 0.015, i,
+                f"{row.Model}{(' ' + mark) if mark else ''}", va="center",
+                fontsize=7, color=INK)
+
+    ax.set_yticks(y)
+    ax.set_yticklabels(sub["ActivityType"], fontsize=8)
+    ax.set_xlabel("balanced accuracy (best model)", fontsize=9)
+    # Room past 1.0 for the winning model's name, which sits at the bar's end.
+    # Without it a measure that decodes perfectly has its label clipped, which
+    # is exactly the row a reader looks at first.
+    ax.set_xlim(0, 1.22)
+    ax.set_xticks([0.0, 0.2, 0.4, 0.6, 0.8, 1.0])
+    target = _target_label(str(sub["Target"].iloc[0])) if "Target" in sub else "target"
+    ax.set_title(f"Which measure carries the most information about {target}?",
+                 fontsize=10)
+    _bare(ax)
     return _save(fig, out_path)

--- a/src/meanap/stats/run.py
+++ b/src/meanap/stats/run.py
@@ -39,6 +39,7 @@ from meanap.stats.density_sweep import (
     selection_sensitivity,
 )
 from meanap.stats.figures import StatsResults, draw_stats_figure, stats_figures
+from meanap.stats.measures import compare_measures, summary_lines
 from meanap.stats.regression import regress
 
 __all__ = ["StatsRunResult", "StatsSettings", "run_stats", "OUTPUT_DIRNAME"]
@@ -69,6 +70,12 @@ class StatsSettings:
     #: recordings across 16 cores it was ~15 minutes without subsampling and
     #: ~25 minutes with it.
     density_sweep: bool = False
+    #: Compare the measures of activity a CAT-NAP run analysed against each
+    #: other (:mod:`meanap.stats.measures`). On by default and free: it reads
+    #: the per-measure results the four analyses above already produced, and a
+    #: run with one measure — every ephys run, and every CAT-NAP run that did
+    #: not set ``Params.twop_activities`` — has nothing to compare and skips it.
+    measure_comparison: bool = True
 
     #: Restrict to these metrics; empty means every metric the run computed.
     metrics: tuple[str, ...] = ()
@@ -235,37 +242,74 @@ def run_stats(
             "in a way this can read. Repeated-measures handling is inert.")
 
     lags = ds.lags or [None]
-    for lag in lags:
-        sub = ds.for_lag(lag) if lag is not None else ds
-        folder = dest / (_lag_dirname(lag) if lag is not None else "all")
-        folder.mkdir(parents=True, exist_ok=True)
-        log(f"— {folder.name}: {len(sub.table)} recordings")
+    # A CAT-NAP run that analysed several measures of activity is analysed once
+    # per measure, exactly as it is analysed once per lag and for the same
+    # reason: two measures of one recording are two measurements, and a model
+    # or a decoder pooling them would treat one culture as two independent
+    # samples. What compares *across* measures runs afterwards, on the results
+    # collected here — see meanap.stats.measures.
+    activities = ds.activities or [None]
+    if len(activities) > 1:
+        log(f"Measures of activity in this run: {', '.join(map(str, activities))} "
+            "— each analysed separately, then compared")
 
-        # The analyses fill this in; the figures are drawn from it afterwards,
-        # through the same catalogue the exporter and the viewer draw through
-        # (meanap.stats.figures). Drawing here instead would give this module
-        # its own private list of which figures exist, and three lists that
-        # must agree is two too many.
-        computed = StatsResults(dataset=sub, lag=lag,
-                                n_trajectory_metrics=settings.n_trajectory_metrics)
-        for name, fn in (
-            ("comparisons", _run_comparisons),
-            ("correlation", _run_correlation),
-            ("decoding", _run_decoding),
-            ("regression", _run_regression),
-            ("density_sweep", _run_density_sweep),
-        ):
-            if not getattr(settings, name):
-                continue
+    # ``{lag: {measure: results}}``, for the cross-measure comparison below.
+    per_measure: dict = {lag: {"comparisons": {}, "decoding": {}} for lag in lags}
+
+    for activity in activities:
+        for lag in lags:
+            sub = ds.for_lag(lag) if lag is not None else ds
+            if activity is not None:
+                sub = sub.for_activity(activity)
+            name = _analysis_dirname(activity, lag)
+            folder = dest / name
+            folder.mkdir(parents=True, exist_ok=True)
+            # The name, not the basename: a multi-measure run has one folder per
+            # (measure, lag), and three log lines all reading "1000mslag" say
+            # nothing about which measure is being analysed.
+            log(f"— {name}: {len(sub.table)} recordings")
+
+            # The analyses fill this in; the figures are drawn from it afterwards,
+            # through the same catalogue the exporter and the viewer draw through
+            # (meanap.stats.figures). Drawing here instead would give this module
+            # its own private list of which figures exist, and three lists that
+            # must agree is two too many.
+            computed = StatsResults(dataset=sub, lag=lag,
+                                    n_trajectory_metrics=settings.n_trajectory_metrics)
+            for fn_name, fn in (
+                ("comparisons", _run_comparisons),
+                ("correlation", _run_correlation),
+                ("decoding", _run_decoding),
+                ("regression", _run_regression),
+                ("density_sweep", _run_density_sweep),
+            ):
+                if not getattr(settings, fn_name):
+                    continue
+                try:
+                    fn(sub, folder, settings, result, lag, log, progress, computed,
+                       sweep_root)
+                except Exception as exc:  # one analysis failing must not stop the rest
+                    result.skipped.append(f"{name}/{fn_name}: {exc}")
+                    log(f"  ! {fn_name} failed: {exc}")
+                    log(traceback.format_exc(limit=3))
+
+            _draw_all(computed, folder, settings, scheme, result, log)
+
+            if activity is not None:
+                if computed.comparisons is not None:
+                    per_measure[lag]["comparisons"][activity] = computed.comparisons
+                if computed.decoding is not None:
+                    per_measure[lag]["decoding"][activity] = computed.decoding
+
+    if settings.measure_comparison and len(activities) > 1:
+        for lag in lags:
             try:
-                fn(sub, folder, settings, result, lag, log, progress, computed,
-                   sweep_root)
-            except Exception as exc:  # one analysis failing must not stop the rest
-                result.skipped.append(f"{folder.name}/{name}: {exc}")
-                log(f"  ! {name} failed: {exc}")
+                _run_measure_comparison(ds, dest, settings, scheme, result, lag,
+                                        per_measure[lag], log, progress)
+            except Exception as exc:
+                result.skipped.append(f"measures/{lag}: {exc}")
+                log(f"  ! measure comparison failed: {exc}")
                 log(traceback.format_exc(limit=3))
-
-        _draw_all(computed, folder, settings, scheme, result, log)
 
     if sweep_bundle is not None:
         sweep_bundle.close()
@@ -288,6 +332,11 @@ def _run_density_sweep(ds: StatsDataset, folder: Path, settings,
     once per lag would be the dominant cost on a multi-lag run.
     """
     log("  density sweep: topology at matched connection density")
+    # A multi-measure CAT-NAP run stores each measure's adjacency in that
+    # measure's own subtree. Sweeping the run root for every measure would
+    # silently re-measure the primary measure's matrices and label them with
+    # whichever measure's folder they landed in.
+    source_root = _activity_source_root(source_root, ds)
     n_nodes = _resolve_target_nodes(source_root, settings, log)
     sweep = run_density_sweep(
         source_root, densities=settings.sweep_densities,
@@ -707,6 +756,178 @@ def _lag_dirname(lag) -> str:
     return str(lag).replace("/", "-").replace(" ", "")
 
 
+#: Folder holding the cross-measure comparison, one subfolder per lag. Its own
+#: top-level folder rather than a file inside each measure's, because it belongs
+#: to no single measure — filing it under one would suggest it did.
+MEASURES_DIRNAME = "MeasureComparison"
+
+
+def _shared_metrics(ds: StatsDataset) -> list[str]:
+    """Metrics usable under *every* measure of activity, in the run's order.
+
+    A metric that only one measure produces cannot be compared across measures:
+    ``RC`` and ``effRank`` are computed on some activity types and not others,
+    and the event-shape metrics (event amplitude, duration, area) exist only for
+    detected peaks. They belong in that measure's own results and nowhere in a
+    comparison against a measure that never had them.
+    """
+    per_measure = [set(ds.for_activity(a).metrics) for a in ds.activities]
+    if not per_measure:
+        return list(ds.metrics)
+    common = set.intersection(*per_measure)
+    return [m for m in ds.metrics if m in common]
+
+
+def _comparable_decoding(ds: StatsDataset, shared: list[str], collected: dict,
+                         settings, lag, log, progress) -> dict:
+    """Decoding results for every measure, trained on the same features.
+
+    The per-measure decoders in the folders above each use that measure's own
+    usable metrics, which is right for those folders and wrong for a comparison:
+    with 50 features under one measure and 47 under another, the difference in
+    accuracy is partly a difference in feature set rather than in the measure.
+    So unless every measure already decoded on identical features, they are
+    decoded again here on the shared set.
+
+    Reusing when the sets already agree is not just a saving — a re-run with a
+    different fold split would put slightly different numbers on 5F4 than the
+    ``5C`` figures beside it, for no gain.
+    """
+    feature_sets = {tuple(getattr(r, "features", []) or ()) for r in collected.values()}
+    if collected and len(collected) == len(ds.activities) and len(feature_sets) == 1:
+        return collected
+
+    out = {}
+    log(f"  decoding each measure again on the {len(shared)} metrics they share, "
+        "so the scores are comparable")
+    for activity in ds.activities:
+        sub = ds.for_activity(activity)
+        try:
+            res = decode(
+                sub, target=settings.decoding_target, models=settings.models,
+                metrics=shared, n_splits=settings.n_splits,
+                n_repeats=settings.n_repeats,
+                n_permutations=settings.n_permutations,
+                importance_repeats=settings.importance_repeats,
+                seed=settings.seed, lag=lag, progress=progress)
+        except Exception as exc:
+            log(f"    {activity}: decoding failed: {exc}")
+            continue
+        if res.scores.empty:
+            log(f"    {activity}: {_undecodable_reason(sub, shared)}")
+            continue
+        best = res.summary().iloc[0]
+        log(f"    {activity}: best {best['Model']} at "
+            f"{best['BalancedAccuracy']:.3f} balanced accuracy")
+        out[activity] = res
+    return out
+
+
+def _undecodable_reason(ds: StatsDataset, metrics: list[str] | None = None) -> str:
+    """Why this dataset produced no decoder, in terms someone can act on.
+
+    ``decode`` returns empty for three quite different reasons and used to
+    report one sentence covering all of them. The one that actually bites is the
+    third: ``feature_matrix`` drops any recording with a missing value in *any*
+    feature, so a single metric that is rarely computed — ``RC`` is missing for
+    377 of 378 recordings on some activity types — takes the entire dataset with
+    it, and the run says only "not enough data".
+    """
+    import numpy as np
+    import pandas as pd
+
+    names = [m for m in (metrics or ds.metrics) if m in ds.table.columns]
+    frame = ds.table[names].apply(pd.to_numeric, errors="coerce")
+    frame = frame.replace([np.inf, -np.inf], np.nan)
+    complete = int(frame.notna().all(axis=1).sum())
+    if complete >= 10:
+        n_classes = ds.table[ds.group_col].nunique()
+        if n_classes < 2:
+            return (f"skipped: only one class of {ds.group_col} present, so there "
+                    "is nothing to tell apart")
+        return (f"skipped: {complete} complete recordings and "
+                f"{ds.table[ds.culture_col].nunique()} cultures is too few to "
+                "cross-validate")
+    # Name the columns that emptied it, worst first — the actionable part.
+    missing = frame.isna().sum().sort_values(ascending=False)
+    culprits = [f"{name} (missing for {int(count)} of {len(frame)})"
+                for name, count in missing.items() if count > 0.5 * len(frame)][:3]
+    detail = ("; ".join(culprits) if culprits
+              else "no single metric dominates — missing values are spread across many")
+    return (f"skipped: only {complete} recordings have every metric, because "
+            f"{detail}. Re-run the statistics step restricted to the metrics you "
+            "need, or exclude the sparse ones.")
+
+
+def _activity_source_root(root: Path, ds: StatsDataset) -> Path:
+    """Where *ds*'s measure of activity stored its per-recording adjacency.
+
+    The run root for a single-measure run and for the primary measure of a
+    multi-measure one — both of which keep the top-level ``ExperimentMatFiles``
+    — and the measure's own subtree otherwise. Falls back to the root when the
+    subtree is absent, so a folder written before measures could be combined,
+    or one whose subtree was pruned, still sweeps rather than raising.
+    """
+    from meanap.catnap.activities import BY_ACTIVITY_DIR, activity_slug
+
+    activity = ds.activity
+    if activity is None:
+        return Path(root)
+    candidate = Path(root) / BY_ACTIVITY_DIR / activity_slug(str(activity))
+    return candidate if (candidate / "ExperimentMatFiles").is_dir() else Path(root)
+
+
+def _analysis_dirname(activity, lag) -> str:
+    """Folder for one measure at one lag, e.g. ``peaks/1000mslag``.
+
+    A single-measure run keeps the bare lag name it has always used, so old
+    results folders and new ones written the old way are laid out identically.
+    """
+    from meanap.catnap.activities import activity_slug
+
+    stem = _lag_dirname(lag) if lag is not None else "all"
+    return stem if activity is None else f"{activity_slug(str(activity))}/{stem}"
+
+
+def _run_measure_comparison(ds: StatsDataset, dest: Path, settings, scheme,
+                            result: StatsRunResult, lag, collected: dict,
+                            log, progress=None) -> None:
+    """Compare the measures of activity against each other, for one lag.
+
+    Reads the per-measure comparisons and decoders the loop above already
+    fitted rather than refitting anything, so the effect this reports for a
+    measure is by construction the identical number that measure's own ``5A``
+    table reports.
+    """
+    sub = ds.for_lag(lag) if lag is not None else ds
+    log(f"— {MEASURES_DIRNAME}/{_lag_dirname(lag) if lag is not None else 'all'}: "
+        "comparing measures of activity")
+    shared = _shared_metrics(sub)
+    comparison = compare_measures(
+        sub, comparisons=collected.get("comparisons"),
+        decoding=_comparable_decoding(sub, shared, collected.get("decoding") or {},
+                                      settings, lag, log, progress),
+        metrics=list(settings.metrics) or shared or None, lag=lag)
+    if not comparison.ran:
+        return
+
+    folder = dest / MEASURES_DIRNAME / (
+        _lag_dirname(lag) if lag is not None else "all")
+    folder.mkdir(parents=True, exist_ok=True)
+    _write_table(comparison.agreement, folder / "measure_agreement.csv", result)
+    _write_table(comparison.differences, folder / "measure_differences.csv", result)
+    _write_table(comparison.effects, folder / "measure_effects.csv", result)
+    _write_table(comparison.concordance, folder / "measure_concordance.csv", result)
+    _write_table(comparison.decoding, folder / "measure_decoding.csv", result)
+
+    for line in summary_lines(comparison):
+        log(line)
+    result.summary.setdefault("measures", {})[str(lag)] = comparison.summary
+
+    computed = StatsResults(dataset=sub, lag=lag, measures=comparison)
+    _draw_all(computed, folder, settings, scheme, result, log)
+
+
 # ── the four analyses ────────────────────────────────────────────────────────
 
 def _run_comparisons(ds: StatsDataset, folder: Path, settings,
@@ -763,8 +984,9 @@ def _run_decoding(ds: StatsDataset, folder: Path, settings,
         lag=lag, progress=progress)
 
     if res.scores.empty:
-        result.skipped.append(f"{folder.name}/decoding: not enough data to decode")
-        log("    skipped: not enough data (one class, or too few cultures)")
+        reason = _undecodable_reason(ds)
+        result.skipped.append(f"{folder.name}/decoding: {reason}")
+        log(f"    {reason}")
         return
 
     computed.decoding = res

--- a/src/meanap/timescale.py
+++ b/src/meanap/timescale.py
@@ -68,6 +68,16 @@ def timescale_label(params) -> str:
     return timescale_kind(params)
 
 
+def timescale_folder_display(name, params) -> str:
+    """Render a stored timescale key the way this run should name it.
+
+    The structural keys on disk are always ``…mslag`` (see the module note), so
+    a log line that echoes one verbatim tells a correlation run it used a
+    "lag". This re-spells the number in the run's own vocabulary.
+    """
+    return timescale_folder(timescale_value(name), params)
+
+
 def timescale_value(name) -> int:
     """The number out of ``'1000msbin'`` / ``'1000mslag'`` / ``1000``.
 


### PR DESCRIPTION
A CAT-NAP recording has no single "activity". Detected calcium events, the deconvolved trace, raw fluorescence and suite2p's spike estimate are four readings of the same field of view, and the pipeline builds a different network from each — events give an STTC coincidence network, the three continuous traces a binned Pearson correlation network. Every number downstream is conditional on that choice, and `Params.twop_activity` made it a decision buried in a settings file that does not travel with a figure.

This makes the choice an axis of the output, and then asks what it costs.

## ⚠️ One commit changes existing numbers

`1aa49ba` clears the self-loops the correlation adjacency was carrying. `suite2pToAdjm.m` stores `double(corr(X))` and nothing downstream clears the diagonal, so on the `F` / `spks` / `denoised F` paths every node carried a self-loop of weight 1 — the largest weight in the matrix — while the STTC path has always returned a zero diagonal. The two connectivity measures were not producing comparable graphs.

Affected: `Dens` (counted `triu(adjM)` *including* the diagonal against a denominator excluding it, so density was inflated by `2/(n-1)` and could exceed 1 — which is how this was found), `NS` (gained exactly 1.0 per node), and `sigEdgesMean` / `sigEdgesTop10` (pooled n maximum-weight self-edges into the distribution; the top-10% mean is hit hardest). `ND` and `MEW` are unaffected.

**Anything already published from a correlation-mode run needs re-reading against this.** A run needing the old behaviour bit-for-bit can compare against a pre-fix bundle.

## What's here

Four independent commits, smallest first:

| commit | |
|---|---|
| `1aa49ba` | `catnap:` clear the self-loops a correlation adjacency was carrying |
| `d9b5e6b` | `catnap:` say "bin" in the cartography log when that is what the number is |
| `18bafc9` | `remote:` don't re-fetch `ops.npy` once its sidecar has been extracted |
| `000b09b` | `catnap:` analyse several measures of activity in one run, and say whether the conclusion survives the choice |

### Several measures in one run

`Params.twop_activities` lists extra measures to analyse beside `twop_activity`. Empty — the default, and what every settings file written before this carries — means the run analyses one measure and is named exactly as it always was, down to the folder names.

Loading and denoising happen **once** per recording however many measures are asked for; only the per-measure half repeats. That is what makes this one run rather than N.

The primary measure keeps the top-level folders byte-for-byte. Each extra measure gets a *complete* run folder under `ByActivityType/<slug>/` — its own `ExperimentMatFiles`, `netmet_results.json`, figures and a `params.json` naming that measure alone — so the report, the bundle viewer and `meanap-stats` can be pointed straight at it. The four tables at the top level pool every measure with an `ActivityType` column, which is the form step 5 compares from and the reason the subtrees are not simply separate runs.

**Nothing is pooled across measures that must not be.** Cartography boundaries are placed per measure, because an STTC event network and a binned correlation network have PC/Z distributions that do not live on the same scale. Batch metric ranges likewise. And each measure draws from a generator seeded from the recording name alone rather than a stream shared down the run, so `peaks` analysed beside `denoised F` gives numbers **identical** to `peaks` analysed on its own.

### Does the measure change the answer?

Step 5 treats the measure as an axis like the lag: each measure is analysed separately, then `meanap.stats.measures` compares them in `5_StatsAndML/MeasureComparison/<lag>/`.

- **5F1 agreement** — Spearman (do the recordings rank alike?), Lin's CCC and Bland-Altman bias/limits (are the values the same?)
- **5F2 differences** — the paired within-recording shift, Wilcoxon plus Hedges' `g_av`, standardised by the pooled SD rather than the SD of the differences, which inflates without limit as the two conditions correlate — which by construction they do
- **5F3 concordance** — each group/age effect measured one way against the other, with a verdict: *agree (both significant)* / *disagree (only \<measure\>)* / *opposite signs*
- **5F4 decoding** — accuracy per measure

5F3 is the point. A genotype effect significant under `peaks` and absent under `denoised F` is a finding about the analysis, not the biology, and it should be visible before publication rather than after.

**On Yin's 378 recordings** (three existing single-measure runs pooled, 1000 ms, 121 cultures): median cross-measure Spearman rho 0.79 over the 46 shared metrics, but 27 of 138 comparisons below 0.5 — the cartography/z-score family worst (`percentZscoreLessThanZero` rho 0.14, `Hub3` 0.18). 547 of 690 conclusions agree, 143 do not, only one an outright sign flip. Restricted to the genotype contrasts, **roughly a fifth depend on which measure was used**. Decoding is a near-tie: peaks 0.607, spks 0.579, denoised F 0.575 against chance 0.333.

### Two bugs the comparison surfaced, wrong on their own terms

- **5F4 was comparing decoders trained on different feature sets** — 50 metrics under `peaks`, 48 under `denoised F`, 47 under `spks`, 46 shared — so the difference in accuracy was partly a difference in feature set. The comparison now decodes every measure again on the shared set unless they already agreed.
- **A present-but-sparse metric silently cost a whole decoder.** `feature_matrix` drops any recording with a missing value in any feature, so `RC` — missing for 377 of 378 recordings on some activity types — emptied the matrix, and the run said only "not enough data (one class, or too few cultures)". It now names the column and the count. This bites the ordinary single-measure path too.

## Test plan

- `python/test_catnap_multi_activity.py` — new, 44 checks: the output layout, that the measures stay independent of each other (`peaks` alone vs `peaks` in company, byte-for-byte), and that the comparison's verdicts say what they mean
- Verified green against the committed tree: `test_catnap_multi_activity` 44/44, `test_catnap_resume` 49/49, `test_catnap_correlation_bins`, plus `test_catnap_*`, `test_pipeline_catnap`, `test_stats` 70/70, `test_bundle_render` 156/156, `test_gui_mode_defaults`, `test_remote_pipeline`
- GUI checked headless (`QT_QPA_PLATFORM=offscreen`): the CAT-NAP tab's "Also analyse" row and the Stats tab toggle round-trip through `Params`

**Known unrelated failure:** `python/test_stats_report.py` section B (29/31). It asserts `local/YinThesisRun.meanap` carries no step-5 results; that local bundle now does. Pre-existing — the same assertion fails on `main` — and untouched here.
