### PR TITLE
Make the verbose level do something, and stop dropdowns clipping their options

### DIFF
--- a/python/PIPELINE_PORT_STATUS.md
+++ b/python/PIPELINE_PORT_STATUS.md
@@ -1681,6 +1681,54 @@ With that in place, two runs at `random_seed=42` produce byte-identical
 (all 48 columns, `Q`/`SW`/`PC`/`num_nnmf_components` included); `random_seed=7`
 differs, as it should. No BLAS thread pinning was needed.
 
+## Verbose level (`Params.verbose_level`, 2026-09-04)
+
+Was stored, written to `params.json` and **never read** — the GUI offered three
+levels and every run printed the same thing. `pipeline/verbosity.py` now makes
+it mean something.
+
+The design constraint is that the levels are **additive**: `Verbose` adds to
+what `Normal` prints, `Debug` adds to both, and nothing is ever removed. A
+level that could suppress a line would make a Debug log unsafe to reason from
+(is that warning missing, or was it never printed?) and would make raising the
+level a decision rather than a free one. Concretely: none of the ~150 existing
+`log(...)` call sites had to be audited or changed.
+
+`RunLog` is *callable*, so `log("…")` still means "print at every level"; the
+new channels are `log.detail(…)` (Verbose+), `log.debug(…)` (Debug only) and
+`log.timed(label)` (a context manager that reports elapsed time at Verbose+).
+`run_pipeline` promotes whatever callable it was given once, at the top, so
+every step and every worker downstream inherits the level.
+
+Two things worth knowing:
+
+1. **Workers get the level through `Params`, not through the log.** Steps 3 and
+   4 compute in spawned processes and buffer their own lines into a list that
+   the parent replays. Each promotes its own buffer with
+   `as_run_log(logs.append, params.verbose_level)` — the level travels in the
+   pickled `Params` that was going there anyway.
+2. **`as_run_log` never re-levels an existing `RunLog`.** A function further
+   down the stack guessing a level from its own arguments is how the run's
+   level and a step's level would drift apart.
+
+MATLAB's `Params.verboseLevel` is `'Normal' | 'High' | 'Silent'`;
+`normalise_level` accepts those names (`High` → `Verbose`, `Silent` → `Normal`,
+there being no quieter level here) so a params file from that pipeline keeps
+its intent instead of silently landing on the default. Anything unrecognised —
+a hand-edited file, a `None` — logs normally rather than raising.
+
+What each level adds, and where:
+
+| Level | Adds | Where |
+| --- | --- | --- |
+| Normal | (unchanged) | everywhere |
+| Verbose | the batch and its groups/DIVs; every setting that differs from its default; per-method spike counts and mean rate; active electrodes, mean FR, burst rate; edges surviving thresholding per lag; active nodes, density, modules/Q, small-worldness, global efficiency per lag; per-stage timings | `runner._log_run_header`, `_describe_spikes`, `step2._describe_activity`, `step3._describe_edges`, `step4._describe_network`, `catnap._describe_adjms` |
+| Debug | file paths, sampling rates and durations, detection/threshold settings, worker counts, Python/platform/library versions, and *every* setting rather than the changed ones | the same places, via `log.debug` |
+
+Checked by `python/test_verbose_level.py` (~5 s), whose load-bearing assertion
+is that the netmet JSON is byte-identical across all three levels: turning
+Debug on to diagnose a run must not invalidate it.
+
 ## Spreadsheet range convention
 
 `Params.spreadsheet_range` is a string like `"A2:A100000"`. The parser

--- a/python/test_gui_combo_popup.py
+++ b/python/test_gui_combo_popup.py
@@ -1,0 +1,183 @@
+"""A dropdown has to be wide enough for the options it is listing.
+
+Run from the repo root::
+
+    uv run python python/test_gui_combo_popup.py
+
+Qt opens a combo box's popup at the width of the *box*. The box is sized by the
+form around it, and the popup does not draw its rows the way the box does — it
+adds a check-mark column (18px under this theme, plus 6px of spacing) to the
+left of every row, out of the same width. On "Verbose level" that left 48px of
+a 50px word, and the options came out clipped.
+
+The condition for a row to be drawn in full is therefore
+
+    popup viewport ≥ check column + spacing + the widest option
+
+and that is what these checks assert — on the popup Qt actually opens, not on
+the width we asked for. The rest hold the two properties that make the fix safe
+to leave installed everywhere: combo boxes built or filled *later* are covered
+too, and no box is resized (widening those would reflow every settings form to
+suit the longest word in a dropdown).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from PyQt6.QtGui import QFontMetrics  # noqa: E402
+from PyQt6.QtWidgets import QApplication, QComboBox, QStyle  # noqa: E402
+
+from meanap.gui import theme  # noqa: E402
+
+app = QApplication.instance() or QApplication([])
+# Widths depend on the style, so measure under the one the app actually ships.
+theme.apply(app)
+
+from meanap.gui.advanced import AdvancedSection  # noqa: E402
+from meanap.gui.combo import popup_width  # noqa: E402
+from meanap.gui.main_window import MainWindow  # noqa: E402
+from meanap.gui.panels.pipeline import PipelinePanel  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if condition else 'FAIL'}  {name}"
+          + (f"   [{detail}]" if detail and not condition else ""))
+    if not condition:
+        FAILURES.append(f"{name}: {detail}" if detail else name)
+
+
+def needed(combo: QComboBox) -> int:
+    """What one row has to draw: the check column, its gap, and the text.
+
+    Deliberately computed here from the style rather than imported from
+    ``gui.combo`` — a test that asks the code under test what the answer is
+    only proves it is consistent with itself.
+    """
+    view = combo.view()
+    style = view.style()
+    metrics = QFontMetrics(view.font())
+    return (
+        max(metrics.horizontalAdvance(combo.itemText(i))
+            for i in range(combo.count()))
+        + style.pixelMetric(QStyle.PixelMetric.PM_IndicatorWidth, None, view)
+        + style.pixelMetric(QStyle.PixelMetric.PM_CheckBoxLabelSpacing, None, view)
+    )
+
+
+window = MainWindow()
+window.resize(1200, 900)
+window.show()
+# The settings this is really about live in folded sections; open them so the
+# boxes are laid out at the width the form gives them, not at a placeholder.
+for section in window.findChildren(AdvancedSection):
+    section.header.setChecked(True)
+app.processEvents()
+
+combos = [c for c in window.findChildren(QComboBox) if c.count()]
+verbose = window.findChildren(PipelinePanel)[0].verbose_level
+
+
+print("The dropdown this started with")
+
+# The bug, stated as the measurement that showed it: at the width Qt would have
+# used, the row had less room than it needed. If this ever stops holding the
+# fix is no longer being tested by the case that motivated it.
+frame = 2 * verbose.view().frameWidth()
+check("'Verbose level' is a box too narrow for its own options",
+      verbose.width() - frame < needed(verbose),
+      f"box {verbose.width()} - frame {frame} vs needed {needed(verbose)}")
+
+verbose.showPopup()
+app.processEvents()
+opened = verbose.view().parentWidget().width()
+viewport = verbose.view().viewport().width()
+check("but the popup it opens is wide enough for them",
+      viewport >= needed(verbose),
+      f"viewport {viewport} vs needed {needed(verbose)}")
+check("and it is wider than the box, not the same as it",
+      opened > verbose.width(), f"{opened} vs {verbose.width()}")
+verbose.hidePopup()
+
+
+print("\nEvery other dropdown in the window")
+
+too_narrow = [
+    (c.currentText(), c.view().minimumWidth(), needed(c))
+    for c in combos if c.view().minimumWidth() < needed(c)
+]
+check("no dropdown lists options it cannot draw",
+      not too_narrow, str(too_narrow[:3]))
+
+# A popup that is wider than the screen is a different bug in the same place.
+screen_width = window.screen().availableGeometry().width()
+overflowing = [(c.currentText(), popup_width(c))
+               for c in combos if popup_width(c) > screen_width]
+check("and none of them runs off the screen", not overflowing, str(overflowing[:3]))
+
+check("the boxes themselves were left alone",
+      all(c.minimumWidth() == 0 for c in combos),
+      str([c.currentText() for c in combos if c.minimumWidth()][:3]))
+
+
+print("\nDropdowns built or filled later")
+
+# The reason this is an application-wide filter rather than a sweep: the panels
+# that add rows as you use them are the ones with the long labels.
+late = QComboBox(window)
+late.addItems(["Short", "Excitatory (NeuN+ & ~GAD+) — a deliberately long label"])
+late.show()
+app.processEvents()          # Polish fires here, and with it the fitter
+check("a box built after the window is covered too",
+      late.view().minimumWidth() >= needed(late),
+      f"{late.view().minimumWidth()} vs {needed(late)}")
+
+before = late.view().minimumWidth()
+late.addItem("An option longer than any of the ones it was created with, by far")
+check("and refits when an option is added",
+      late.view().minimumWidth() > before
+      and late.view().minimumWidth() >= needed(late),
+      f"{before} → {late.view().minimumWidth()}, needs {needed(late)}")
+
+late.clear()
+late.addItems(["a", "b"])
+check("and again when its options are replaced wholesale",
+      late.view().minimumWidth() >= needed(late),
+      f"{late.view().minimumWidth()} vs {needed(late)}")
+
+empty = QComboBox(window)
+empty.show()
+app.processEvents()
+check("an empty box asks for nothing rather than raising",
+      popup_width(empty) == 0, str(popup_width(empty)))
+
+
+print("\nLong lists")
+
+# A list longer than the popup shows scrolls, and the scroll bar comes out of
+# the width — so the option text would be clipped again on exactly the lists
+# that need the room most.
+long_list = QComboBox(window)
+long_list.addItems([f"Recording {i:02d} — a name of realistic length" for i in range(40)])
+long_list.show()
+app.processEvents()
+bar = long_list.style().pixelMetric(
+    QStyle.PixelMetric.PM_ScrollBarExtent, None, long_list.view())
+check("a scrolling list leaves room for its scroll bar",
+      long_list.view().minimumWidth() >= needed(long_list) + bar,
+      f"{long_list.view().minimumWidth()} vs {needed(long_list) + bar}")
+
+print()
+if FAILURES:
+    print(f"{len(FAILURES)} FAILED:")
+    for f in FAILURES:
+        print(f"  - {f}")
+    raise SystemExit(1)
+print("All combo-popup checks passed.")

--- a/python/test_gui_toolbar.py
+++ b/python/test_gui_toolbar.py
@@ -81,7 +81,7 @@ texts = [a.text() for a in toolbar.actions()]
 first_named = next((t for t in texts if t), "")
 check("and it comes before every action, which is what makes that true",
       toolbar.actions()[0].text() == ""  # the Mode label is a widget action
-      and first_named == "New", f"{first_named!r} / {texts[:4]}")
+      and first_named == "Reset to defaults", f"{first_named!r} / {texts[:4]}")
 
 # Opening a bundle lives with the other things you do to a finished run.
 check("the toolbar is parameters, advanced and help — nothing about results",

--- a/python/test_verbose_level.py
+++ b/python/test_verbose_level.py
@@ -1,0 +1,300 @@
+"""What the verbose level does, now that it does anything.
+
+Run from the repo root::
+
+    uv run python python/test_verbose_level.py
+
+``Params.verbose_level`` was stored, saved to ``params.json`` and never read:
+the GUI offered three levels and every run printed the same thing. It now
+selects between three *additive* levels — Verbose adds to Normal, Debug adds to
+both — implemented by :mod:`meanap.pipeline.verbosity`.
+
+Three claims are worth holding in place, and the third is the one that matters:
+
+  - **additive** — every line a quieter level prints, a louder one prints too.
+    A level that could hide a line would make a Debug log unsafe to reason
+    from, and a Normal log unsafe to run with;
+  - **it reaches the workers** — steps 3 and 4 compute in separate processes
+    that buffer their own log lines. The level travels in ``Params``, so the
+    check is that a Verbose run actually shows a line only a worker can write;
+  - **it changes nothing else** — the numbers a run produces are identical at
+    every level. That is what the GUI tooltip promises, and it is the reason
+    someone can turn Debug on to diagnose a run without invalidating it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import re
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from meanap.params import Params  # noqa: E402
+from meanap.pipeline.io import save_spike_times_npz  # noqa: E402
+from meanap.pipeline.output_folders import create_output_folders  # noqa: E402
+from meanap.pipeline.runner import run_pipeline  # noqa: E402
+from meanap.pipeline.verbosity import (  # noqa: E402
+    VERBOSE_LEVELS, RunLog, as_run_log, format_elapsed, normalise_level,
+)
+
+Check = tuple[str, bool, str]
+
+N_REC, N_CH, FS, LAG = 3, 8, 2000.0, 25
+RECS = [f"rec{i}" for i in range(N_REC)]
+
+
+def _report(title: str, checks: list[Check]) -> tuple[int, int]:
+    print(f"\n{title}")
+    n = 0
+    for name, ok, detail in checks:
+        print(f"  {'✓' if ok else '✗'} {name}" + ("" if ok else f"  [{detail}]"))
+        n += bool(ok)
+    print(f"  → {n}/{len(checks)} passed")
+    return n, len(checks)
+
+
+# ── The log itself ────────────────────────────────────────────────────────────
+
+def _runlog_checks() -> list[Check]:
+    checks: list[Check] = []
+
+    checks.append(("the levels are Normal, Verbose, Debug",
+                   VERBOSE_LEVELS == ["Normal", "Verbose", "Debug"],
+                   str(VERBOSE_LEVELS)))
+
+    # A params file is user-editable and can come from the MATLAB pipeline, so
+    # nothing here may raise — an unreadable level logs normally.
+    cases = {
+        "Normal": "Normal", "verbose": "Verbose", "DEBUG": "Debug",
+        "High": "Verbose",              # MATLAB's name for the middle level
+        "Silent": "Normal",             # no quieter level exists here
+        "": "Normal", None: "Normal", "gibberish": "Normal", 7: "Normal",
+    }
+    bad = {k: normalise_level(k) for k, want in cases.items()
+           if normalise_level(k) != want}
+    checks.append(("every stored level resolves to a real one", not bad, str(bad)))
+
+    said: dict[str, list[str]] = {}
+    for level in VERBOSE_LEVELS:
+        lines: list[str] = []
+        log = RunLog(lines.append, level)
+        log("always")
+        log.detail("detail")
+        log.debug("debug")
+        said[level] = lines
+
+    checks.append(("Normal prints only the always-lines",
+                   said["Normal"] == ["always"], str(said["Normal"])))
+    checks.append(("Verbose adds the detail channel",
+                   said["Verbose"] == ["always", "detail"], str(said["Verbose"])))
+    checks.append(("Debug adds the debug channel on top",
+                   said["Debug"] == ["always", "detail", "debug"],
+                   str(said["Debug"])))
+    checks.append(("so each level is a superset of the one below",
+                   set(said["Normal"]) < set(said["Verbose"]) < set(said["Debug"]),
+                   ""))
+
+    quiet = RunLog(lambda m: None, "Normal")
+    loud = RunLog(lambda m: None, "Debug")
+    checks.append(("wants_detail/wants_debug agree with the channels",
+                   (not quiet.wants_detail, not quiet.wants_debug,
+                    loud.wants_detail, loud.wants_debug) == (True, True, True, True),
+                   ""))
+
+    # Timing: silent below its level, one line at or above it.
+    for level, want in (("Normal", 0), ("Verbose", 1)):
+        lines = []
+        with RunLog(lines.append, level).timed("  work"):
+            pass
+        checks.append((f"timed() says {want} thing(s) at {level}",
+                       len(lines) == want, str(lines)))
+    checks.append(("and names what it timed", "work took" in lines[0], str(lines)))
+
+    checks.append(("elapsed keeps sub-second precision",
+                   (format_elapsed(0.4), format_elapsed(75)) == ("0.40s", "1m 15s"),
+                   f"{format_elapsed(0.4)} / {format_elapsed(75)}"))
+
+    # A worker promotes its own line buffer; a nested call must not re-level a
+    # log the run already built, or the two would drift apart.
+    lines = []
+    promoted = as_run_log(lines.append, "Debug")
+    checks.append(("a plain callable is promoted", isinstance(promoted, RunLog)
+                   and promoted.level == "Debug", promoted.level))
+    checks.append(("an existing RunLog is left alone",
+                   as_run_log(promoted, "Normal") is promoted
+                   and promoted.level == "Debug", promoted.level))
+    return checks
+
+
+# ── A whole run, at each level ────────────────────────────────────────────────
+
+def _seed(root: Path) -> None:
+    """Spike times and adjacency: what steps 2-4 read."""
+    from meanap.pipeline.atomic import atomic_savez
+
+    for i, rec in enumerate(RECS):
+        rng = np.random.default_rng(i)
+        spikes = {ch: {"bior1p5": np.sort(rng.uniform(0, 60, 60 + 3 * ch))}
+                  for ch in range(N_CH)}
+        save_spike_times_npz(
+            root / "1_SpikeDetection" / "1A_SpikeDetectedData" / f"{rec}_spikes.npz",
+            spikes, np.arange(1, N_CH + 1), FS, duration_s=60.0)
+        adj = np.abs(rng.normal(0, 0.3, (N_CH, N_CH)))
+        adj = (adj + adj.T) / 2
+        np.fill_diagonal(adj, 0)
+        atomic_savez(root / "ExperimentMatFiles" / f"{rec}_adjM.npz",
+                     channels=np.arange(1, N_CH + 1),
+                     **{f"adjM{LAG}mslag": adj, f"adjM{LAG}mslag_raw": adj})
+
+
+def _params(tmp: Path, name: str, level: str) -> Params:
+    return Params(
+        output_data_folder=str(tmp), output_data_folder_name=name,
+        spreadsheet_file_name=str(tmp / "recs.csv"), spreadsheet_range="2:100",
+        raw_data=str(tmp / "no-raw"),
+        start_analysis_step=4, stop_analysis_step=4,
+        func_con_lag_val=[LAG], channel_layout="MCS60",
+        min_number_of_nodes_to_cal_net_met=2, random_seed=5,
+        recording_workers=1, express_mode=True, verbose_level=level,
+    )
+
+
+def _run_checks() -> list[Check]:
+    checks: list[Check] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        pd.DataFrame([{"Recording Filename": r, "DIV group": 21, "Genotype": "WT"}
+                      for r in RECS]).to_csv(tmp / "recs.csv", index=False)
+
+        said: dict[str, list[str]] = {}
+        results: dict[str, str] = {}
+        for level in VERBOSE_LEVELS:
+            root = create_output_folders(tmp, level, ["WT"])
+            _seed(root)
+            lines: list[str] = []
+            started = time.perf_counter()
+            out = run_pipeline(_params(tmp, level, level), log=lines.append)
+            said[level] = lines
+            print(f"    ({level}: {len(lines)} lines in "
+                  f"{time.perf_counter() - started:.1f}s)")
+            # Express mode, so the three runs cost a second rather than a
+            # minute of drawing figures nothing here looks at. It folds the
+            # output into a bundle, and the metrics travel inside it.
+            with zipfile.ZipFile(out) as bundle:
+                results[level] = json.dumps(
+                    json.loads(bundle.read("4_NetworkActivity/netmet_results.json")),
+                    sort_keys=True)
+
+        # The claim the tooltip makes.
+        checks.append(("the numbers are identical at every level",
+                       results["Normal"] == results["Verbose"] == results["Debug"]
+                       and bool(results["Normal"]),
+                       "empty" if not results["Normal"] else "differ"))
+
+        # Additive, on real output rather than a unit fixture. Compared with
+        # the run's own name and every number blanked: three runs write to
+        # three folders and take three different amounts of time, and neither
+        # difference is what "additive" is about.
+        def shape(lines: list[str], level: str) -> list[str]:
+            return [re.sub(r"\d+(?:\.\d+)?", "#", ln.replace(level, "RUN"))
+                    for ln in lines]
+
+        normal, verbose, debug = (set(shape(said[k], k)) for k in VERBOSE_LEVELS)
+        missing_v = sorted(normal - verbose)
+        missing_d = sorted(verbose - debug)
+        checks.append(("Verbose keeps every line Normal printed",
+                       not missing_v, str(missing_v[:3])))
+        checks.append(("Debug keeps every line Verbose printed",
+                       not missing_d, str(missing_d[:3])))
+        checks.append(("and each says strictly more",
+                       len(said["Normal"]) < len(said["Verbose"]) < len(said["Debug"]),
+                       f"{len(said['Normal'])}/{len(said['Verbose'])}/"
+                       f"{len(said['Debug'])}"))
+
+        joined = {k: "\n".join(v) for k, v in said.items()}
+
+        # A Normal run is unchanged: none of the new material leaks into it.
+        checks.append(("Normal says nothing about the settings or the batch",
+                       "Settings changed" not in joined["Normal"]
+                       and "Batch:" not in joined["Normal"], ""))
+
+        checks.append(("Verbose says which batch ran",
+                       f"{N_REC} recording(s)" in joined["Verbose"], ""))
+        checks.append(("and which settings differ from the defaults",
+                       "Settings changed from the defaults" in joined["Verbose"]
+                       and "random_seed" in joined["Verbose"], ""))
+        checks.append(("and reports the level itself, so a pasted log says "
+                       "how complete it is",
+                       "Log level: Verbose" in joined["Verbose"]
+                       and "Log level: Debug" in joined["Debug"], ""))
+
+        # Only ``_step4_compute_one`` can write this, and it runs in a worker
+        # process: seeing it proves the level travelled in Params.
+        checks.append(("a worker's own detail line comes back",
+                       "active nodes" in joined["Verbose"], ""))
+        checks.append(("with the timing of the computation it did",
+                       "took" in joined["Verbose"] or "in 0." in joined["Verbose"],
+                       ""))
+
+        checks.append(("Debug adds the machine and the libraries",
+                       "Libraries:" in joined["Debug"]
+                       and "CPU(s)" in joined["Debug"], ""))
+        checks.append(("and every setting, not only the changed ones",
+                       "min_activity_level" in joined["Debug"]
+                       and "min_activity_level" not in joined["Verbose"], ""))
+    return checks
+
+
+# ── The GUI offers exactly these levels ───────────────────────────────────────
+
+def _gui_checks() -> list[Check]:
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    from meanap.gui.panels.pipeline import PipelinePanel
+
+    panel = PipelinePanel()
+    offered = [panel.verbose_level.itemText(i)
+               for i in range(panel.verbose_level.count())]
+    checks = [("the GUI offers the levels the pipeline implements",
+               offered == VERBOSE_LEVELS, str(offered))]
+
+    # A level the GUI cannot reach would be a setting nobody can turn on.
+    p = Params()
+    p.verbose_level = "Debug"
+    panel.load(p)
+    saved = Params()
+    panel.save(saved)
+    checks.append(("and round-trips the one that is set",
+                   saved.verbose_level == "Debug", saved.verbose_level))
+    checks.append(("with a tooltip explaining the difference",
+                   "Debug" in panel.verbose_level.toolTip(), ""))
+    del app
+    return checks
+
+
+if __name__ == "__main__":
+    passed = total = 0
+    for title, fn in (
+        ("The log and its levels", _runlog_checks),
+        ("A run at each level", _run_checks),
+        ("The GUI control", _gui_checks),
+    ):
+        n, m = _report(title, fn())
+        passed += n
+        total += m
+
+    print(f"\n{passed}/{total} checks passed")
+    raise SystemExit(0 if passed == total else 1)

--- a/src/meanap/catnap/pipeline.py
+++ b/src/meanap/catnap/pipeline.py
@@ -58,6 +58,7 @@ from meanap.pipeline.resume import (
     build_input_locator,
 )
 from meanap.pipeline.rng import make_rng
+from meanap.pipeline.verbosity import as_run_log
 from meanap.pipeline.parallel import StreamingPool, suggest_process_count
 from meanap.pipeline.spreadsheet import RecordingInfo
 from meanap.pipeline.step4 import (
@@ -376,6 +377,7 @@ def run_catnap_pipeline(
     change. With per-recording streams a seeded resume reproduces the numbers
     of the run it resumed from.
     """
+    log = as_run_log(log, params.verbose_level)
     from meanap.pipeline.progress import RunProgress
 
     progress = progress or RunProgress()
@@ -724,12 +726,16 @@ def _compute_recording(
         log(f"  [{rec.filename}] SKIP: {e}")
         return None
 
+    log = as_run_log(log, params.verbose_level)
     # Said per recording, not once per run: the rate comes from this
     # recording's own ops.npy and a 2P batch routinely mixes rates. Everything
     # below converts seconds to frames with it, so it belongs in the log
     # *before* the first thing that uses it.
     log(f"  [{rec.filename}] {data.fs:.4g} Hz, {data.n_frames} frames "
         f"({data.duration_s:.0f} s)")
+    log.debug(f"      suite2p folder {plane0}")
+    log.detail(f"      {data.F.shape[0]} ROIs"
+               + ("" if data.F_denoised is None else ", denoised traces already on disk"))
 
     measures = activity_types(params)
     if any(a in _NEEDS_DENOISING for a in measures) and (
@@ -762,6 +768,8 @@ def _compute_recording(
         )
         _log_bin_rounding(res, log, rec.filename)
         duration_s = res.F.shape[0] / res.fs
+        log.detail_lines(_describe_adjms(
+            res.adjMs, f" [{activity}]" if len(measures) > 1 else ""))
 
         state = RecordingState(
             adjMs=res.adjMs, coords=res.coords, channels=res.channels,
@@ -786,6 +794,29 @@ def _compute_recording(
                     "network plots drawn without a backdrop")
         out[activity] = (state, _activity_stats_for(res, p_act, duration_s))
     return out
+
+
+def _describe_adjms(adj_ms: dict[str, np.ndarray], note: str) -> list[str]:
+    """One line per lag: how connected the network this measure produced is.
+
+    The equivalent of step 3's edge report on the ephys side. It is the first
+    place a measure of activity that found almost nothing — a denoising
+    threshold set too high, say — becomes visible, and this is a run where the
+    choice of measure is the thing being tested.
+    """
+    lines = []
+    for key, adj in sorted(adj_ms.items()):
+        adj = np.asarray(adj)
+        if adj.ndim != 2 or adj.shape[0] < 2:
+            continue
+        n = adj.shape[0]
+        possible = n * (n - 1) // 2
+        upper = np.triu_indices(n, k=1)
+        kept = int(np.count_nonzero(adj[upper] > 0))
+        prefix = f"{note.strip()} " if note.strip() else ""
+        lines.append(f"      {prefix}{key}: {n} nodes, {kept} edges "
+                     f"({kept / possible * 100:.1f}% of {possible} possible)")
+    return lines
 
 
 def _activity_matrix_for(res, twop_activity: str) -> np.ndarray | None:

--- a/src/meanap/gui/combo.py
+++ b/src/meanap/gui/combo.py
@@ -1,0 +1,179 @@
+"""Make a combo box's popup as wide as the options it lists.
+
+Qt opens a combo box's popup at the width of the *box*, and the box is sized
+by the form it sits in — so a narrow field lists its options in a narrow strip.
+That would be harmless if the list drew its items the way the box does, but it
+does not: the popup adds a check-mark column to the left of every row (18px
+under this theme, plus its spacing), and that column comes out of the same
+width. The text is what gives way. On the Pipeline tab's "Verbose level" the
+box is 82px and the popup gives its rows 72 of that, of which the check column
+takes 24 — so "Verbose" is drawn into 48px of a 50px word and comes out a few
+pixels short: enough to read as broken, not enough to guess at.
+
+So the popup is given a minimum width covering what it actually has to draw:
+
+    what the box would need for the widest option
+      + the check column + its spacing + the popup's own frame
+
+Every term comes from the style rather than from a constant — the check column
+and the paddings are the theme's (``qdarktheme``'s) and would move if the theme
+did. The **box** is left exactly as it was: widening those would reflow every
+settings form to suit the longest word in a dropdown.
+
+Installed on the application, like the wheel guard, so it covers combo boxes
+built later — the cell-type rows and the results pickers add theirs as you use
+them, and those are the ones with the long labels.
+"""
+
+from __future__ import annotations
+
+import atexit
+
+from PyQt6.QtCore import QEvent, QObject, QSize
+from PyQt6.QtGui import QFontMetrics
+from PyQt6.QtWidgets import (
+    QApplication, QComboBox, QStyle, QStyleOptionComboBox,
+)
+
+__all__ = ["popup_width", "fit_popup", "install_combo_popup_fit"]
+
+#: Marks a combo box whose popup this module already keeps up to date, so a
+#: second polish — ``setStyleSheet`` triggers one — doesn't stack connections.
+_FITTED = "_meanap_popup_fitted"
+
+
+def popup_width(combo: QComboBox) -> int:
+    """The width *combo*'s popup needs to draw its longest option in full.
+
+    A *minimum*, not a size: Qt already opens the popup at the width of the
+    box, so this only ever widens it. Deliberately not clamped up to
+    ``combo.width()`` — the box has not been laid out yet when this is first
+    called, and a stale placeholder width would be baked in as a floor.
+
+    Capped at the screen the box will open on, so one very long option cannot
+    produce a popup that runs off the edge.
+    """
+    if combo.count() == 0:
+        return 0
+
+    view = combo.view()
+    metrics = QFontMetrics(view.font())
+
+    icon_width = 0
+    if any(not combo.itemIcon(i).isNull() for i in range(combo.count())):
+        # Matching QComboBoxPrivate::computeWidthHint: the icon and the gap
+        # after it, for the widest item, whether or not that item has one.
+        icon_width = combo.iconSize().width() + 4
+
+    text_width = max(metrics.horizontalAdvance(combo.itemText(i))
+                     for i in range(combo.count()))
+
+    # What the *box* would have to be to show that text — the same question Qt
+    # answers for AdjustToContents, so the theme's own horizontal padding round
+    # a label is included rather than guessed at. It also counts the drop-down
+    # arrow, which the popup does not draw; that surplus is the slack that
+    # keeps this from landing a pixel short when a font substitutes.
+    option = QStyleOptionComboBox()
+    combo.initStyleOption(option)
+    width = combo.style().sizeFromContents(
+        QStyle.ContentsType.CT_ComboBox, option,
+        QSize(text_width + icon_width, metrics.height()), combo,
+    ).width()
+
+    def pm(metric: QStyle.PixelMetric) -> int:
+        return view.style().pixelMetric(metric, None, view)
+
+    # Then what the popup draws and the box does not.
+    width += (
+        2 * view.frameWidth()                               # its border and padding
+        + pm(QStyle.PixelMetric.PM_IndicatorWidth)          # the check column
+        + pm(QStyle.PixelMetric.PM_CheckBoxLabelSpacing)    # …and the gap after it
+    )
+    # A list longer than the popup shows scrolls, and the scroll bar is inside
+    # the width — so without this the fix would clip the text again on exactly
+    # the long lists that need it most.
+    if combo.count() > combo.maxVisibleItems():
+        width += pm(QStyle.PixelMetric.PM_ScrollBarExtent)
+
+    screen = combo.screen()
+    if screen is not None:
+        width = min(width, screen.availableGeometry().width())
+    return width
+
+
+def fit_popup(combo: QComboBox) -> None:
+    """Size *combo*'s popup to its options. Cheap; safe to call again."""
+    combo.view().setMinimumWidth(popup_width(combo))
+
+
+def _track(combo: QComboBox) -> None:
+    """Fit *combo* now, and again whenever its options change.
+
+    A combo box is usually polished before it is filled — and several here are
+    refilled as the run's output changes — so fitting once at install time
+    would size the popups of exactly the lists that never change.
+    """
+    if combo.property(_FITTED):
+        return
+    combo.setProperty(_FITTED, True)
+
+    def refit(*_args: object) -> None:
+        # The Python wrapper outlives the C++ widget, and a model signal can
+        # still arrive after the combo has been deleted — during teardown, or
+        # when a panel rebuilds its rows.
+        try:
+            fit_popup(combo)
+        except RuntimeError:
+            pass
+
+    model = combo.model()
+    model.rowsInserted.connect(refit)
+    model.rowsRemoved.connect(refit)
+    model.modelReset.connect(refit)
+    model.dataChanged.connect(refit)
+    refit()
+
+
+class _PopupFitter(QObject):
+    """Application event filter that tracks every combo box it meets."""
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # noqa: D102
+        # Polish, as in wheel.py: every widget is polished before it is first
+        # shown, so this covers the rows and dialogs built as the app is used.
+        if event.type() == QEvent.Type.Polish and isinstance(obj, QComboBox):
+            _track(obj)
+        return False
+
+
+#: Module-level so the filter outlives the call that installed it.
+_FITTER: _PopupFitter | None = None
+
+
+def install_combo_popup_fit(app: QApplication | None = None) -> None:
+    """Install the fitter on *app*. Safe to call more than once."""
+    global _FITTER
+    app = app or QApplication.instance()
+    if app is None or _FITTER is not None:
+        return
+    _FITTER = _PopupFitter()
+    app.installEventFilter(_FITTER)
+    # Everything already built: the filter only sees a widget from its next
+    # event on, and the window's own combo boxes are polished by then.
+    for widget in app.allWidgets():
+        if isinstance(widget, QComboBox):
+            _track(widget)
+    # Removed before the QApplication is torn down — an application event
+    # filter that outlives it crashes the process during shutdown. See the
+    # same note in wheel.py.
+    atexit.register(_uninstall, app)
+
+
+def _uninstall(app: QApplication) -> None:
+    global _FITTER
+    if _FITTER is None:
+        return
+    try:
+        app.removeEventFilter(_FITTER)
+    except RuntimeError:
+        pass        # the application went first; nothing left to detach from
+    _FITTER = None

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -145,8 +145,13 @@ class MainWindow(QMainWindow):
         tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
         self.addToolBar(tb)
 
-        act_new = QAction("New", self)
-        act_new.setToolTip("Reset all parameters to defaults")
+        # "Reset to defaults", not "New": there is no document to be new, and
+        # the one thing the button does is discard the settings on screen.
+        act_new = QAction("Reset to defaults", self)
+        act_new.setToolTip(
+            "Put every setting on every tab back to its default for the "
+            "current pipeline. Parameters you saved to a file are untouched."
+        )
         act_new.triggered.connect(self._on_new)
 
         act_open = QAction("Open params…", self)
@@ -742,7 +747,7 @@ class MainWindow(QMainWindow):
     def _on_new(self) -> None:
         # ask_yes_no rather than QMessageBox.question: the latter lets the
         # platform decide which end Yes goes on, which moves it on a Mac.
-        if ask_yes_no(self, "New parameters",
+        if ask_yes_no(self, "Reset to defaults",
                       "Reset all parameters to defaults?"):
             # Defaults for the pipeline on screen, not for MEA-NAP: resetting
             # in CAT-NAP should not quietly drop you back into the ephys tabs

--- a/src/meanap/gui/main_window.py
+++ b/src/meanap/gui/main_window.py
@@ -46,6 +46,7 @@ from meanap.gui.panels.results import ResultsPanel
 from meanap.gui.panels.stats import StatsPanel
 from meanap.gui.tooltip import install_tooltip_style, wrap_tooltips
 from meanap.gui.tutorial import TutorialOverlay, TutorialStep, tabbar_target
+from meanap.gui.combo import install_combo_popup_fit
 from meanap.gui.wheel import install_wheel_guard
 
 
@@ -130,6 +131,10 @@ class MainWindow(QMainWindow):
         # A scroll over a spin box or combo box belongs to the page it is on,
         # not to the field the pointer happened to cross — see gui/wheel.py.
         install_wheel_guard()
+        # A combo box opens its popup at the width of the box, which is set by
+        # the form around it — too narrow for the options once the popup's own
+        # check column is taken out of it. See gui/combo.py.
+        install_combo_popup_fit()
         # Qt hands focus to the first widget that will take it, so the window
         # opened with a settings field focused that nobody had clicked — and a
         # focused field is one the wheel is allowed to change. The tab strip

--- a/src/meanap/gui/panels/pipeline.py
+++ b/src/meanap/gui/panels/pipeline.py
@@ -13,6 +13,8 @@ from PyQt6.QtWidgets import (
 from meanap.gui.advanced import AdvancedSection
 from meanap.gui.panels.prior import PriorAnalysisPanel
 from meanap.params import GENERATE_CSV_STEP, STATS_STEP, Params
+# One source of truth for the levels: the pipeline is what acts on them.
+from meanap.pipeline.verbosity import VERBOSE_LEVELS
 
 PIPELINE_STEPS = [
     (1, "Spike detection"),
@@ -42,7 +44,6 @@ OPTIONAL_STEPS = [
      "Applies to a single run started from this tab. A queued run does not "
      "pick it up."),
 ]
-VERBOSE_LEVELS = ["Normal", "Verbose", "Debug"]
 
 
 class PipelinePanel(QWidget):
@@ -148,6 +149,20 @@ class PipelinePanel(QWidget):
 
         self.verbose_level = QComboBox()
         self.verbose_level.addItems(VERBOSE_LEVELS)
+        self.verbose_level.setToolTip(
+            "How much the run log says. Each level adds to the one before it, "
+            "so nothing is ever hidden by turning it up.\n\n"
+            "Normal: what each step is doing, and anything that went wrong.\n"
+            "Verbose: what the run was asked to do (the batch, and every "
+            "setting that differs from its default), then the numbers each "
+            "step produced — spikes found per method, active electrodes and "
+            "burst rate, how many edges survived thresholding, the modules and "
+            "small-worldness of each network, and how long each took.\n"
+            "Debug: the internals underneath — file paths, sampling rates, "
+            "worker counts, the machine and library versions, and every "
+            "setting rather than the changed ones.\n\n"
+            "It changes the log only — the results are the same at every level."
+        )
 
         self.time_processes = QCheckBox()
 

--- a/src/meanap/params.py
+++ b/src/meanap/params.py
@@ -194,6 +194,9 @@ class Params:
     # models, NMF, example-trace picking). None = fresh OS entropy each run,
     # matching MATLAB, which seeds nothing. See pipeline/rng.py.
     random_seed: int | None = None
+    # How much the run log says: "Normal", "Verbose" or "Debug", additive in
+    # that order. See pipeline/verbosity.py, which also accepts MATLAB's names
+    # ('High', 'Silent') so a params file from that pipeline keeps its intent.
     verbose_level: str = "Normal"
     time_processes: bool = False
     output_spreadsheet_file_type: str = "csv"

--- a/src/meanap/pipeline/runner.py
+++ b/src/meanap/pipeline/runner.py
@@ -35,6 +35,7 @@ from meanap.pipeline.spike_detection import SpikeDetectionParams, detect_spikes_
 from meanap.pipeline.spreadsheet import (
     RecordingInfo, generate_spreadsheet, read_recording_csv,
 )
+from meanap.pipeline.verbosity import RunLog, as_run_log
 
 
 def default_output_folder_name() -> str:
@@ -121,6 +122,10 @@ def run_pipeline(
     raising :class:`~meanap.pipeline.cancellation.PipelineCancelled`. Callers
     that offer a Stop button should catch that and treat it as a clean stop.
 
+    ``log`` is promoted to a :class:`~meanap.pipeline.verbosity.RunLog` at
+    ``params.verbose_level`` and handed to every step, so a Verbose or Debug
+    run says more through the same callable — see ``pipeline/verbosity.py``.
+
     ``progress``, if given, receives a :class:`~meanap.pipeline.progress.Progress`
     snapshot as each recording finishes — a completed fraction and a calibrated
     estimate of the time left. It is called from whichever thread the pipeline
@@ -131,6 +136,10 @@ def run_pipeline(
     folder first, then ``prior_analysis_path``/``spike_detected_data`` — and
     validated before any compute starts.
     """
+    # Everything below — every step, every worker that is handed this — logs
+    # through the level the run was configured with. See pipeline/verbosity.py.
+    log = as_run_log(log, params.verbose_level)
+
     if not params.spreadsheet_file_name:
         raise ValueError("Spreadsheet file must be set")
     if not params.output_data_folder:
@@ -169,6 +178,7 @@ def run_pipeline(
     # pipeline and version produced it without anyone having to ask.
     log(pipeline_label(mode_for_params(params)))
     log(f"Output folder ready: {output_root}")
+    _log_run_header(params, recordings, output_root, log)
 
     # Snapshot the settings alongside the results. Until this, an output folder
     # recorded nothing about how it was produced — and every plotting routine
@@ -367,6 +377,159 @@ def run_pipeline(
     _report_working_dirs(params, log)
     reporter.finish()
     return output_root
+
+
+def _describe_spikes(result, duration_s: float) -> list[str]:
+    """What step 1 actually found, per detection method.
+
+    A count and a mean rate per method is the check anyone does by hand after
+    a detection run — a method that found nothing, or found a million spikes
+    on one noisy channel, shows up here rather than three steps later in a
+    network metric that looks odd.
+    """
+    import numpy as np
+
+    per_method: dict[str, list[int]] = {}
+    for by_method in result.spike_times.values():
+        for method, times in by_method.items():
+            per_method.setdefault(method, []).append(len(times))
+
+    lines = []
+    for method, counts in per_method.items():
+        arr = np.asarray(counts, dtype=float)
+        total = int(arr.sum())
+        active = int((arr > 0).sum())
+        rate = total / duration_s / max(len(arr), 1) if duration_s else float("nan")
+        lines.append(f"      {method}: {total} spikes on {active}/{len(arr)} "
+                     f"channels, {rate:.2f} Hz mean firing rate")
+    return lines
+
+
+def _log_run_header(
+    params: Params,
+    recordings: list[RecordingInfo],
+    output_root: Path,
+    log: RunLog,
+) -> None:
+    """What this run is, above and beyond the folder it writes to.
+
+    Only reached at Verbose and above. A Normal run's log says what the
+    pipeline is *doing*; this says what it was *asked* to do — which batch,
+    which settings differ from the defaults, and (at Debug) on what machine
+    with which libraries. That is the part a log has to carry for a result to
+    be reproducible from it months later.
+    """
+    if not log.wants_detail:
+        return
+
+    log.detail(f"  Log level: {log.level}")
+    log.detail_lines(_describe_batch(params, recordings))
+    log.detail_lines(_describe_run_shape(params))
+    log.detail_lines(_describe_settings(params, log.wants_debug))
+    log.debug_lines(_describe_environment(params, output_root))
+
+
+def _describe_batch(params: Params, recordings: list[RecordingInfo]) -> list[str]:
+    """The recordings this run covers, grouped the way the analysis will be."""
+    def divs_of(recs: list[RecordingInfo]) -> str:
+        seen = sorted({r.div for r in recs if r.div is not None})
+        if not seen:
+            return ""
+        # DIV is a float in the spreadsheet but almost always whole.
+        shown = [f"{d:g}" for d in seen]
+        return f"  DIV {', '.join(shown)}"
+
+    groups: dict[str, list[RecordingInfo]] = {}
+    for rec in recordings:
+        groups.setdefault(rec.group, []).append(rec)
+
+    lines = [f"  Batch: {len(recordings)} recording(s), {len(groups)} group(s)"
+             f"{divs_of(recordings)}"]
+    for name, recs in groups.items():
+        lines.append(f"    {name}: {len(recs)} recording(s){divs_of(recs)}")
+    lines.append(f"  Spreadsheet: {params.spreadsheet_file_name} "
+                 f"(rows {params.spreadsheet_range})")
+    return lines
+
+
+def _describe_run_shape(params: Params) -> list[str]:
+    """The handful of settings that decide what the run computes at all."""
+    if params.suite2p_mode:
+        shape = "CAT-NAP: calcium imaging, adjacency built in step 2"
+    else:
+        shape = (f"Steps {params.start_analysis_step}-{params.stop_analysis_step}"
+                 f", spike method {params.spikes_method}")
+    lags = ", ".join(str(v) for v in params.func_con_lag_val)
+    lines = [f"  {shape}; lags {lags} ms"]
+    if params.optional_steps_to_run:
+        lines.append(f"  Optional steps: {', '.join(params.optional_steps_to_run)}")
+    return lines
+
+
+def _describe_settings(params: Params, everything: bool) -> list[str]:
+    """The settings, as ``params_summary`` groups them for the report.
+
+    Verbose lists what differs from the defaults — the answer to "what was
+    different about this run?", and usually a dozen lines. Debug appends every
+    field to that, because at that point the question is "what exactly did it
+    use?" — appends rather than replaces, so a Debug log still contains, line
+    for line, everything a Verbose one would have said.
+    """
+    from meanap.params_summary import summarise_params
+
+    try:
+        summary = summarise_params(params)
+    except Exception as e:                       # never lose a run over a log line
+        return [f"  (could not summarise the settings: {e})"]
+
+    changed = [e for g in summary.groups for e in g.entries if e.changed]
+    if changed:
+        lines = [f"  Settings changed from the defaults ({len(changed)}):"]
+        lines += [f"    {e.name} = {e.value!r}   (default {e.default!r})"
+                  for e in changed]
+    else:
+        lines = ["  Settings: every field is at its default."]
+
+    if everything:
+        lines.append(f"  All {summary.total} settings, grouped as Params "
+                     f"declares them (* = changed):")
+        for group in summary.groups:
+            if not group.entries:
+                continue
+            lines.append(f"    {group.name}")
+            for entry in group.entries:
+                mark = "*" if entry.changed else " "
+                lines.append(f"     {mark} {entry.name} = {entry.value!r}")
+    return lines
+
+
+def _describe_environment(params: Params, output_root: Path) -> list[str]:
+    """Machine, interpreter and library versions — the Debug-only preamble.
+
+    Numbers that differ between two runs of the same settings are usually
+    explained here rather than in the pipeline, so a Debug log is worth little
+    without it.
+    """
+    import os
+    import platform
+    import sys
+
+    lines = [
+        f"  Python {sys.version.split()[0]} on {platform.platform()}",
+        f"  Machine: {os.cpu_count() or '?'} CPU(s); "
+        f"recording workers {params.recording_workers or 'auto'}, "
+        f"spike-detection channel workers "
+        f"{params.spike_detection_channel_workers or 'auto'}",
+        f"  Output root: {output_root.resolve()}",
+    ]
+    versions = []
+    for name in ("numpy", "scipy", "pandas", "matplotlib", "numba"):
+        try:
+            versions.append(f"{name} {__import__(name).__version__}")
+        except Exception:
+            versions.append(f"{name} —")
+    lines.append(f"  Libraries: {', '.join(versions)}")
+    return lines
 
 
 def _build_raw_source(params: Params, log):
@@ -620,6 +783,9 @@ def _run_step1_spike_detection(
     if not params.raw_data:
         raise ValueError("Raw data folder must be set to run step 1 (spike detection)")
 
+    # Already a RunLog when run_pipeline called us; promoted here too so the
+    # step can be run on its own (the tests do) and still honour the level.
+    log = as_run_log(log, params.verbose_level)
     progress = progress or RunProgress()
     progress.begin("step1", items=len(recordings))
 
@@ -654,7 +820,11 @@ def _run_step1_spike_detection(
             continue
 
         log(f"  [{rec.filename}] loading raw data…")
+        log.debug(f"      reading {raw_path}")
         dat, channels, fs = load_raw_recording(raw_path)
+        log.detail(f"      {len(channels)} channels, {fs / 1000:g} kHz, "
+                   f"{dat.shape[0] / fs:.1f}s "
+                   f"({dat.nbytes / 1e6:.0f} MB of samples)")
 
         detect_params = SpikeDetectionParams(
             fs=fs,
@@ -671,10 +841,17 @@ def _run_step1_spike_detection(
         )
 
         log(f"  [{rec.filename}] detecting spikes ({len(channels)} channels)…")
-        result = detect_spikes_recording(
-            dat, channels, fs, detect_params,
-            max_workers=params.spike_detection_channel_workers,
-        )
+        log.debug(f"      thresholds {params.thresholds}, wavelets "
+                  f"{params.wname_list}, costs {cost_list}, "
+                  f"band {params.filter_low_pass}-{params.filter_high_pass} Hz, "
+                  f"refractory {params.ref_period} ms, "
+                  f"artifact removal {'on' if params.remove_artifacts else 'off'}")
+        with log.timed(f"      [{rec.filename}] detection"):
+            result = detect_spikes_recording(
+                dat, channels, fs, detect_params,
+                max_workers=params.spike_detection_channel_workers,
+            )
+        log.detail_lines(_describe_spikes(result, dat.shape[0] / fs))
 
         out_path = spike_dir / f"{rec.filename}_spikes.npz"
         save_spike_times_npz(

--- a/src/meanap/pipeline/step2.py
+++ b/src/meanap/pipeline/step2.py
@@ -13,6 +13,7 @@ from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, 
 from meanap.pipeline.io import find_raw_file, load_spike_times_npz, resolve_duration_s
 from meanap.pipeline.firing_rates import firing_rates_bursts
 from meanap.pipeline.plotting_step2 import plot_neuronal_activity_checks
+from meanap.pipeline.verbosity import as_run_log
 
 
 # Recording-level ("whole experiment") and node-level ("single cell/node")
@@ -90,6 +91,44 @@ def convert_numpy(obj):
     return obj
 
 
+def _describe_activity(ephys: dict) -> list[str]:
+    """The headline numbers step 2 just computed for one recording.
+
+    These are the recording-level fields the CSV carries, so a Verbose log and
+    ``NeuronalActivity_RecordingLevel.csv`` say the same thing — the log just
+    says it while the run is still going.
+    """
+    def value(name: str) -> float | None:
+        """The field as a number, or None if it isn't one.
+
+        NaN counts as "isn't one": a recording with no network bursts leaves
+        ``fracInNburst`` undefined, and "nan% of spikes in bursts" reads like a
+        failure rather than like the absence it is.
+        """
+        v = ephys.get(name)
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return None
+        return f if np.isfinite(f) else None
+
+    active = value("numActiveElec")
+    fr_mean = value("FRmean")
+    burst_rate = value("NBurstRate")
+    frac = value("fracInNburst")
+
+    parts = []
+    if active is not None:
+        parts.append(f"{active:.0f} active electrodes")
+    if fr_mean is not None:
+        parts.append(f"mean FR {fr_mean:.2f} Hz")
+    if burst_rate is not None:
+        parts.append(f"{burst_rate:.2f} network bursts/min")
+    if frac is not None:
+        parts.append(f"{frac * 100:.0f}% of spikes in bursts")
+    return [f"      {', '.join(parts)}"] if parts else []
+
+
 def _run_step2_neuronal_activity(
     params: Params,
     recordings: list[RecordingInfo],
@@ -100,7 +139,11 @@ def _run_step2_neuronal_activity(
 ) -> None:
     """Run Step 2: Neuronal Activity and Burst Detection."""
 
+    log = as_run_log(log, params.verbose_level)
     log("\n=== Step 2: Neuronal Activity & Burst Detection ===")
+    log.debug(f"  network bursts: {params.network_burst_detection_method}; "
+              f"single-channel bursts: {params.single_channel_burst_detection_method}; "
+              f"active-electrode floor {params.min_activity_level} Hz")
     progress = progress or RunProgress()
     progress.begin("step2", items=len(recordings))
 
@@ -163,7 +206,12 @@ def _run_step2_neuronal_activity(
             spike_times_dict = ground_spike_times_dict(spike_times_dict, data["channels"], ground_electrodes)
 
         log(f"  [{rec.filename}] calculating firing rates and bursts (method={method})...")
-        ephys = firing_rates_bursts(spike_times_dict, n_channels, fs, duration_s, params)
+        log.debug(f"      {n_channels} channels, {fs / 1000:g} kHz, {duration_s:.1f}s "
+                  f"(duration from the {duration_src})"
+                  + (f", grounding {ground_electrodes}" if ground_electrodes else ""))
+        with log.timed(f"      [{rec.filename}] activity stats"):
+            ephys = firing_rates_bursts(spike_times_dict, n_channels, fs, duration_s, params)
+        log.detail_lines(_describe_activity(ephys))
         
         all_ephys[rec.filename] = ephys
         rec_channels[rec.filename] = data["channels"]

--- a/src/meanap/pipeline/step3.py
+++ b/src/meanap/pipeline/step3.py
@@ -11,6 +11,7 @@ surrogates) is pure Python, so it runs in separate *processes* (see
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Callable
 
@@ -26,10 +27,28 @@ from meanap.pipeline.resume import already_done, build_input_locator
 from meanap.pipeline.rng import make_rng
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
 from meanap.pipeline.atomic import atomic_savez
+from meanap.pipeline.verbosity import as_run_log, format_elapsed
 
 # Peak per-worker RAM for Step 3: spike times (sparse) + a few 64x64xrep_num
 # surrogate stacks (~6 MB at rep_num=200). Tiny — worker count is CPU-limited.
 _STEP3_MEM_PER_TASK_GB = 0.3
+
+
+def _describe_edges(adj_m: np.ndarray, adj_m_ci: np.ndarray, lag_ms: int) -> str:
+    """How much of the raw correlation matrix survived thresholding.
+
+    The one number that says whether a lag was worth computing: an adjacency
+    that kept 2% of its edges and one that kept 60% produce very different
+    step-4 metrics, and nothing downstream reports the difference.
+    """
+    n = adj_m_ci.shape[0]
+    possible = n * (n - 1) // 2
+    upper = np.triu_indices(n, k=1)
+    kept = int(np.count_nonzero(adj_m_ci[upper] > 0))
+    raw = int(np.count_nonzero(adj_m[upper] > 0))
+    density = kept / possible * 100 if possible else 0.0
+    return (f"lag {lag_ms}ms: {kept}/{raw} edges survived thresholding "
+            f"({density:.1f}% of {possible} possible)")
 
 
 def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, list[str]]:
@@ -49,6 +68,10 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
     plot_checks = bool(getattr(params, "prob_thresh_plot_checks", False))
 
     logs: list[str] = []
+    # The buffer is what this worker "prints" — the parent replays it in
+    # completion order — so the level rides along in params and is applied
+    # here, in the process that has the numbers.
+    vlog = as_run_log(logs.append, params.verbose_level)
     # Continuing an interrupted run: adjacency for this recording is already
     # written, and it is the expensive part of this step.
     done_path = mat_files_dir / f"{rec.filename}_adjM.npz"
@@ -82,6 +105,10 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
     if ground_electrodes:
         spike_times_dict = ground_spike_times_dict(spike_times_dict, data["channels"], ground_electrodes)
 
+    vlog.debug(f"      [{rec.filename}] {n_channels} channels, {fs / 1000:g} kHz, "
+               f"{duration_s:.1f}s; {rep_num} surrogates, {tail} tail, "
+               f"seed {params.random_seed if params.random_seed is not None else 'fresh'}")
+
     out_arrays: dict[str, np.ndarray] = {}
     # Per-lag check payloads, written together once every lag is done. The
     # snapshots they come from are tens of megabytes and vanish with this
@@ -96,6 +123,7 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
     for lag_ms in lag_values:
         logs.append(f"  [{rec.filename}] computing adjacency matrix (lag={lag_ms}ms, "
                     f"{rep_num} shuffles)...")
+        lag_started = time.perf_counter()
         if plot_checks:
             adj_m, adj_m_ci, rep_val, dist1 = adjm_thr(
                 spike_times_dict, n_channels, lag_ms, tail, fs, duration_s, rep_num,
@@ -122,6 +150,8 @@ def _step3_one_recording(task: tuple[Params, RecordingInfo, str]) -> tuple[str, 
             )
         out_arrays[f"adjM{lag_ms}mslag"] = adj_m_ci
         out_arrays[f"adjM{lag_ms}mslag_raw"] = adj_m
+        vlog.detail(f"      {_describe_edges(adj_m, adj_m_ci, lag_ms)} "
+                    f"in {format_elapsed(time.perf_counter() - lag_started)}")
 
     out_path = mat_files_dir / f"{rec.filename}_adjM.npz"
     atomic_savez(out_path, channels=data["channels"], **out_arrays)
@@ -151,7 +181,10 @@ def _run_step3_functional_connectivity(
     the array with exact MATLAB parity) for each lag in
     ``params.func_con_lag_val``.
     """
+    log = as_run_log(log, params.verbose_level)
     log("\n=== Step 3: Functional Connectivity ===")
+    log.debug(f"  {len(recordings)} recording(s) over a process pool "
+              f"(recording workers: {params.recording_workers or 'auto'})")
     check_cancel(should_cancel)
     progress = progress or RunProgress()
     progress.begin("step3", items=len(recordings))

--- a/src/meanap/pipeline/step4.py
+++ b/src/meanap/pipeline/step4.py
@@ -6,6 +6,7 @@ and which are deterministic vs. dependent on a stochastic null model).
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
@@ -36,6 +37,7 @@ from meanap.pipeline.plotting_step4 import (
 )
 from meanap.pipeline.resume import ADJM_SUFFIX, build_input_locator
 from meanap.pipeline.rng import make_rng
+from meanap.pipeline.verbosity import as_run_log, format_elapsed
 from meanap.pipeline.spreadsheet import RecordingInfo, ground_spike_times_dict, parse_ground_electrodes
 
 
@@ -537,6 +539,35 @@ def _plot_recording_lag(
 _STEP4_MEM_PER_TASK_GB = 0.6
 
 
+def _describe_network(metrics: dict, min_nodes: int) -> str:
+    """The shape of the network one lag produced, in one line.
+
+    Node count first: a recording that fell below ``min_nodes`` has no metrics
+    at all, and saying so here is the difference between a Verbose log that
+    explains an empty row in the CSV and one that does not.
+    """
+    active = int(metrics.get("aN", 0))
+    if active < min_nodes:
+        return (f"{active} active nodes — below the {min_nodes}-node floor, "
+                f"no metrics computed")
+
+    parts = [f"{active} active nodes"]
+    density = metrics.get("Dens")
+    if density is not None:
+        parts.append(f"density {float(density):.3f}")
+    q = metrics.get("Q")
+    n_mod = metrics.get("nMod")
+    if q is not None and n_mod is not None:
+        parts.append(f"{int(n_mod)} modules (Q {float(q):.3f})")
+    sw = metrics.get("SW")
+    if sw is not None and np.isfinite(sw):
+        parts.append(f"small-worldness {float(sw):.2f}")
+    eglob = metrics.get("Eglob")
+    if eglob is not None:
+        parts.append(f"global efficiency {float(eglob):.3f}")
+    return ", ".join(parts)
+
+
 def _step4_compute_one(
     task: tuple[Params, RecordingInfo, str],
 ) -> tuple[str, dict | None, np.ndarray | None, list[str]]:
@@ -557,6 +588,9 @@ def _step4_compute_one(
     lag_values = params.func_con_lag_val
     min_nodes = params.min_number_of_nodes_to_cal_net_met
     logs: list[str] = []
+    # Level-aware view of the same buffer: the parent replays these lines, but
+    # only this process ever sees the numbers behind them.
+    vlog = as_run_log(logs.append, params.verbose_level)
 
     adj_path = locator.adjm_file(rec.filename)
     spike_path = locator.spike_file(rec.filename)
@@ -579,6 +613,7 @@ def _step4_compute_one(
         params.random_seed, "step4-dimensionality", rec.filename)
 
     logs.append(f"  [{rec.filename}] loading adjacency matrices...")
+    vlog.debug(f"      reading {adj_path}")
     adj_data = np.load(adj_path)
     spike_data = np.load(spike_path)
     fs = float(spike_data["fs"][0])
@@ -604,6 +639,11 @@ def _step4_compute_one(
 
     spike_counts = np.array([len(spike_times_dict[ch]) for ch in range(n_channels)])
     spike_times_list = [spike_times_dict[ch] for ch in range(n_channels)]
+    vlog.debug(f"      [{rec.filename}] {n_channels} channels, {duration_s:.1f}s, "
+               f"{int(spike_counts.sum())} spikes; node floor {min_nodes}, "
+               f"activity floor {params.min_activity_level} Hz; "
+               f"effective rank {'on' if params.compute_eff_rank else 'off'}, "
+               f"NMF {'on' if params.compute_nmf else 'off'}")
 
     # ``None`` means "not asked for" and leaves the field out entirely, as
     # ExtractNetMet.m does for a metric missing from netMetToCal — distinct
@@ -643,12 +683,15 @@ def _step4_compute_one(
         if key not in adj_data:
             continue
         logs.append(f"  [{rec.filename}] computing network metrics (lag={lag_ms}ms)...")
+        lag_started = time.perf_counter()
         metrics = compute_network_metrics(
             adj_data[key], spike_counts, duration_s,
             params.min_activity_level, min_nodes,
             exclude_edges_below_threshold=params.exclude_edges_below_threshold,
             params=params, rng=rng,
         )
+        vlog.detail(f"      lag {lag_ms}ms: {_describe_network(metrics, min_nodes)} "
+                    f"in {format_elapsed(time.perf_counter() - lag_started)}")
         if eff_rank is not None:
             metrics["effRank"] = eff_rank
         metrics.update(nmf_result)
@@ -909,7 +952,11 @@ def _run_step4_network_metrics(
     should_cancel: CancelCheck = None,
     progress: "RunProgress | None" = None,
 ) -> None:
+    log = as_run_log(log, params.verbose_level)
     log("\n=== Step 4: Network Activity ===")
+    log.debug(f"  {len(recordings)} recording(s) over a process pool "
+              f"(recording workers: {params.recording_workers or 'auto'}); "
+              f"lags {', '.join(str(v) for v in params.func_con_lag_val)} ms")
 
     out_dir = output_root / "4_NetworkActivity"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/meanap/pipeline/verbosity.py
+++ b/src/meanap/pipeline/verbosity.py
@@ -1,0 +1,145 @@
+"""How much a run says about itself, and the log that decides it.
+
+``Params.verbose_level`` used to be stored and never read: the GUI offered
+three levels and every run printed the same thing. This is what makes the
+setting mean something.
+
+The levels are **additive**. ``Verbose`` adds to what ``Normal`` prints;
+``Debug`` adds to both. Nothing is ever taken away, so turning the level up
+cannot hide a warning and turning it down cannot hide a failure — the only
+question is how much detail sits between the lines that always appear.
+
+:class:`RunLog` is callable, so ``log("...")`` still means "print this at every
+level" and the ~150 existing call sites did not have to change. What is new is
+``log.detail(...)`` (Verbose and up) and ``log.debug(...)`` (Debug only). Any
+function that is handed a plain callable — a worker collecting lines into a
+list, a test passing ``print`` — can promote it with :func:`as_run_log`, which
+leaves an existing :class:`RunLog` alone.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterable, Iterator
+
+__all__ = [
+    "VERBOSE_LEVELS", "RunLog", "as_run_log", "normalise_level",
+    "format_elapsed",
+]
+
+#: The levels, quietest first, as the GUI offers them.
+VERBOSE_LEVELS = ["Normal", "Verbose", "Debug"]
+
+_RANK = {name: i for i, name in enumerate(VERBOSE_LEVELS)}
+
+#: MATLAB's ``Params.verboseLevel`` is ``'Normal' | 'High' | 'Silent'``, and a
+#: params file can come from either pipeline. Mapping the names it uses means
+#: such a file keeps its intent instead of silently landing on the default.
+#: 'Silent' has no equivalent here — every level prints the run's progress —
+#: so it maps to the quietest one we have.
+_ALIASES = {"high": "Verbose", "silent": "Normal", "none": "Normal"}
+
+
+def normalise_level(level: str | None) -> str:
+    """The canonical level name for whatever was stored, defaulting to Normal.
+
+    Never raises: a params file is user-editable, and an unrecognised level is
+    a reason to log normally, not a reason to lose the run.
+    """
+    text = str(level or "").strip().lower()
+    for name in VERBOSE_LEVELS:
+        if text == name.lower():
+            return name
+    return _ALIASES.get(text, VERBOSE_LEVELS[0])
+
+
+def format_elapsed(seconds: float) -> str:
+    """A short duration, keeping the decimals that matter for a single step."""
+    seconds = max(0.0, float(seconds))
+    if seconds < 10:
+        return f"{seconds:.2f}s"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, secs = divmod(int(round(seconds)), 60)
+    if minutes < 60:
+        return f"{minutes}m {secs:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes:02d}m"
+
+
+class RunLog:
+    """A run's log, with a detail channel and a debug channel above it.
+
+    Wraps the callable the caller gave :func:`~meanap.pipeline.runner.run_pipeline`
+    — the GUI's log pane, ``print``, a worker's ``list.append`` — and gates the
+    two extra channels on the run's verbose level.
+    """
+
+    __slots__ = ("_out", "level", "_rank")
+
+    def __init__(self, out: Callable[[str], None], level: str | None = None) -> None:
+        self._out = out
+        self.level = normalise_level(level)
+        self._rank = _RANK[self.level]
+
+    def __call__(self, message: str) -> None:
+        """Print at every level. What ``log(...)`` has always meant."""
+        self._out(message)
+
+    # ── The two extra channels ────────────────────────────────────────────────
+
+    @property
+    def wants_detail(self) -> bool:
+        """Whether ``detail`` would print — for skipping work only it needs."""
+        return self._rank >= _RANK["Verbose"]
+
+    @property
+    def wants_debug(self) -> bool:
+        return self._rank >= _RANK["Debug"]
+
+    def detail(self, message: str) -> None:
+        """The numbers behind a step: Verbose and above."""
+        if self._rank >= _RANK["Verbose"]:
+            self._out(message)
+
+    def debug(self, message: str) -> None:
+        """Internals — paths, shapes, workers, versions: Debug only."""
+        if self._rank >= _RANK["Debug"]:
+            self._out(message)
+
+    def detail_lines(self, lines: Iterable[str]) -> None:
+        for line in lines:
+            self.detail(line)
+
+    def debug_lines(self, lines: Iterable[str]) -> None:
+        for line in lines:
+            self.debug(line)
+
+    @contextmanager
+    def timed(self, label: str, *, level: str = "Verbose") -> Iterator[None]:
+        """Time the block and say how long it took, at *level*.
+
+        Silent — and free of the clock call — when the run is below *level*, so
+        it can wrap anything without a Normal run paying for it.
+        """
+        if _RANK[normalise_level(level)] > self._rank:
+            yield
+            return
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._out(f"{label} took {format_elapsed(time.perf_counter() - started)}")
+
+
+def as_run_log(log: Callable[[str], None], level: str | None = None) -> RunLog:
+    """Promote a plain log callable to a :class:`RunLog`.
+
+    An existing :class:`RunLog` is returned unchanged, level and all: it was
+    built by whoever started the run, and a function further down the stack
+    guessing a level from its own arguments is how the two would drift apart.
+    """
+    if isinstance(log, RunLog):
+        return log
+    return RunLog(log, level)


### PR DESCRIPTION
Three changes to the Pipeline tab and the toolbar, each independent.

## The verbose level now changes what a run says

`Params.verbose_level` was stored, written to `params.json` and **never read** — the GUI offered three levels and every run printed the same thing. `pipeline/verbosity.py` makes it mean something.

The levels are **additive**: Verbose adds to Normal, Debug adds to both, and nothing is ever taken away. A level that could suppress a line would make a Debug log unsafe to reason from — is that warning missing, or was it never printed? — and would make turning the level up a decision rather than a free one. It also meant none of the ~150 existing `log(...)` call sites had to be audited: `RunLog` is callable, so `log("…")` still means "print at every level", and `log.detail(…)` / `log.debug(…)` / `log.timed(label)` sit beside it.

| Level | Adds |
| --- | --- |
| Normal | (unchanged) |
| Verbose | the batch and its groups/DIVs; every setting that differs from its default; then per recording — spikes per detection method with mean rate, active electrodes / mean FR / burst rate, edges surviving thresholding per lag, active nodes / density / modules+Q / small-worldness / global efficiency per lag, each timed |
| Debug | file paths, sampling rates and durations, detection and threshold settings, worker counts, Python/platform/library versions, and *every* setting rather than only the changed ones |

Two things worth knowing:

- **Workers get the level through `Params`, not through the log.** Steps 3 and 4 compute in spawned processes that buffer their own lines for the parent to replay; the level travels in the `Params` already being pickled to them.
- **`as_run_log` never re-levels an existing `RunLog`.** A function further down the stack guessing a level from its own arguments is how a step and its run would drift apart.

MATLAB's `verboseLevel` names are accepted too (`High` → Verbose, `Silent` → Normal, there being no quieter level here), so a params file from that pipeline keeps its intent instead of landing on the default.

## Dropdowns are wide enough for their options

Qt opens a combo box's popup at the width of the *box*, and the box is sized by the form around it. That would be harmless if the popup drew its rows the way the box does, but it adds a check-mark column — 18px under this theme, plus 6px of spacing — to the left of every row, out of the same width. On "Verbose level" the box is 82px, the popup gives its rows 72 of that, the check column takes 24, and "Verbose" is drawn into 48px of a 50px word.

The popup now gets a minimum width covering what it actually draws: what the box would need for the widest option (via the same `CT_ComboBox` sizing Qt uses for `AdjustToContents`, so the theme's own padding round a label is included rather than guessed), plus the check column, its spacing, the popup's frame, and the scroll bar when the list is longer than the popup shows. Every term comes from the style, so it follows qdarktheme rather than pinning its numbers.

Installed application-wide like the wheel guard, and for the same reason: the panels that build combo boxes as you use them are the ones with the long labels. **The boxes themselves are untouched** — widening those would reflow every settings form to suit the longest word in a dropdown.

## "New" is now "Reset to defaults"

There is no document for "New" to make, and the one thing the button does is discard the settings on screen — which the confirmation dialog had to explain because the label did not.

## Testing

- `python/test_verbose_level.py` (new, ~5s) — the log's semantics, a full run at each level, and the GUI control. Its load-bearing check is that `netmet_results.json` is **identical across all three levels**: turning Debug on to diagnose a run must not invalidate it.
- `python/test_gui_combo_popup.py` (new) — asserts the real condition (popup viewport ≥ check column + spacing + widest option) on the popup Qt actually opens, across every dropdown in the window, plus the built-later, filled-later and scrolling-list cases. It computes the requirement from the style independently rather than asking `gui/combo.py` for its own answer; with the fix disabled, 7 of its 11 checks fail, the first being `viewport 72 vs needed 74` on Verbose level.
- All 12 `test_gui_*` suites, `test_run_queue` (45/45) and `test_continue_interrupted` (57/57) pass on this branch.
- `python/PIPELINE_PORT_STATUS.md` has a new section on the verbosity design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrUsH3WcxcDb32ZwZEBMM3